### PR TITLE
Improve dashboard layout responsiveness

### DIFF
--- a/packages/dashboard/src/app/(dashboard)/dashboard/page.tsx
+++ b/packages/dashboard/src/app/(dashboard)/dashboard/page.tsx
@@ -67,7 +67,7 @@ export default function DashboardPage() {
 
 
   return (
-    <div className="p-6 md:p-6 lg:p-8 space-y-8 md:space-y-8 page-illumination">
+    <div className="py-6 lg:py-8 space-y-8 md:space-y-8 page-illumination">
         {/* Welcome Section */}
         <div className="relative rounded-2xl p-4 md:p-6 bg-gradient-to-r from-background via-background to-primary/5">
           <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
@@ -113,7 +113,7 @@ export default function DashboardPage() {
           
           <TabsContent value="overview" className="space-y-6 md:space-y-8">
             {/* Stats Overview - Enhanced Stats Cards */}
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 md:gap-6">
+            <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3 md:gap-6">
               <StatsCard
                 title="Total Projects"
                 value={projects?.length || 0}
@@ -201,7 +201,7 @@ export default function DashboardPage() {
               </div>
 
               {projects && projects.length > 0 ? (
-                <div className="grid grid-cols-2 gap-3 md:gap-4 lg:gap-6 xl:grid-cols-3">
+                <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3 md:gap-4 lg:gap-6">
                   {projects.map((project: any, index: number) => (
                     <div 
                       key={project.id} 

--- a/packages/dashboard/src/components/dashboard-client-layout.tsx
+++ b/packages/dashboard/src/components/dashboard-client-layout.tsx
@@ -60,6 +60,14 @@ export function DashboardClientLayout({
   const [projects, setProjects] = useState<Project[]>(initialProjects);
   const supabase = useMemo(() => createBrowserSupabaseClient(), []);
   const mountedRef = useRef(true);
+  const mobileLayoutMetrics = useMemo(
+    () =>
+      ({
+        '--dashboard-mobile-header-height': 'calc(4rem + env(safe-area-inset-top, 0px))',
+        '--dashboard-mobile-bottom-offset': 'calc(4.5rem + env(safe-area-inset-bottom, 0px))',
+      }) as React.CSSProperties,
+    [],
+  );
 
   useEffect(() => {
     mountedRef.current = true;
@@ -119,34 +127,41 @@ export function DashboardClientLayout({
   return (
     <DashboardContext.Provider value={{ user, projects, refreshProjects }}>
       <SidebarProvider>
-        <div className="flex h-screen w-full">
+        <div className="flex min-h-dvh w-full bg-background">
           <DashboardSidebar user={user} />
-          
+
           {/* Desktop: No top bar, just main content */}
           <div className="hidden lg:flex flex-1 flex-col overflow-hidden">
             <main className="flex-1 overflow-auto w-full bg-background prevent-bounce">
-              <div className="min-h-screen bg-background transition-opacity duration-200 ease-in-out flex flex-col">
+              <div className="min-h-dvh bg-background transition-opacity duration-200 ease-in-out flex flex-col">
                 <div className="flex-1 pb-8 sm:pb-12 md:pb-16">
                   <RouteLoading />
-                  {children}
+                  <div className="mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-10">
+                    {children}
+                  </div>
                 </div>
                 <div className="mt-auto">
-                  <div className="h-8"></div>
                   <BottomBar />
                 </div>
               </div>
             </main>
           </div>
-          
+
           {/* Mobile: Simple header with logo and theme toggle only */}
-          <div className="flex lg:hidden flex-1 flex-col overflow-hidden">
+          <div
+            className="flex lg:hidden flex-1 flex-col overflow-hidden"
+            style={mobileLayoutMetrics}
+          >
             {!isProjectDetailPage && (
-              <header className="fixed top-0 left-0 right-0 z-50 flex items-center justify-between p-4 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+              <header
+                className="fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-4 pb-4 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60"
+                style={{ paddingTop: 'calc(env(safe-area-inset-top, 0px) + 1rem)' }}
+              >
                 {/* Left: Logo and text */}
                 <Link href="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
                   <div className="h-8 w-8 flex items-center justify-center">
-                    <img 
-                    src="/logo.svg" 
+                    <img
+                    src="/logo.svg"
                     alt="feedbacks.dev" 
                     className="h-8 w-8 rounded"
                   />
@@ -160,17 +175,24 @@ export function DashboardClientLayout({
                 </div>
               </header>
             )}
-            
+
             <main className="flex-1 overflow-auto w-full bg-background prevent-bounce">
               <div
-                className={'min-h-screen bg-background transition-opacity duration-200 ease-in-out flex flex-col ' + (isProjectDetailPage ? 'pt-4 ' : 'pt-16 ') + ' pb-20'}
+                className="min-h-dvh bg-background transition-opacity duration-200 ease-in-out flex flex-col"
+                style={{
+                  paddingTop: isProjectDetailPage
+                    ? 'calc(env(safe-area-inset-top, 0px) + 1rem)'
+                    : 'var(--dashboard-mobile-header-height)',
+                  paddingBottom: 'var(--dashboard-mobile-bottom-offset)',
+                }}
               >
                 <div className="flex-1 pb-8 sm:pb-12 md:pb-16">
                   <RouteLoading />
-                  {children}
+                  <div className="mx-auto w-full max-w-6xl px-4 sm:px-6">
+                    {children}
+                  </div>
                 </div>
                 <div className="mt-auto">
-                  <div className="h-8"></div>
                   <BottomBar />
                 </div>
               </div>

--- a/packages/dashboard/src/components/mobile-bottom-nav.tsx
+++ b/packages/dashboard/src/components/mobile-bottom-nav.tsx
@@ -4,8 +4,6 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { Home, BarChart3, MessageSquare, Settings, Plus } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 
 interface MobileBottomNavProps {
   projectsCount?: number;
@@ -47,27 +45,31 @@ export function MobileBottomNav({ projectsCount = 0 }: MobileBottomNavProps) {
   return (
     <div className="md:hidden">
       {/* Fixed bottom navigation */}
-      <div className="fixed bottom-0 left-0 right-0 z-50 bg-background/95 backdrop-blur-md border-t border-border">
+      <nav
+        className="fixed bottom-0 left-0 right-0 z-50 border-t border-border bg-background/95 backdrop-blur-md"
+        aria-label="Primary"
+      >
         {/* Safe area padding for iOS */}
         <div className="pb-safe-area-inset-bottom">
-          <div className="flex items-center justify-around px-2 py-2">
+          <div className="mx-auto flex w-full max-w-3xl items-center justify-around px-2 py-2">
             {navItems.map((item) => {
-              const isActive = pathname === item.url || 
+              const isActive = pathname === item.url ||
                 (item.url !== '/dashboard' && pathname.startsWith(item.url));
-              
+
               return (
                 <Link
                   key={item.url}
                   href={item.url}
                   className={cn(
                     "flex flex-col items-center justify-center min-h-[48px] px-2 py-1 rounded-lg transition-all duration-200 relative group flex-1 max-w-[80px]",
-                    isActive 
-                      ? "bg-primary/10 text-primary" 
+                    isActive
+                      ? "bg-primary/10 text-primary"
                       : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
                   )}
+                  aria-current={isActive ? 'page' : undefined}
                 >
                   <div className="relative">
-                    <item.icon 
+                    <item.icon
                       className={cn(
                         "h-5 w-5 transition-all duration-200",
                         isActive ? "text-primary" : "group-hover:scale-110",
@@ -98,10 +100,7 @@ export function MobileBottomNav({ projectsCount = 0 }: MobileBottomNavProps) {
             })}
           </div>
         </div>
-      </div>
-      
-      {/* Bottom padding to account for fixed nav */}
-      <div className="h-[80px]" />
+      </nav>
     </div>
   );
 }

--- a/packages/dashboard/src/components/route-loading.tsx
+++ b/packages/dashboard/src/components/route-loading.tsx
@@ -38,9 +38,12 @@ export function RouteLoading({ className }: RouteLoadingProps) {
   if (!isLoading) return null;
 
   return (
-    <div className={cn("fixed top-0 left-0 right-0 z-50", className)}>
-      <Progress 
-        value={progress} 
+    <div
+      className={cn('fixed left-0 right-0 z-50 pointer-events-none', className)}
+      style={{ top: 'max(env(safe-area-inset-top, 0px), 0px)' }}
+    >
+      <Progress
+        value={progress}
         className="h-1 bg-transparent border-none"
       />
       <div className="absolute top-1 left-1/2 transform -translate-x-1/2 -translate-y-full">


### PR DESCRIPTION
## Summary
- adjust the dashboard client layout to respect safe-area insets, center content within a max width, and ensure both mobile and desktop flows use dynamic viewport heights
- refine the mobile bottom navigation with semantic markup, safe-area spacing, and aria-current support while letting the main content reserve space for it
- tune the dashboard overview page grids for smaller screens and offset the route loader from device notches

## Testing
- `npm run type-check --workspace=packages/dashboard` *(fails: repository currently has pre-existing type errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8513f6108333a50a5bd45358cfa1