### PR TITLE
Refine mobile widget workflow layout

### DIFF
--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/page.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/page.tsx
@@ -37,6 +37,13 @@ const SECTION_LABEL: Record<ProjectSection, string> = {
 };
 
 const WIDGET_STEPS: WidgetStep[] = ['setup', 'appearance', 'fields', 'protection', 'publish'];
+const WIDGET_STEP_LABEL: Record<WidgetStep, string> = {
+  setup: 'Setup',
+  appearance: 'Appearance',
+  fields: 'Fields',
+  protection: 'Protection',
+  publish: 'Publish',
+};
 
 export default async function ProjectPage({ params, searchParams }: ProjectPageProps) {
   const supabase = createServerSupabaseClient();
@@ -111,45 +118,59 @@ export default async function ProjectPage({ params, searchParams }: ProjectPageP
   const sectionBadge = SECTION_LABEL[activeSection];
 
   const mobileOverviewCard = (
-    <div className="lg:hidden">
-      <div className="rounded-2xl border border-border/60 bg-card/60 p-4 shadow-sm">
-        <div className="flex items-center justify-between">
-          <span className="text-[11px] uppercase tracking-[0.22em] text-muted-foreground/80">Overview</span>
-          <Badge variant="outline" className="border-border/60 text-[11px] font-semibold uppercase tracking-[0.16em]">
+    <div className="lg:hidden px-3">
+      <section className="rounded-3xl border border-border/70 bg-card/80 p-4 shadow-sm">
+        <header className="flex items-center justify-between gap-3">
+          <span className="text-[10px] uppercase tracking-[0.32em] text-muted-foreground/80">Overview</span>
+          <Badge variant="outline" className="border-border/60 text-[10px] font-semibold uppercase tracking-[0.28em]">
             {sectionBadge}
           </Badge>
-        </div>
-        <div className="mt-3 space-y-3">
+        </header>
+        <div className="mt-3 space-y-4">
           <div>
             <h1 className="text-lg font-semibold text-foreground">{project.name}</h1>
-            <p className="text-sm text-muted-foreground">Manage your feedback collection</p>
+            <p className="mt-1 text-sm text-muted-foreground">Manage your feedback collection</p>
           </div>
-          <div className="grid grid-cols-2 gap-3 text-xs">
-            <div className="rounded-lg bg-muted/30 p-3">
-              <p className="text-[10px] uppercase tracking-[0.2em] text-muted-foreground">Project ID</p>
-              <p className="mt-1 text-sm font-semibold text-foreground">{String(project.id).slice(0, 6)}…</p>
+          <div className="grid grid-cols-3 gap-2 text-xs">
+            <div className="rounded-xl bg-muted/30 p-3">
+              <p className="text-[9px] uppercase tracking-[0.26em] text-muted-foreground">Project ID</p>
+              <p className="mt-1 truncate text-sm font-semibold text-foreground">{String(project.id).slice(0, 8)}…</p>
             </div>
-            <div className="rounded-lg bg-muted/30 p-3">
-              <p className="text-[10px] uppercase tracking-[0.2em] text-muted-foreground">Created</p>
+            <div className="rounded-xl bg-muted/30 p-3">
+              <p className="text-[9px] uppercase tracking-[0.26em] text-muted-foreground">Created</p>
               <p className="mt-1 text-sm font-semibold text-foreground">
                 {new Date(project.created_at).toLocaleDateString()}
               </p>
             </div>
+            <div className="rounded-xl bg-muted/30 p-3">
+              <p className="text-[9px] uppercase tracking-[0.26em] text-muted-foreground">Feedback</p>
+              <p className="mt-1 text-sm font-semibold text-foreground">
+                {typeof count === 'number' ? count : feedbacks?.length || 0}
+              </p>
+            </div>
           </div>
+          {activeSection === 'widget-installation' && (
+            <div className="rounded-2xl border border-primary/30 bg-primary/10 p-3 text-xs">
+              <p className="text-[9px] uppercase tracking-[0.26em] text-primary/80">Active step</p>
+              <p className="mt-1 text-sm font-semibold text-primary">
+                {WIDGET_STEP_LABEL[activeWidgetStep]}
+              </p>
+            </div>
+          )}
         </div>
-      </div>
+      </section>
     </div>
   );
 
   return (
     <div className="min-h-screen bg-background overflow-x-hidden">
-      <div className="mx-auto w-full max-w-6xl px-4 pb-6 pt-0 sm:px-6 sm:pt-6 lg:px-8">
-        <ProjectMobileTabs
-          projectId={project.id}
-          projectName={project.name}
-          activeSection={activeSection}
-          widgetStep={activeWidgetStep}
-        />
+      <ProjectMobileTabs
+        projectId={project.id}
+        projectName={project.name}
+        activeSection={activeSection}
+        widgetStep={activeWidgetStep}
+      />
+      <div className="mx-auto w-full max-w-6xl px-0 pb-8 pt-3 sm:px-6 sm:pt-6 lg:px-8">
         <div className="mb-6 hidden flex-col gap-3 lg:flex lg:flex-row lg:items-center lg:justify-between">
           <Button variant="ghost" asChild className="w-full justify-start gap-2 sm:w-auto">
             <Link href="/dashboard">
@@ -210,7 +231,7 @@ export default async function ProjectPage({ params, searchParams }: ProjectPageP
           {activeSection === 'feedback' && (
             <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
               <div className="space-y-6 lg:col-span-2">
-                <Card>
+                <Card className="rounded-[30px] border border-border/70 bg-card/80 shadow-sm sm:rounded-2xl">
                   <CardHeader className="p-4 sm:p-6">
                     <CardTitle className="flex items-center gap-2">
                       <MessageSquare className="h-5 w-5" />
@@ -363,7 +384,7 @@ export default async function ProjectPage({ params, searchParams }: ProjectPageP
               </div>
 
               <div className="space-y-6">
-                <Card>
+                <Card className="rounded-[30px] border border-border/70 bg-card/80 shadow-sm sm:rounded-2xl">
                   <CardHeader className="p-4 sm:p-6">
                     <CardTitle>Project Stats</CardTitle>
                   </CardHeader>
@@ -387,7 +408,7 @@ export default async function ProjectPage({ params, searchParams }: ProjectPageP
                   </CardContent>
                 </Card>
 
-                <Card>
+                <Card className="rounded-[30px] border border-border/70 bg-card/80 shadow-sm sm:rounded-2xl">
                   <CardHeader className="p-4 sm:p-6">
                     <CardTitle>Quick Actions</CardTitle>
                   </CardHeader>
@@ -408,7 +429,7 @@ export default async function ProjectPage({ params, searchParams }: ProjectPageP
           )}
 
           {activeSection === 'analytics' && (
-            <Card>
+            <Card className="rounded-[30px] border border-border/70 bg-card/80 shadow-sm sm:rounded-2xl">
               <CardHeader className="p-4 sm:p-6">
                 <CardTitle className="flex items-center gap-2">
                   <BarChart3 className="h-5 w-5" />
@@ -422,7 +443,7 @@ export default async function ProjectPage({ params, searchParams }: ProjectPageP
           )}
 
           {activeSection === 'integrations' && (
-            <Card>
+            <Card className="rounded-[30px] border border-border/70 bg-card/80 shadow-sm sm:rounded-2xl">
               <CardHeader className="p-4 sm:p-6">
                 <CardTitle className="flex items-center gap-2">
                   <Webhook className="h-5 w-5" />

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/page.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/page.tsx
@@ -110,9 +110,40 @@ export default async function ProjectPage({ params, searchParams }: ProjectPageP
 
   const sectionBadge = SECTION_LABEL[activeSection];
 
+  const mobileOverviewCard = (
+    <div className="lg:hidden">
+      <div className="rounded-2xl border border-border/60 bg-card/60 p-4 shadow-sm">
+        <div className="flex items-center justify-between">
+          <span className="text-[11px] uppercase tracking-[0.22em] text-muted-foreground/80">Overview</span>
+          <Badge variant="outline" className="border-border/60 text-[11px] font-semibold uppercase tracking-[0.16em]">
+            {sectionBadge}
+          </Badge>
+        </div>
+        <div className="mt-3 space-y-3">
+          <div>
+            <h1 className="text-lg font-semibold text-foreground">{project.name}</h1>
+            <p className="text-sm text-muted-foreground">Manage your feedback collection</p>
+          </div>
+          <div className="grid grid-cols-2 gap-3 text-xs">
+            <div className="rounded-lg bg-muted/30 p-3">
+              <p className="text-[10px] uppercase tracking-[0.2em] text-muted-foreground">Project ID</p>
+              <p className="mt-1 text-sm font-semibold text-foreground">{String(project.id).slice(0, 6)}…</p>
+            </div>
+            <div className="rounded-lg bg-muted/30 p-3">
+              <p className="text-[10px] uppercase tracking-[0.2em] text-muted-foreground">Created</p>
+              <p className="mt-1 text-sm font-semibold text-foreground">
+                {new Date(project.created_at).toLocaleDateString()}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
   return (
     <div className="min-h-screen bg-background overflow-x-hidden">
-      <div className="container mx-auto px-3 sm:px-4 py-6">
+      <div className="mx-auto w-full max-w-6xl px-4 pb-6 pt-0 sm:px-6 sm:pt-6 lg:px-8">
         <ProjectMobileTabs
           projectId={project.id}
           projectName={project.name}
@@ -136,38 +167,44 @@ export default async function ProjectPage({ params, searchParams }: ProjectPageP
           </div>
         </div>
 
-        <div className="mb-6 space-y-2">
-          <div>
-            <h1 className="text-xl font-semibold text-foreground sm:text-2xl md:text-3xl">
-              {project.name}
-            </h1>
-            <p className="text-sm text-muted-foreground sm:text-base">
-              Manage your feedback collection
-            </p>
-          </div>
-          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground sm:text-sm">
-            <Badge variant="secondary" className="px-2 py-1">
-              Project ID: {String(project.id).slice(0, 6)}…
-            </Badge>
-            <Badge variant="outline" className="px-2 py-1">
-              Created {new Date(project.created_at).toLocaleDateString()}
-            </Badge>
-            <Badge variant="outline" className="px-2 py-1 text-[11px] sm:text-xs">
-              {sectionBadge}
-            </Badge>
+        <div className="mb-6 space-y-4">
+          {activeSection !== 'widget-installation' && mobileOverviewCard}
+          <div className="hidden lg:block space-y-2">
+            <div>
+              <h1 className="text-xl font-semibold text-foreground sm:text-2xl md:text-3xl">
+                {project.name}
+              </h1>
+              <p className="text-sm text-muted-foreground sm:text-base">
+                Manage your feedback collection
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground sm:text-sm">
+              <Badge variant="secondary" className="px-2 py-1">
+                Project ID: {String(project.id).slice(0, 6)}…
+              </Badge>
+              <Badge variant="outline" className="px-2 py-1">
+                Created {new Date(project.created_at).toLocaleDateString()}
+              </Badge>
+              <Badge variant="outline" className="px-2 py-1 text-[11px] sm:text-xs">
+                {sectionBadge}
+              </Badge>
+            </div>
           </div>
         </div>
 
         <div className="space-y-6">
           {activeSection === 'widget-installation' && (
-            <WidgetInstallationExperience
-              key={project.id + '-' + activeWidgetStep}
-              projectId={params.id}
-              projectKey={project.api_key}
-              projectName={project.name}
-              widgetVersion={WIDGET_VERSION}
-              initialStep={activeWidgetStep}
-            />
+            <>
+              <WidgetInstallationExperience
+                key={project.id + '-' + activeWidgetStep}
+                projectId={params.id}
+                projectKey={project.api_key}
+                projectName={project.name}
+                widgetVersion={WIDGET_VERSION}
+                initialStep={activeWidgetStep}
+              />
+              {mobileOverviewCard}
+            </>
           )}
 
           {activeSection === 'feedback' && (

--- a/packages/dashboard/src/app/(dashboard)/projects/new/page.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/new/page.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useToast } from '@/hooks/use-toast';
 import { createBrowserSupabaseClient } from '@/lib/supabase-browser';
+import { useDashboard } from '@/components/dashboard-client-layout';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -19,6 +20,7 @@ export default function NewProjectPage() {
   const router = useRouter();
   const { toast } = useToast();
   const supabase = createBrowserSupabaseClient();
+  const { refreshProjects } = useDashboard();
 
   useEffect(() => {
     const checkAuth = async () => {
@@ -68,6 +70,7 @@ export default function NewProjectPage() {
           description: `${trimmedName} is ready to collect feedback.`,
         });
 
+        await refreshProjects();
         router.push(`/projects/${project.id}`);
       } catch (err: any) {
         setError(err.message || 'Failed to create project');

--- a/packages/dashboard/src/components/project-mobile-tabs.tsx
+++ b/packages/dashboard/src/components/project-mobile-tabs.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useRouter, usePathname, useSearchParams } from 'next/navigation';
-import { ArrowLeft, MessageSquare, BarChart3, Webhook, Code } from 'lucide-react';
-import type { LucideIcon } from 'lucide-react';
+import { ArrowLeft } from 'lucide-react';
 import { RefreshButton } from '@/components/refresh-button';
 import { ProjectSettingsLauncher } from '@/components/project-settings-launcher';
 import { cn } from '@/lib/utils';
 import type { WidgetStep } from '@/components/widget-installation';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 
 export type ProjectSection = 'widget-installation' | 'feedback' | 'analytics' | 'integrations';
 
@@ -17,17 +18,11 @@ interface ProjectMobileTabsProps {
   widgetStep: WidgetStep;
 }
 
-type SectionTab = {
-  id: ProjectSection;
-  label: string;
-  icon: LucideIcon;
-};
-
-const SECTION_TABS: SectionTab[] = [
-  { id: 'widget-installation', label: 'Widget', icon: Code },
-  { id: 'feedback', label: 'Feedback', icon: MessageSquare },
-  { id: 'analytics', label: 'Analytics', icon: BarChart3 },
-  { id: 'integrations', label: 'Integrations', icon: Webhook },
+const SECTION_TABS: Array<{ id: ProjectSection; label: string }> = [
+  { id: 'widget-installation', label: 'Widget' },
+  { id: 'feedback', label: 'Feedback' },
+  { id: 'analytics', label: 'Analytics' },
+  { id: 'integrations', label: 'Integrations' },
 ];
 
 const WIDGET_SUB_STEPS: Array<{ id: WidgetStep; label: string }> = [
@@ -42,6 +37,9 @@ export function ProjectMobileTabs({ projectId, projectName, activeSection, widge
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+
+  const rawWidgetIndex = WIDGET_SUB_STEPS.findIndex((step) => step.id === widgetStep);
+  const activeWidgetIndex = rawWidgetIndex >= 0 ? rawWidgetIndex : 0;
 
   const handleSectionChange = (section: ProjectSection) => {
     if (section === activeSection) {
@@ -80,72 +78,96 @@ export function ProjectMobileTabs({ projectId, projectName, activeSection, widge
 
   return (
     <div className="lg:hidden sticky top-0 z-40 border-b border-border/60 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/75">
-      <div className="flex items-center justify-between px-3 py-2">
-        <button
-          type="button"
-          onClick={() => router.back()}
-          className="flex h-9 w-9 items-center justify-center rounded-full border border-border text-sm text-foreground"
-          aria-label="Go back"
-        >
-          <ArrowLeft className="h-4 w-4" />
-        </button>
-        <div className="flex-1 px-3">
-          <p className="truncate text-center text-sm font-semibold leading-tight">{projectName}</p>
-        </div>
-        <div className="flex items-center gap-2">
-          <RefreshButton className="h-8 w-8 rounded-full p-0" />
-          <ProjectSettingsLauncher
-            projectId={projectId}
-            projectName={projectName}
-            variant="icon"
-            className="h-8 w-8"
-          />
+      <div className="border-b border-border/60 px-4 pb-3 pt-3">
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="flex h-10 w-10 items-center justify-center rounded-lg border border-border text-sm text-foreground transition-colors hover:bg-muted"
+            aria-label="Go back"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </button>
+          <div className="min-w-0 flex-1">
+            <p className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Project</p>
+            <p className="truncate text-base font-semibold leading-tight text-foreground">{projectName}</p>
+          </div>
+          <div className="flex items-center gap-2">
+            <RefreshButton className="h-9 w-9 rounded-lg p-0" />
+            <ProjectSettingsLauncher
+              projectId={projectId}
+              projectName={projectName}
+              variant="icon"
+              className="h-9 w-9 rounded-lg"
+            />
+          </div>
         </div>
       </div>
 
-      <div className="flex gap-2 overflow-x-auto px-3 pb-2">
-        {SECTION_TABS.map((tab) => {
-          const Icon = tab.icon;
-          const isActive = tab.id === activeSection;
-          return (
-            <button
-              key={tab.id}
-              type="button"
-              onClick={() => handleSectionChange(tab.id)}
-              className={cn(
-                'flex flex-shrink-0 items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium transition',
-                isActive
-                  ? 'bg-primary text-primary-foreground shadow-sm'
-                  : 'bg-muted text-muted-foreground hover:bg-muted/80'
-              )}
-            >
-              <Icon className="h-4 w-4" />
-              <span>{tab.label}</span>
-            </button>
-          );
-        })}
+      <div className="px-4 pb-3 pt-3">
+        <div className="grid w-full grid-cols-2 gap-2">
+          {SECTION_TABS.map((tab) => {
+            const isActive = tab.id === activeSection;
+            return (
+              <Button
+                key={tab.id}
+                type="button"
+                variant={isActive ? 'default' : 'secondary'}
+                onClick={() => handleSectionChange(tab.id)}
+                className={cn(
+                  'h-11 w-full justify-center rounded-lg text-sm font-semibold transition-all duration-150',
+                  !isActive && 'bg-muted text-muted-foreground hover:bg-muted/80'
+                )}
+              >
+                {tab.label}
+              </Button>
+            );
+          })}
+        </div>
       </div>
 
       {activeSection === 'widget-installation' && (
-        <div className="flex gap-2 overflow-x-auto px-3 pb-3">
-          {WIDGET_SUB_STEPS.map((step) => {
-            const isStepActive = step.id === widgetStep;
-            return (
-              <button
-                key={step.id}
-                type="button"
-                onClick={() => handleWidgetStepChange(step.id)}
-                className={cn(
-                  'flex flex-shrink-0 items-center justify-center rounded-full px-3 py-1 text-[11px] font-medium uppercase tracking-[0.18em]',
-                  isStepActive
-                    ? 'bg-foreground text-background'
-                    : 'bg-muted text-muted-foreground hover:bg-muted/80'
-                )}
-              >
-                {step.label}
-              </button>
-            );
-          })}
+        <div className="px-4 pb-4 pt-1">
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <h2 className="text-sm font-semibold text-foreground">Widget installation</h2>
+              <p className="text-xs text-muted-foreground">
+                Fine-tune, preview, and publish the experience for {projectName}.
+              </p>
+            </div>
+            <div className="rounded-xl border border-primary/25 bg-primary/5 p-3 shadow-sm">
+              <div className="flex items-center justify-between">
+                <span className="text-[10px] font-semibold uppercase tracking-[0.3em] text-primary/80">Widget steps</span>
+                <Badge
+                  variant="outline"
+                  className="border-primary/40 bg-primary/10 text-[10px] font-medium uppercase tracking-[0.3em] text-primary"
+                >
+                  {activeWidgetIndex + 1}/{WIDGET_SUB_STEPS.length}
+                </Badge>
+              </div>
+              <div className="mt-3 grid grid-cols-2 gap-2">
+                {WIDGET_SUB_STEPS.map((step, index) => {
+                  const isStepActive = step.id === widgetStep;
+                  return (
+                    <Button
+                      key={step.id}
+                      type="button"
+                      onClick={() => handleWidgetStepChange(step.id)}
+                      variant={isStepActive ? 'default' : 'outline'}
+                      className={cn(
+                        'h-9 w-full justify-center rounded-lg px-2 text-[11px] font-semibold uppercase tracking-[0.16em]',
+                        isStepActive
+                          ? 'bg-foreground text-background shadow-sm'
+                          : 'border-primary/30 text-primary hover:bg-primary/10'
+                      )}
+                    >
+                      {index + 1}. {step.label}
+                    </Button>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/packages/dashboard/src/components/project-mobile-tabs.tsx
+++ b/packages/dashboard/src/components/project-mobile-tabs.tsx
@@ -25,6 +25,13 @@ const SECTION_TABS: Array<{ id: ProjectSection; label: string }> = [
   { id: 'integrations', label: 'Integrations' },
 ];
 
+const SECTION_LABEL: Record<ProjectSection, string> = {
+  'widget-installation': 'Widget',
+  feedback: 'Feedback',
+  analytics: 'Analytics',
+  integrations: 'Integrations',
+};
+
 const WIDGET_SUB_STEPS: Array<{ id: WidgetStep; label: string }> = [
   { id: 'setup', label: 'Setup' },
   { id: 'appearance', label: 'Appearance' },
@@ -77,46 +84,53 @@ export function ProjectMobileTabs({ projectId, projectName, activeSection, widge
   };
 
   return (
-    <div className="lg:hidden sticky top-0 z-40 border-b border-border/60 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/75">
-      <div className="border-b border-border/60 px-4 pb-3 pt-3">
-        <div className="flex items-center gap-3">
-          <button
+    <div className="lg:hidden sticky top-0 z-50 border-b border-border/60 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/75">
+      <div className="px-3 pb-3 pt-[max(env(safe-area-inset-top),0.75rem)]">
+        <div className="flex items-center justify-between gap-3">
+          <Button
             type="button"
-            onClick={() => router.back()}
-            className="flex h-10 w-10 items-center justify-center rounded-lg border border-border text-sm text-foreground transition-colors hover:bg-muted"
-            aria-label="Go back"
+            variant="ghost"
+            onClick={() => router.push('/dashboard')}
+            className="h-9 min-w-0 flex-1 justify-start gap-2 rounded-md border border-border/70 px-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground/90 transition-colors hover:bg-muted"
           >
-            <ArrowLeft className="h-4 w-4" />
-          </button>
-          <div className="min-w-0 flex-1">
-            <p className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground">Project</p>
-            <p className="truncate text-base font-semibold leading-tight text-foreground">{projectName}</p>
-          </div>
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Back
+          </Button>
           <div className="flex items-center gap-2">
-            <RefreshButton className="h-9 w-9 rounded-lg p-0" />
+            <RefreshButton className="h-9 w-9 rounded-md border border-border/70 bg-background/80 p-0" />
             <ProjectSettingsLauncher
               projectId={projectId}
               projectName={projectName}
               variant="icon"
-              className="h-9 w-9 rounded-lg"
+              className="h-9 w-9 rounded-md border border-border/70 bg-background/80"
             />
           </div>
         </div>
-      </div>
 
-      <div className="px-4 pb-3 pt-3">
-        <div className="grid w-full grid-cols-2 gap-2">
+        <div className="mt-3 flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <p className="text-[10px] uppercase tracking-[0.26em] text-muted-foreground/80">Project</p>
+            <p className="truncate text-base font-semibold leading-tight text-foreground">{projectName}</p>
+          </div>
+          <Badge variant="outline" className="border-border/70 text-[10px] font-semibold uppercase tracking-[0.32em]">
+            {SECTION_LABEL[activeSection]}
+          </Badge>
+        </div>
+
+        <div className="mt-4 grid grid-cols-4 gap-1.5">
           {SECTION_TABS.map((tab) => {
             const isActive = tab.id === activeSection;
             return (
               <Button
                 key={tab.id}
                 type="button"
-                variant={isActive ? 'default' : 'secondary'}
+                variant="ghost"
                 onClick={() => handleSectionChange(tab.id)}
                 className={cn(
-                  'h-11 w-full justify-center rounded-lg text-sm font-semibold transition-all duration-150',
-                  !isActive && 'bg-muted text-muted-foreground hover:bg-muted/80'
+                  'relative h-9 min-w-0 justify-center rounded-md border px-0 text-[11px] font-semibold uppercase tracking-[0.2em] transition-all duration-150',
+                  isActive
+                    ? 'border-foreground bg-foreground text-background shadow-sm'
+                    : 'border-border/70 bg-muted/40 text-muted-foreground hover:bg-muted/70'
                 )}
               >
                 {tab.label}
@@ -124,28 +138,22 @@ export function ProjectMobileTabs({ projectId, projectName, activeSection, widge
             );
           })}
         </div>
-      </div>
 
-      {activeSection === 'widget-installation' && (
-        <div className="px-4 pb-4 pt-1">
-          <div className="space-y-3">
-            <div className="space-y-1">
-              <h2 className="text-sm font-semibold text-foreground">Widget installation</h2>
-              <p className="text-xs text-muted-foreground">
-                Fine-tune, preview, and publish the experience for {projectName}.
-              </p>
-            </div>
-            <div className="rounded-xl border border-primary/25 bg-primary/5 p-3 shadow-sm">
-              <div className="flex items-center justify-between">
-                <span className="text-[10px] font-semibold uppercase tracking-[0.3em] text-primary/80">Widget steps</span>
+        {activeSection === 'widget-installation' && (
+          <div className="mt-4">
+            <div className="rounded-2xl border border-primary/35 bg-primary/10 p-3 shadow-sm">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-[10px] font-semibold uppercase tracking-[0.32em] text-primary/80">
+                  Widget steps
+                </span>
                 <Badge
                   variant="outline"
-                  className="border-primary/40 bg-primary/10 text-[10px] font-medium uppercase tracking-[0.3em] text-primary"
+                  className="border-primary/40 bg-primary/15 text-[10px] font-semibold uppercase tracking-[0.28em] text-primary"
                 >
                   {activeWidgetIndex + 1}/{WIDGET_SUB_STEPS.length}
                 </Badge>
               </div>
-              <div className="mt-3 grid grid-cols-2 gap-2">
+              <div className="mt-3 grid grid-cols-5 gap-1.5">
                 {WIDGET_SUB_STEPS.map((step, index) => {
                   const isStepActive = step.id === widgetStep;
                   return (
@@ -153,23 +161,26 @@ export function ProjectMobileTabs({ projectId, projectName, activeSection, widge
                       key={step.id}
                       type="button"
                       onClick={() => handleWidgetStepChange(step.id)}
-                      variant={isStepActive ? 'default' : 'outline'}
+                      variant="ghost"
                       className={cn(
-                        'h-9 w-full justify-center rounded-lg px-2 text-[11px] font-semibold uppercase tracking-[0.16em]',
+                        'h-12 min-w-0 flex-col items-center justify-center gap-1 rounded-lg border px-1 text-[9px] font-medium uppercase tracking-[0.18em] transition-colors',
                         isStepActive
-                          ? 'bg-foreground text-background shadow-sm'
+                          ? 'border-primary bg-primary text-primary-foreground shadow-sm'
                           : 'border-primary/30 text-primary hover:bg-primary/10'
                       )}
                     >
-                      {index + 1}. {step.label}
+                      <span className="text-xs font-semibold leading-none">{index + 1}</span>
+                      <span className="truncate text-[9px] font-semibold uppercase tracking-[0.26em]">
+                        {step.label}
+                      </span>
                     </Button>
                   );
                 })}
               </div>
             </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }

--- a/packages/dashboard/src/components/widget-installation/widget-installation.tsx
+++ b/packages/dashboard/src/components/widget-installation/widget-installation.tsx
@@ -1601,11 +1601,13 @@ function StepNavigation({
   return (
     <div
       className={cn(
-        'flex flex-col gap-3 rounded-lg border bg-card/60 p-3 sm:flex-row sm:items-center sm:justify-between',
+        'flex flex-col gap-3 rounded-[28px] border border-border/70 bg-card/80 p-3 shadow-sm sm:flex-row sm:items-center sm:justify-between',
         variant === 'top' ? 'mt-3 mb-6' : 'mt-6'
       )}
     >
-      <div className="text-xs font-medium text-muted-foreground">Step {currentIndex + 1} of {steps.length}</div>
+      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+        Step {currentIndex + 1} of {steps.length}
+      </div>
       <div className="flex items-center gap-2">
         <Button
           type="button"
@@ -1613,7 +1615,10 @@ function StepNavigation({
           size="sm"
           onClick={onPrev}
           disabled={!hasPrev}
-          className={cn('flex items-center gap-1 h-9 px-3 text-xs', variant === 'top' ? 'md:text-sm' : '')}
+          className={cn(
+            'flex h-9 items-center gap-2 rounded-lg border-border/70 px-3 text-[11px] font-semibold uppercase tracking-[0.18em]',
+            variant === 'top' ? 'md:text-[12px]' : ''
+          )}
         >
           <ChevronLeft className="h-4 w-4" />
           Previous
@@ -1624,7 +1629,10 @@ function StepNavigation({
             size="sm"
             onClick={onNext}
             disabled={disableNext}
-            className={cn('flex items-center gap-1 h-9 px-3 text-xs', variant === 'top' ? 'md:text-sm' : '')}
+            className={cn(
+              'flex h-9 items-center gap-2 rounded-lg px-3 text-[11px] font-semibold uppercase tracking-[0.18em]',
+              variant === 'top' ? 'md:text-[12px]' : ''
+            )}
           >
             {nextLabel}
             {showArrow && <ChevronRight className="h-4 w-4" />}

--- a/packages/dashboard/src/components/widget-installation/widget-installation.tsx
+++ b/packages/dashboard/src/components/widget-installation/widget-installation.tsx
@@ -932,7 +932,7 @@ const CARD_CONTENT = 'p-3 pt-0 sm:p-6 sm:pt-0';
   }), [config.inlineBorder, config.inlineShadow, config.backgroundColor]);
 
   const sections = (
-    <div ref={tabsRef} className="space-y-6 sm:space-y-8 mx-auto max-w-[360px] sm:max-w-none">
+    <div ref={tabsRef} className="space-y-6 sm:space-y-8">
       <Tabs
         value={activeTab}
         onValueChange={(value) => {
@@ -941,16 +941,20 @@ const CARD_CONTENT = 'p-3 pt-0 sm:p-6 sm:pt-0';
         }}
         className="w-full"
       >
-        <TabsList className="mb-4 flex w-full gap-1 overflow-x-auto rounded-full border border-border/60 bg-muted/40 p-1 text-[11px] font-medium uppercase tracking-[0.12em] scrollbar-thin sm:gap-2 sm:text-sm sm:tracking-[0.18em]">
-          <TabsTrigger value="setup" className="flex-shrink-0  rounded-full px-2.5 py-1.5 data-[state=active]:bg-background data-[state=active]:shadow-sm sm:px-3 sm:py-2">Setup</TabsTrigger>
-          <TabsTrigger value="appearance" className="flex-shrink-0  rounded-full px-2.5 py-1.5 data-[state=active]:bg-background data-[state=active]:shadow-sm sm:px-3 sm:py-2">Appearance</TabsTrigger>
-          <TabsTrigger value="fields" className="flex-shrink-0  rounded-full px-2.5 py-1.5 data-[state=active]:bg-background data-[state=active]:shadow-sm sm:px-3 sm:py-2">Fields</TabsTrigger>
-          <TabsTrigger value="protection" className="flex-shrink-0  rounded-full px-2.5 py-1.5 data-[state=active]:bg-background data-[state=active]:shadow-sm sm:px-3 sm:py-2">Protection</TabsTrigger>
-          <TabsTrigger value="publish" className="flex-shrink-0  rounded-full px-2.5 py-1.5 data-[state=active]:bg-background data-[state=active]:shadow-sm sm:px-3 sm:py-2">Publish</TabsTrigger>
+        <TabsList className="mb-4 grid w-full grid-cols-2 gap-2 sm:flex sm:flex-wrap sm:gap-2">
+          {steps.map((step, index) => (
+            <TabsTrigger
+              key={step.id}
+              value={step.id}
+              className="flex h-11 items-center justify-center rounded-lg border border-border bg-background px-3 text-[11px] font-semibold uppercase tracking-[0.18em] transition data-[state=active]:border-primary data-[state=active]:bg-primary/10 data-[state=active]:text-primary sm:flex-1 sm:px-4 sm:text-xs sm:tracking-[0.2em]"
+            >
+              {index + 1}. {step.label}
+            </TabsTrigger>
+          ))}
         </TabsList>
         {null}
 
-      <TabsContent value="setup" className="space-y-6 sm:space-y-8 mx-auto max-w-[360px] sm:max-w-none">
+      <TabsContent value="setup" className="space-y-6 sm:space-y-8">
         <Card>
           <CardHeader className={CARD_HEADER}>
             <CardTitle className="flex items-center gap-2"><Sparkles className="h-4 w-4 text-primary" />Choose an experience</CardTitle>
@@ -1028,7 +1032,7 @@ const CARD_CONTENT = 'p-3 pt-0 sm:p-6 sm:pt-0';
         </Card>
       </TabsContent>
 
-      <TabsContent value="appearance" className="space-y-6 sm:space-y-8 mx-auto max-w-[360px] sm:max-w-none">
+      <TabsContent value="appearance" className="space-y-6 sm:space-y-8">
         <Card>
           <CardHeader className={CARD_HEADER}>
             <CardTitle>Branding</CardTitle>
@@ -1151,7 +1155,7 @@ const CARD_CONTENT = 'p-3 pt-0 sm:p-6 sm:pt-0';
           </CardContent>
         </Card>
       </TabsContent>
-      <TabsContent value="fields" className="space-y-6 sm:space-y-8 mx-auto max-w-[360px] sm:max-w-none">
+      <TabsContent value="fields" className="space-y-6 sm:space-y-8">
         <Card>
           <CardHeader className={CARD_HEADER}>
             <CardTitle>Inputs & behavior</CardTitle>
@@ -1262,7 +1266,7 @@ const CARD_CONTENT = 'p-3 pt-0 sm:p-6 sm:pt-0';
           </CardContent>
         </Card>
       </TabsContent>
-      <TabsContent value="protection" className="space-y-6 sm:space-y-8 mx-auto max-w-[360px] sm:max-w-none">
+      <TabsContent value="protection" className="space-y-6 sm:space-y-8">
         <Card>
           <CardHeader className={CARD_HEADER}>
             <CardTitle>Spam & abuse controls</CardTitle>
@@ -1325,7 +1329,7 @@ const CARD_CONTENT = 'p-3 pt-0 sm:p-6 sm:pt-0';
         </Card>
         <AlertCard />
       </TabsContent>
-      <TabsContent value="publish" className="space-y-6 sm:space-y-8 mx-auto max-w-[360px] sm:max-w-none">
+      <TabsContent value="publish" className="space-y-6 sm:space-y-8">
         <Card>
           <CardHeader className={CARD_HEADER}>
             <CardTitle className="text-lg font-semibold leading-tight sm:text-xl">Integration snippets</CardTitle>
@@ -1493,23 +1497,23 @@ const CARD_CONTENT = 'p-3 pt-0 sm:p-6 sm:pt-0';
     </div>
   );
   return (
-    <div className="space-y-4 sm:space-y-5 pb-24">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+    <div className="space-y-4 sm:space-y-5 pb-12">
+      <div className="hidden sm:flex sm:items-center sm:justify-between">
         <div className="space-y-1">
           <h2 className="text-xl font-semibold tracking-tight">Widget installation</h2>
           <p className="text-sm text-muted-foreground">Fine-tune, preview, and publish the experience for {projectName}.</p>
         </div>
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <div className="flex items-center gap-2">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="sm" disabled={loading} className="w-full sm:w-auto">Reset</Button>
+              <Button variant="outline" size="sm" disabled={loading}>Reset</Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuItem onClick={() => resetToSaved()}>Reset to Last Published</DropdownMenuItem>
               <DropdownMenuItem onClick={() => resetToDefaults()}>Reset to Defaults</DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
-          <Button onClick={handleSave} disabled={loading || saving || !isDirty} className="w-full sm:w-auto">
+          <Button onClick={handleSave} disabled={loading || saving || !isDirty}>
             {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <ShieldCheck className="mr-2 h-4 w-4" />}
             {saving ? 'Saving...' : isDirty ? 'Save & publish' : 'Saved'}
           </Button>
@@ -1527,7 +1531,27 @@ const CARD_CONTENT = 'p-3 pt-0 sm:p-6 sm:pt-0';
             sections
           )}
         </div>
-        <div className="space-y-5 sm:space-y-6">
+        <div className="space-y-4 sm:space-y-6">
+          <div className="flex items-center justify-end gap-2 sm:hidden">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" size="sm" disabled={loading} className="h-9 px-3 text-xs">Reset</Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => resetToSaved()}>Reset to Last Published</DropdownMenuItem>
+                <DropdownMenuItem onClick={() => resetToDefaults()}>Reset to Defaults</DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <Button
+              onClick={handleSave}
+              disabled={loading || saving || !isDirty}
+              size="sm"
+              className="h-9 px-3 text-xs"
+            >
+              {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <ShieldCheck className="mr-2 h-4 w-4" />}
+              {saving ? 'Saving...' : isDirty ? 'Save & publish' : 'Saved'}
+            </Button>
+          </div>
           <WidgetPreview config={config} projectKey={projectKey} widgetVersion={widgetVersion} viewport={viewport} onViewportChange={setViewport} />
         </div>
       </div>
@@ -1544,24 +1568,6 @@ const CARD_CONTENT = 'p-3 pt-0 sm:p-6 sm:pt-0';
         showNext={activeTab === 'publish' ? true : hasNext}
       />
 
-      {/* Sticky action bar */}
-      <div className="fixed bottom-0 left-0 right-0 z-40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 border-t border-border">
-        <div className="container mx-auto px-4 py-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end" style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 8px)' }}>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="sm" disabled={loading} className="w-full sm:w-auto">Reset</Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={() => resetToSaved()}>Reset to Last Published</DropdownMenuItem>
-              <DropdownMenuItem onClick={() => resetToDefaults()}>Reset to Defaults</DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-          <Button onClick={handleSave} disabled={loading || saving || !isDirty} className="w-full sm:w-auto">
-            {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <ShieldCheck className="mr-2 h-4 w-4" />}
-            {saving ? 'Saving...' : isDirty ? 'Save & publish' : 'Saved'}
-          </Button>
-        </div>
-      </div>
     </div>
   );
 }
@@ -1595,19 +1601,19 @@ function StepNavigation({
   return (
     <div
       className={cn(
-        'flex flex-col gap-3 rounded-xl border bg-card/60 p-3 sm:flex-row sm:items-center sm:justify-between',
-        variant === 'top' ? 'mt-3 mb-6' : 'mt-8'
+        'flex flex-col gap-3 rounded-lg border bg-card/60 p-3 sm:flex-row sm:items-center sm:justify-between',
+        variant === 'top' ? 'mt-3 mb-6' : 'mt-6'
       )}
     >
-      <div className="text-xs text-muted-foreground">Step {currentIndex + 1} of {steps.length}</div>
-      <div className="flex gap-2 flex-wrap sm:flex-nowrap">
+      <div className="text-xs font-medium text-muted-foreground">Step {currentIndex + 1} of {steps.length}</div>
+      <div className="flex items-center gap-2">
         <Button
           type="button"
           variant="outline"
           size="sm"
           onClick={onPrev}
           disabled={!hasPrev}
-          className={cn('flex items-center gap-1 w-full sm:w-auto', variant === 'top' ? 'px-3 text-xs md:text-sm' : '')}
+          className={cn('flex items-center gap-1 h-9 px-3 text-xs', variant === 'top' ? 'md:text-sm' : '')}
         >
           <ChevronLeft className="h-4 w-4" />
           Previous
@@ -1618,7 +1624,7 @@ function StepNavigation({
             size="sm"
             onClick={onNext}
             disabled={disableNext}
-            className={cn('flex items-center gap-1 w-full sm:w-auto', variant === 'top' ? 'px-3 text-xs md:text-sm' : '')}
+            className={cn('flex items-center gap-1 h-9 px-3 text-xs', variant === 'top' ? 'md:text-sm' : '')}
           >
             {nextLabel}
             {showArrow && <ChevronRight className="h-4 w-4" />}


### PR DESCRIPTION
## Summary
- streamline the mobile widget navigation with a compact heading and numbered step buttons that eliminate horizontal scrolling
- tighten the widget installation layout on small screens by widening content, relocating the reset/save controls above the preview, and slimming the step navigator buttons
- move the mobile overview card to the bottom of the widget section and drop the extra top padding so the page meets the viewport edge on phones

## Testing
- npm run lint --workspace @feedbacks/dashboard
- npm run type-check --workspace @feedbacks/dashboard


------
https://chatgpt.com/codex/tasks/task_e_68ca1a6de1888333b37580c3f71d2845