### PR TITLE
fix: Dodo webhook signature verification (CRITICAL)

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -33,6 +33,7 @@
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "standardwebhooks": "^1.0.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/packages/dashboard/src/lib/dodo.ts
+++ b/packages/dashboard/src/lib/dodo.ts
@@ -1,4 +1,4 @@
-import { createHmac, timingSafeEqual } from 'node:crypto'
+import { Webhook } from 'standardwebhooks'
 import { env } from './env.ts'
 
 const API_BASES = {
@@ -81,40 +81,26 @@ export async function createDodoCustomerPortalSession(payload: DodoPortalRequest
   }>(`/customers/${payload.customerId}/customer-portal/session`, {})
 }
 
-function headerValue(headers: Headers, key: string) {
-  return headers.get(key) || headers.get(key.toLowerCase())
-}
-
 export async function verifyDodoWebhook(request: Request) {
   if (!env.DODO_PAYMENTS_WEBHOOK_SECRET) {
     throw new Error('Dodo webhook secret is not configured')
   }
 
   const payload = await request.text()
-  const signature = headerValue(request.headers, 'webhook-signature')
-  const webhookId = headerValue(request.headers, 'webhook-id')
-  const timestamp = headerValue(request.headers, 'webhook-timestamp')
-
-  if (!signature || !webhookId || !timestamp) {
-    throw new Error('Missing Dodo webhook headers')
+  const headers: Record<string, string> = {}
+  for (const key of ['webhook-id', 'webhook-signature', 'webhook-timestamp']) {
+    const value = request.headers.get(key)
+    if (!value) {
+      throw new Error(`Missing Dodo webhook header: ${key}`)
+    }
+    headers[key] = value
   }
 
-  const signedContent = `${webhookId}.${timestamp}.${payload}`
-  const expected = createHmac('sha256', env.DODO_PAYMENTS_WEBHOOK_SECRET)
-    .update(signedContent)
-    .digest('hex')
-
-  const expectedBuffer = Buffer.from(expected)
-  const signatureBuffer = Buffer.from(signature)
-  if (
-    expectedBuffer.length !== signatureBuffer.length ||
-    !timingSafeEqual(expectedBuffer, signatureBuffer)
-  ) {
-    throw new Error('Invalid webhook signature')
-  }
+  const wh = new Webhook(env.DODO_PAYMENTS_WEBHOOK_SECRET)
+  wh.verify(payload, headers)
 
   return {
-    webhookId,
+    webhookId: headers['webhook-id'],
     payload,
     event: JSON.parse(payload) as DodoEventPayload,
   }

--- a/packages/dashboard/tests/unit/dodo-webhooks.test.ts
+++ b/packages/dashboard/tests/unit/dodo-webhooks.test.ts
@@ -7,7 +7,8 @@ process.env.NEXT_PUBLIC_SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || '
 process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'anon-key'
 process.env.SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || 'service-role-key'
 process.env.NEXT_PUBLIC_APP_ORIGIN = process.env.NEXT_PUBLIC_APP_ORIGIN || 'https://app.feedbacks.dev'
-process.env.DODO_PAYMENTS_WEBHOOK_SECRET = process.env.DODO_PAYMENTS_WEBHOOK_SECRET || 'whsec_test'
+// standardwebhooks expects whsec_ + base64-encoded secret
+process.env.DODO_PAYMENTS_WEBHOOK_SECRET = process.env.DODO_PAYMENTS_WEBHOOK_SECRET || 'whsec_' + Buffer.from('testsecret123456789012345').toString('base64')
 
 async function loadFixture(name: string) {
   const fixtureUrl = new URL(`../fixtures/dodo/${name}.json`, import.meta.url)
@@ -60,10 +61,16 @@ test('verifies valid Dodo webhook signatures', async () => {
   const fixture = await loadFixture('subscription-active')
   const payload = JSON.stringify(fixture)
   const webhookId = 'evt_test_valid'
-  const timestamp = '1710000000'
-  const signature = createHmac('sha256', process.env.DODO_PAYMENTS_WEBHOOK_SECRET!)
-    .update(`${webhookId}.${timestamp}.${payload}`)
-    .digest('hex')
+  const timestamp = Math.floor(Date.now() / 1000).toString()
+
+  // standardwebhooks expects: whsec_ prefix stripped, base64-decoded secret
+  // signature format: v1,<base64-hmac>
+  const secret = process.env.DODO_PAYMENTS_WEBHOOK_SECRET!
+  const secretBytes = Buffer.from(secret.replace(/^whsec_/, ''), 'base64')
+  const signedContent = `${webhookId}.${timestamp}.${payload}`
+  const signature = 'v1,' + createHmac('sha256', secretBytes)
+    .update(signedContent)
+    .digest('base64')
 
   const request = new Request('https://example.com/api/billing/webhook', {
     method: 'POST',
@@ -97,5 +104,5 @@ test('rejects invalid Dodo webhook signatures', async () => {
     body: payload,
   })
 
-  await assert.rejects(() => verifyDodoWebhook(request), /Invalid webhook signature/)
+  await assert.rejects(() => verifyDodoWebhook(request), /WebhookVerificationError/)
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
+      standardwebhooks:
+        specifier: ^1.0.0
+        version: 1.0.0
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.1
@@ -1320,6 +1323,9 @@ packages:
   '@rushstack/eslint-patch@1.16.1':
     resolution: {integrity: sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@supabase/auth-js@2.99.2':
     resolution: {integrity: sha512-uRGNXMKEw4VhwouNW7N0XDAGqJP9redHNDmWi17dTrcO1lvFfyRiXsqqfgnVC8aqtRn8kLkLPEzHjiRWsni+oQ==}
     engines: {node: '>=20.0.0'}
@@ -2116,6 +2122,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
@@ -2975,6 +2984,9 @@ packages:
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -4149,6 +4161,8 @@ snapshots:
 
   '@rushstack/eslint-patch@1.16.1': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@supabase/auth-js@2.99.2':
     dependencies:
       tslib: 2.8.1
@@ -5201,6 +5215,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.0: {}
 
   fastq@1.20.1:
@@ -6096,6 +6112,11 @@ snapshots:
   source-map-js@1.2.1: {}
 
   stable-hash@0.0.5: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
 
   statuses@2.0.2: {}
 


### PR DESCRIPTION
## Critical Bug Fix

The webhook signature verification was using raw HMAC-SHA256 hex, but Dodo Payments uses standardwebhooks (Svix) format which requires:
1. Stripping `whsec_` prefix from secret and base64-decoding it
2. Producing base64 HMAC-SHA256 digest
3. Parsing `v1,<base64>` signature format from the header

**Without this fix, Pro subscriptions would NEVER activate after payment.** The entire billing flow would silently fail.

All 5 tests passing ✅