### PR TITLE
Index Product Updates rollout foreign keys

### DIFF
--- a/packages/dashboard/tests/unit/plan-foreign-key-indexes-migration.test.ts
+++ b/packages/dashboard/tests/unit/plan-foreign-key-indexes-migration.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const migration = new URL('../../../../sql/032_plan_foreign_key_indexes.sql', import.meta.url)
+
+test('plan tables cover foreign keys used by parent updates and deletes', async () => {
+  const sql = await readFile(migration, 'utf8')
+
+  assert.match(
+    sql,
+    /on public\.product_update_metrics\s*\(project_id, update_id\)/i,
+  )
+  assert.match(
+    sql,
+    /on public\.product_updates\s*\(created_by\)\s*where created_by is not null/i,
+  )
+  assert.match(
+    sql,
+    /on public\.webhook_digest_items\s*\(last_delivery_id\)\s*where last_delivery_id is not null/i,
+  )
+})

--- a/sql/032_plan_foreign_key_indexes.sql
+++ b/sql/032_plan_foreign_key_indexes.sql
@@ -1,0 +1,14 @@
+-- 032_plan_foreign_key_indexes.sql
+-- Cover the foreign-key columns introduced by the Product Updates rollout so
+-- parent updates and deletes do not scan the full referencing tables.
+
+create index if not exists idx_product_update_metrics_project_update
+  on public.product_update_metrics(project_id, update_id);
+
+create index if not exists idx_product_updates_created_by
+  on public.product_updates(created_by)
+  where created_by is not null;
+
+create index if not exists idx_webhook_digest_items_last_delivery
+  on public.webhook_digest_items(last_delivery_id)
+  where last_delivery_id is not null;


### PR DESCRIPTION
## What changed

- add covering indexes for the Product Updates metrics composite foreign key
- add partial indexes for nullable update-author and digest-delivery foreign keys
- add a migration contract test for all three indexes

## Why

Supabase's post-release performance advisor found three plan-related foreign keys without covering indexes. The schema was correct, but parent updates and deletes could eventually require full scans of the referencing tables.

Migration `032_plan_foreign_key_indexes` is already applied to the linked live project. The advisor now reports no unindexed foreign keys.

## Validation

- `pnpm type-check` — passed
- `pnpm lint` — passed
- `pnpm test:unit` — 97 passed, 0 failed, 0 skipped
- `pnpm build` — passed
- `pnpm widget:check-size` — 52,398 bytes raw / 15,333 bytes gzip
- `pnpm supabase:check` — passed
- `git diff --check` — passed