### PR TITLE
Polish the complete product experience

### DIFF
--- a/packages/dashboard/src/app/(dashboard)/feedback/feedback-project-scope.tsx
+++ b/packages/dashboard/src/app/(dashboard)/feedback/feedback-project-scope.tsx
@@ -25,7 +25,7 @@ export function FeedbackProjectScope({
     <div className="border-y py-2.5">
       <div className="mb-2 px-0.5">
         <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">Project view</p>
-        <p className="text-[11px] text-muted-foreground/75">Choose one project or include the whole workspace.</p>
+        <p className="text-[11px] text-muted-foreground">Choose one project or include the whole workspace.</p>
       </div>
       <div className="-mx-4 px-4 md:mx-0 md:px-0">
         <div className="scroll-fade-x flex snap-x items-center gap-2 overflow-x-auto pb-1 pr-8 scrollbar-thin md:pr-0">
@@ -51,4 +51,3 @@ export function FeedbackProjectScope({
     </div>
   )
 }
-

--- a/packages/dashboard/src/app/(dashboard)/feedback/page.tsx
+++ b/packages/dashboard/src/app/(dashboard)/feedback/page.tsx
@@ -805,7 +805,7 @@ function FeedbackRow({
           aria-hidden="true"
           className={cn(
             'mt-2 h-2 w-2 shrink-0 rounded-full transition-colors',
-            isUnread ? 'bg-primary shadow-[0_0_0_3px_hsl(var(--primary)/0.12)]' : 'bg-transparent'
+            isUnread ? 'bg-primary shadow-[0_0_0_3px_oklch(var(--primary)/0.12)]' : 'bg-transparent'
           )}
         />
         <TypeIcon type={fb.type} className="mt-0.5 shrink-0 text-muted-foreground" />

--- a/packages/dashboard/src/app/(dashboard)/layout.tsx
+++ b/packages/dashboard/src/app/(dashboard)/layout.tsx
@@ -20,23 +20,31 @@ export default async function DashboardLayout({
     redirect('/auth')
   }
 
-  const { data: projects } = await supabase
-    .from('projects')
-    .select('id, name, settings')
-    .eq('owner_user_id', user.id)
-    .order('created_at', { ascending: false })
-
-  const { data: billingAccount } = await supabase
-    .from('billing_accounts')
-    .select('plan_tier, billing_status')
-    .eq('user_id', user.id)
-    .maybeSingle()
-
-  const { data: userSettings } = await supabase
-    .from('user_settings')
-    .select('preferences')
-    .eq('user_id', user.id)
-    .maybeSingle()
+  const [
+    { data: projects },
+    { data: billingAccount },
+    { data: userSettings },
+    headersList,
+    cookieStore,
+  ] = await Promise.all([
+    supabase
+      .from('projects')
+      .select('id, name, settings')
+      .eq('owner_user_id', user.id)
+      .order('created_at', { ascending: false }),
+    supabase
+      .from('billing_accounts')
+      .select('plan_tier, billing_status')
+      .eq('user_id', user.id)
+      .maybeSingle(),
+    supabase
+      .from('user_settings')
+      .select('preferences')
+      .eq('user_id', user.id)
+      .maybeSingle(),
+    headers(),
+    cookies(),
+  ])
 
   const projectIds = (projects || []).map((project: { id: string }) => project.id)
   const { data: boardSettings } = projectIds.length > 0
@@ -48,8 +56,6 @@ export default async function DashboardLayout({
     : { data: [] }
 
   // Extract current project ID from URL path
-  const headersList = await headers()
-  const cookieStore = await cookies()
   const pathname = headersList.get('x-pathname') || headersList.get('x-invoke-path') || ''
   const projectMatch = pathname.match(/\/projects\/([^/]+)/)
   const storedProjectId = cookieStore.get(CURRENT_PROJECT_COOKIE)?.value
@@ -81,8 +87,8 @@ export default async function DashboardLayout({
         boardSlugs={boardSlugs}
         billingAccount={billingAccount}
       />
-      <main className="min-h-0 flex-1 overflow-y-auto bg-muted/35 pb-[env(safe-area-inset-bottom,0px)] dark:bg-background">
-        <div className="mx-auto max-w-7xl px-4 py-4 md:px-6 md:py-6">{children}</div>
+      <main className="min-h-0 flex-1 overflow-y-auto bg-muted/25 pb-[env(safe-area-inset-bottom,0px)] dark:bg-background">
+        <div className="mx-auto max-w-[1320px] px-4 py-5 md:px-7 md:py-7">{children}</div>
       </main>
       <ProductTour
         initialOpen={false}

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/loading.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/loading.tsx
@@ -24,7 +24,7 @@ export default function ProjectLoading() {
       <div className="rounded-xl border-2 border-foreground/15 bg-card p-3 dark:border-primary/25">
         <div className="grid gap-3 md:grid-cols-4">
           {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="rounded-xl border-2 border-foreground/15 bg-background p-4 shadow-[5px_5px_0_hsl(var(--foreground)/0.16)] dark:border-primary/25">
+            <div key={i} className="rounded-xl border border-border/80 bg-background p-4 shadow-[var(--shadow-card)] dark:border-primary/25">
               <div className="flex gap-3">
                 <Skeleton className="h-7 w-7 rounded-full" />
                 <div className="space-y-2">

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/project-home.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/project-home.tsx
@@ -9,12 +9,12 @@ export function ProjectHome({ project }: { project: Project }) {
   const feedbackEnabled = project.settings?.widget_config?.feedbackEnabled !== false
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-7 animate-fade-in">
       <section className="border-b pb-6">
-        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-primary">Project home</p>
-        <h1 className="mt-2 text-2xl font-semibold tracking-tight">What do you want to manage?</h1>
+        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-primary">{project.name}</p>
+        <h1 className="mt-2 text-3xl font-semibold tracking-[-0.035em]">Two products. One shared connection.</h1>
         <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-          {project.name} uses one small embed for two separate products. Install it once, then manage both products here without changing your site code.
+          Choose the product you want to manage. The shared embed is installed once, then saved changes reach your site remotely.
         </p>
       </section>
 
@@ -24,7 +24,7 @@ export function ProjectHome({ project }: { project: Project }) {
           eyebrow="Feedback collection"
           title="Feedback form"
           description="Collect bugs, ideas, questions, ratings, screenshots, and contact details from inside your product."
-          detail="You control the button, placement, fields, wording, and anti-spam settings remotely."
+          detail="Control the button, placement, fields, wording, and anti-spam settings remotely."
           status={feedbackEnabled ? 'Enabled' : 'Disabled'}
           href={`/projects/${project.id}/feedback-form`}
           action="Manage feedback form"
@@ -34,13 +34,13 @@ export function ProjectHome({ project }: { project: Project }) {
           eyebrow="In-product communication"
           title="Release notes"
           description="Publish “What’s new” announcements that appear inside your users’ product."
-          detail="Create, preview, schedule, and publish announcements. This is not a log of feedbacks.dev website changes."
+          detail="Create, preview, schedule, and publish announcements for your users."
           href={`/projects/${project.id}/release-notes`}
           action="Open release notes"
         />
       </div>
 
-      <Card className="overflow-hidden border-primary/25 bg-primary/[0.035]">
+      <Card className="overflow-hidden border-primary/25 bg-primary/[0.045]">
         <CardContent className="grid gap-6 p-5 sm:p-6 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
           <div className="flex gap-4">
             <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
@@ -52,7 +52,7 @@ export function ProjectHome({ project }: { project: Project }) {
                 <Badge variant="secondary">Install once</Badge>
               </div>
               <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-                Add the public project embed to your app shell. After that, saved changes to the feedback form and release notes arrive remotely on the next page load—no replacement snippet or redeploy required.
+                Add the public project embed to your app shell. After that, Feedback form and Release notes changes arrive remotely on the next page load. No replacement snippet or redeploy is required.
               </p>
               <div className="mt-4 flex flex-wrap items-center gap-2 text-xs font-medium text-muted-foreground" aria-label="Product setup flow">
                 <span className="rounded-md border bg-background px-2.5 py-1.5">1. Install embed</span>

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/project-verify-client.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/project-verify-client.tsx
@@ -96,10 +96,10 @@ export function ProjectVerifyClient({
             </div>
           </div>
           <Button asChild className="shrink-0">
-            <Link href={`/feedback/${verifiedFeedbackId}`}>
+            <a href={`/feedback/${verifiedFeedbackId}`}>
               Open verified item
               <ExternalLink className="ml-2 h-4 w-4" />
-            </Link>
+            </a>
           </Button>
         </div>
       )}

--- a/packages/dashboard/src/app/(dashboard)/projects/new/page.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/new/page.tsx
@@ -13,10 +13,16 @@ import { cn } from '@/lib/utils'
 import { DEFAULT_PROJECT_ICON, PROJECT_ICONS } from '@/lib/project-icons'
 
 const setupSteps = [
-  { Icon: CheckCircle2, title: 'Create project', body: 'Name the place where feedback belongs.' },
-  { Icon: Code2, title: 'Copy the default install', body: 'The generated snippet works without configuration.' },
-  { Icon: Inbox, title: 'Verify one message', body: 'Send one test, confirm the inbox, then customize if needed.' },
+  { Icon: CheckCircle2, title: 'Create this project', body: 'Choose the first product. You can enable the other later.' },
+  { Icon: Code2, title: 'Install one shared embed', body: 'Paste the generated Website snippet into your app shell.' },
+  { Icon: Inbox, title: 'Verify the connection', body: 'Send one test and confirm it reached the project inbox.' },
 ]
+
+const productChoices = [
+  { value: 'feedback', label: 'Feedback form', body: 'Collect bugs, ideas, questions, ratings, and screenshots.' },
+  { value: 'updates', label: 'Release notes', body: 'Publish in-product “What’s new” announcements.' },
+  { value: 'both', label: 'Both products', body: 'Collect user signal and communicate what shipped.' },
+] as const
 
 export default function NewProjectPage() {
   const [name, setName] = React.useState('')
@@ -92,7 +98,7 @@ export default function NewProjectPage() {
   }
 
   return (
-    <div className="mx-auto max-w-4xl space-y-6">
+    <div className="mx-auto max-w-5xl space-y-7 animate-fade-in">
       <Link
         href="/projects"
         className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
@@ -100,10 +106,16 @@ export default function NewProjectPage() {
         <ArrowLeft className="h-4 w-4" /> Back to projects
       </Link>
 
-      <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_320px]">
+      <header className="max-w-2xl">
+        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-primary">New project</p>
+        <h1 className="mt-2 text-3xl font-semibold tracking-[-0.035em]">What are you adding to your product?</h1>
+        <p className="mt-3 text-sm leading-6 text-muted-foreground">A project is one app or website. Start with the product you need now, then install the shared embed once.</p>
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_300px] lg:items-start">
         <Card data-tour="project-create-form">
           <CardHeader>
-            <CardTitle>Create project</CardTitle>
+            <CardTitle className="text-lg">Project details</CardTitle>
             <CardDescription>
               One name is enough. The next screen gives you a working install snippet immediately.
             </CardDescription>
@@ -127,12 +139,13 @@ export default function NewProjectPage() {
             </div>
             <fieldset className="space-y-2">
               <legend className="text-sm font-medium">What do you want to do first?</legend>
-              <div className="grid gap-2 sm:grid-cols-3">
-                {([
-                  ['updates', 'Publish release notes'],
-                  ['feedback', 'Collect feedback'],
-                  ['both', 'Both'],
-                ] as const).map(([value, label]) => <button key={value} type="button" onClick={() => setGoal(value)} className={cn('min-h-11 rounded-md border px-3 text-left text-sm font-medium', goal === value ? 'border-primary bg-primary/5 text-primary' : 'hover:bg-muted/50')} aria-pressed={goal === value}>{label}</button>)}
+              <div className="grid gap-2">
+                {productChoices.map(({ value, label, body }) => (
+                  <button key={value} type="button" onClick={() => setGoal(value)} className={cn('grid min-h-16 grid-cols-[18px_1fr] gap-3 rounded-lg border px-4 py-3 text-left transition-colors', goal === value ? 'border-primary/50 bg-primary/[0.055]' : 'hover:border-foreground/20 hover:bg-muted/35')} aria-label={label} aria-pressed={goal === value}>
+                    <span className={cn('mt-0.5 flex h-4 w-4 items-center justify-center rounded-full border', goal === value ? 'border-primary bg-primary' : 'border-input')}>{goal === value && <span className="h-1.5 w-1.5 rounded-full bg-primary-foreground" />}</span>
+                    <span><span className={cn('block text-sm font-semibold', goal === value && 'text-primary')}>{label}</span><span className="mt-1 block text-xs leading-5 text-muted-foreground">{body}</span></span>
+                  </button>
+                ))}
               </div>
               <p className="text-xs text-muted-foreground">You can turn either product on or off later without changing the shared embed.</p>
             </fieldset>
@@ -211,25 +224,22 @@ export default function NewProjectPage() {
           </CardContent>
         </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Setup stays linear</CardTitle>
-            <CardDescription>
-              One screen at a time, no setup maze.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {setupSteps.map(({ Icon, title, body }) => (
-              <div key={title} className="flex gap-3 rounded-lg border bg-muted/20 p-3">
-                <Icon className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+        <aside className="rounded-lg border bg-card px-5 py-5 shadow-[var(--shadow-card)]">
+          <p className="text-sm font-semibold">What happens next</p>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">Three focused screens. Advanced settings stay out of the way.</p>
+          <div className="mt-5 border-y">
+            {setupSteps.map(({ title, body }, index) => (
+              <div key={title} className="flex gap-3 border-b py-4 last:border-b-0">
+                <span className="font-mono text-[10px] text-primary">0{index + 1}</span>
                 <div className="min-w-0">
                   <p className="text-sm font-medium">{title}</p>
                   <p className="mt-0.5 text-xs leading-5 text-muted-foreground">{body}</p>
                 </div>
               </div>
             ))}
-          </CardContent>
-        </Card>
+          </div>
+          <p className="mt-4 flex items-start gap-2 text-xs leading-5 text-muted-foreground"><CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" /> Future form and release-note changes are delivered remotely. No new snippet.</p>
+        </aside>
       </div>
     </div>
   )

--- a/packages/dashboard/src/app/auth/page.tsx
+++ b/packages/dashboard/src/app/auth/page.tsx
@@ -2,31 +2,17 @@
 
 import * as React from 'react'
 import { Suspense } from 'react'
-import { generateInstallSnippets } from '@feedbacks/shared'
 import { createClient } from '@/lib/supabase-browser'
-import { publicEnv } from '@/lib/public-env'
 import { Button } from '@/components/ui/button'
 import { BrandWordmark } from '@/components/brand-wordmark'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Separator } from '@/components/ui/separator'
-import { Github, Mail, Loader2, ArrowRight, CheckCircle2, KeyRound } from 'lucide-react'
+import { ArrowLeft, ArrowRight, Check, Github, KeyRound, Loader2, Mail, MessageSquare, Megaphone } from 'lucide-react'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 import { cn } from '@/lib/utils'
 import { sanitizeRedirectPath } from '@/lib/redirects'
-
-const features = [
-  'Sign in and land on project setup with the install snippet ready',
-  'Start with the Website snippet, then verify one real submission',
-  'Capture URL, browser context, and optional screenshots automatically',
-  'Add routing and public boards after the core loop is working',
-]
-
-const codeSnippet = generateInstallSnippets({
-  projectKey: 'your-project-key',
-  appOrigin: publicEnv.NEXT_PUBLIC_APP_ORIGIN,
-}).find((snippet) => snippet.label === 'Website')?.code || ''
 
 function AuthPageInner() {
   const [email, setEmail] = React.useState('')
@@ -39,329 +25,132 @@ function AuthPageInner() {
   const searchParams = useSearchParams()
   const redirect = sanitizeRedirectPath(searchParams.get('redirect'), '/projects/new')
   const encodedRedirect = encodeURIComponent(redirect)
-
   const supabase = React.useMemo(() => createClient(), [])
 
-  const handlePasswordSignIn = async (e: React.FormEvent) => {
-    e.preventDefault()
+  const handlePasswordSignIn = async (event: React.FormEvent) => {
+    event.preventDefault()
     setLoading(true)
     setError('')
-
-    const { error } = await supabase.auth.signInWithPassword({
-      email,
-      password,
-    })
-
+    const { error: authError } = await supabase.auth.signInWithPassword({ email, password })
     setLoading(false)
-    if (error) {
-      setError(error.message)
-      return
-    }
-
+    if (authError) return setError(authError.message)
     window.location.href = redirect
   }
 
-  const handleMagicLink = async (e: React.FormEvent) => {
-    e.preventDefault()
+  const handleMagicLink = async (event: React.FormEvent) => {
+    event.preventDefault()
     setMagicLoading(true)
     setError('')
-
-    const { error } = await supabase.auth.signInWithOtp({
+    const { error: authError } = await supabase.auth.signInWithOtp({
       email,
-      options: {
-        emailRedirectTo: `${window.location.origin}/auth/callback?redirect=${encodedRedirect}`,
-      },
+      options: { emailRedirectTo: `${window.location.origin}/auth/callback?redirect=${encodedRedirect}` },
     })
-
     setMagicLoading(false)
-    if (error) {
-      setError(error.message)
-    } else {
-      setSent(true)
-    }
+    if (authError) setError(authError.message)
+    else setSent(true)
   }
 
   const handleGitHub = async () => {
     setGithubLoading(true)
     await supabase.auth.signInWithOAuth({
       provider: 'github',
-      options: {
-        redirectTo: `${window.location.origin}/auth/callback?redirect=${encodedRedirect}`,
-      },
+      options: { redirectTo: `${window.location.origin}/auth/callback?redirect=${encodedRedirect}` },
     })
   }
 
   return (
-    <div className="relative flex min-h-screen overflow-hidden bg-[hsl(238_28%_99%)] dark:bg-[hsl(238_22%_8%)]">
-
-      {/* ── Left panel: brand/feature cover ──────────────────────────────── */}
-      <div className="relative hidden w-[52%] shrink-0 overflow-hidden lg:flex">
-
-        {/* Dark indigo base */}
-        <div className="absolute inset-0 bg-[hsl(238_40%_10%)]" />
-
-        <div className="absolute inset-x-0 top-0 h-px bg-white/20" />
-        <div className="absolute bottom-0 left-0 right-0 h-32 bg-white/[0.03]" />
-
-        {/* Subtle dot grid overlay */}
-        <div
-          className="absolute inset-0 opacity-[0.06]"
-          style={{
-            backgroundImage: 'radial-gradient(circle, white 1px, transparent 1px)',
-            backgroundSize: '28px 28px',
-          }}
-        />
-
-        {/* Content */}
-        <div className="relative z-10 flex flex-col justify-between p-12 xl:p-16">
-          {/* Top: logo */}
-          <Link
-            href="/"
-            className="font-semibold text-white/90 transition-opacity hover:text-white active:opacity-70"
-          >
-            <BrandWordmark
-              className="text-xl"
-              markClassName="h-7 w-7"
-              dotClassName="text-[hsl(238_72%_78%)]"
-            />
+    <main className="relative min-h-screen overflow-hidden bg-background">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_18%_16%,oklch(var(--primary)/0.1),transparent_34%)]" />
+      <div className="relative mx-auto grid min-h-screen max-w-7xl lg:grid-cols-[1fr_0.85fr]">
+        <section className="hidden border-r px-10 py-9 lg:flex lg:flex-col xl:px-16">
+          <Link href="/" className="inline-flex w-fit font-semibold transition-opacity hover:opacity-80">
+            <BrandWordmark className="text-lg" markClassName="h-6 w-6" />
           </Link>
+          <div className="my-auto max-w-xl py-16">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-primary">First value in minutes</p>
+            <h1 className="mt-5 text-4xl font-semibold leading-[1.05] tracking-[-0.04em] xl:text-5xl">A small setup path.<br />A complete feedback loop.</h1>
+            <p className="mt-5 max-w-lg leading-7 text-muted-foreground">Sign in, create one project, install one shared embed, and send a test. Everything else can wait until the connection works.</p>
 
-          {/* Middle: headline + features */}
-          <div className="mt-auto">
-            <p className="mb-2 text-[11px] font-medium uppercase tracking-[0.18em] text-[hsl(238_72%_78%)]">
-              First-run setup
-            </p>
-            <h1 className="max-w-sm text-4xl font-bold leading-[1.1] text-white xl:text-[2.75rem]">
-              Sign in,
-              <br />
-              create the project,
-              <br />
-              paste the snippet.
-            </h1>
+            <div className="mt-10 overflow-hidden rounded-xl border bg-card shadow-[var(--shadow-card)]">
+              <div className="grid sm:grid-cols-2">
+                <div className="border-b p-5 sm:border-b-0 sm:border-r">
+                  <div className="flex items-center gap-2 text-sm font-semibold"><MessageSquare className="h-4 w-4 text-primary" /> Feedback form</div>
+                  <p className="mt-2 text-xs leading-5 text-muted-foreground">Users send bugs, ideas, questions, ratings, and screenshots to your inbox.</p>
+                </div>
+                <div className="p-5">
+                  <div className="flex items-center gap-2 text-sm font-semibold"><Megaphone className="h-4 w-4 text-amber-500" /> Release notes</div>
+                  <p className="mt-2 text-xs leading-5 text-muted-foreground">You publish clear “What’s new” announcements back inside your product.</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-3 border-t bg-primary/[0.045] px-5 py-4 text-xs text-muted-foreground">
+                <Check className="h-4 w-4 shrink-0 text-primary" /><span><strong className="text-foreground">One embed for both.</strong> Install it once and manage configuration remotely.</span>
+              </div>
+            </div>
 
-            <ul className="mt-8 space-y-3">
-              {features.map((f, i) => (
-                <li
-                  key={f}
-                  className="flex items-start gap-3 animate-fade-in"
-                  style={{ animationDelay: `${i * 80}ms` }}
-                >
-                  <CheckCircle2 className="mt-[2px] h-4 w-4 shrink-0 text-[hsl(238_72%_78%)]" />
-                  <span className="text-[15px] text-white/70">{f}</span>
+            <ol className="mt-8 grid grid-cols-3 border-y">
+              {['Create project', 'Install once', 'Verify a test'].map((step, index) => (
+                <li key={step} className="border-l px-3 py-4 first:border-l-0 first:pl-0">
+                  <span className="font-mono text-[10px] text-primary">0{index + 1}</span>
+                  <p className="mt-1 text-xs font-semibold">{step}</p>
                 </li>
               ))}
-            </ul>
-
-            {/* Code snippet */}
-            <div className="mt-10 overflow-hidden rounded-xl border border-white/10 bg-black/30 backdrop-blur-sm">
-              <div className="flex items-center gap-1.5 border-b border-white/10 px-4 py-2.5">
-                <span className="h-2.5 w-2.5 rounded-full bg-white/15" />
-                <span className="h-2.5 w-2.5 rounded-full bg-white/15" />
-                <span className="h-2.5 w-2.5 rounded-full bg-white/15" />
-                <span className="ml-2 text-[11px] text-white/30">index.html</span>
-              </div>
-              <pre className="scrollbar-thin overflow-x-auto px-5 py-4 text-[13px] leading-relaxed">
-                <code>
-                  {codeSnippet.split('\n').map((line, i) => (
-                    <span key={i} className="block">
-                      {line.trim().startsWith('data-project') ? (
-                        <>
-                          <span className="text-[hsl(220_80%_75%)]">  data-project</span>
-                          <span className="text-white/40">{`="`}</span>
-                          <span className="text-[hsl(150_60%_68%)]">your-project-key</span>
-                          <span className="text-white/40">{`"`}</span>
-                        </>
-                      ) : line.trim().startsWith('data-api-url') ? (
-                        <>
-                          <span className="text-[hsl(220_80%_75%)]">  data-api-url</span>
-                          <span className="text-white/40">{`="`}</span>
-                          <span className="text-[hsl(150_60%_68%)]">{publicEnv.NEXT_PUBLIC_APP_ORIGIN}/api/feedback</span>
-                          <span className="text-white/40">{`"`}</span>
-                        </>
-                      ) : line.includes('script') ? (
-                        <span className="text-white/55">{line}</span>
-                      ) : (
-                        <span className="text-white/40">{line}</span>
-                      )}
-                    </span>
-                  ))}
-                </code>
-              </pre>
-            </div>
+            </ol>
           </div>
-        </div>
-      </div>
+          <p className="text-xs text-muted-foreground">Public browser-safe keys only. Private credentials stay server-side.</p>
+        </section>
 
-      {/* ── Right panel: auth form ────────────────────────────────────────── */}
-      <div className="relative flex min-w-0 flex-1 flex-col items-center justify-center px-4 py-16 sm:px-6">
-
-        {/* Mobile logo */}
-        <div className="mb-10 text-center lg:hidden">
-          <Link
-            href="/"
-            className="font-semibold transition-opacity active:opacity-70"
-          >
-            <BrandWordmark className="text-xl" markClassName="h-7 w-7" />
-          </Link>
-          <h1 className="mt-3 text-2xl font-bold tracking-tight">
-            Sign in and start setup.
-          </h1>
-        </div>
-
-        <div className="w-full max-w-[360px] animate-fade-in">
-          {/* Heading */}
-          <div className="mb-8">
-            <h2 className="text-2xl font-semibold tracking-tight">
-              {sent ? 'Check your inbox' : 'Sign in to start setup'}
-            </h2>
-            <p className="mt-1.5 text-[14px] text-muted-foreground">
-              {sent
-                ? `We sent a magic link to ${email}`
-                : 'You will land on project setup first: create a project, copy the Website snippet, then verify one real submission.'}
-            </p>
+        <section className="flex min-w-0 flex-col px-5 py-6 sm:px-8 lg:justify-center lg:px-12 xl:px-20">
+          <div className="flex items-center justify-between lg:hidden">
+            <Link href="/" className="font-semibold"><BrandWordmark className="text-lg" markClassName="h-6 w-6" /></Link>
+            <Link href="/" className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground"><ArrowLeft className="h-3.5 w-3.5" /> Home</Link>
           </div>
 
-          {sent ? (
-            /* ── Sent state ────────────────────────────────────────────── */
-            <div className="space-y-4">
-              <div className="flex items-start gap-3 rounded-xl border border-primary/20 bg-[hsl(var(--primary)/0.06)] p-4">
-                <Mail className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
-                <div>
-                  <p className="text-[13px] font-medium">Magic link sent</p>
-                  <p className="mt-0.5 text-[12px] text-muted-foreground">
-                    Click the link in your email to sign in. It expires in 24 hours.
-                  </p>
-                </div>
-              </div>
-              <Button
-                variant="ghost"
-                className="w-full text-[13px] text-muted-foreground"
-                onClick={() => { setSent(false); setEmail('') }}
-              >
-                Use a different email
-              </Button>
+          <div className="mx-auto my-auto w-full max-w-[390px] py-12">
+            <div className="mb-8">
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-primary">Your workspace</p>
+              <h2 className="mt-3 text-2xl font-semibold tracking-[-0.025em] sm:text-3xl">{sent ? 'Check your inbox' : 'Sign in or create an account'}</h2>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">{sent ? `We sent a secure sign-in link to ${email}.` : 'New here? GitHub or a magic link creates your account and opens project setup automatically.'}</p>
             </div>
-          ) : (
-            /* ── Sign-in form ──────────────────────────────────────────── */
-            <div className="space-y-3">
-              {/* GitHub */}
-              <Button
-                variant="outline"
-                className={cn(
-                  'group w-full justify-between border-border/80 text-[13px]',
-                  'h-11',
-                  'transition-all duration-200 hover:border-foreground/20 hover:bg-accent'
-                )}
-                onClick={handleGitHub}
-                disabled={githubLoading}
-                >
-                  <span className="flex items-center gap-2.5">
-                    {githubLoading ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <Github className="h-4 w-4" />
-                    )}
-                  Continue with GitHub
-                  </span>
-                  <ArrowRight className="h-3.5 w-3.5 text-muted-foreground transition-transform duration-200 group-hover:translate-x-0.5" />
-                </Button>
 
-              {/* Divider */}
-              <div className="relative my-1 flex items-center gap-3">
-                <Separator className="flex-1" />
-                <span className="shrink-0 text-[11px] text-muted-foreground">or</span>
-                <Separator className="flex-1" />
+            {sent ? (
+              <div className="space-y-4">
+                <div className="flex items-start gap-3 rounded-lg border border-primary/25 bg-primary/[0.055] p-4">
+                  <Mail className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                  <div><p className="text-sm font-semibold">Magic link sent</p><p className="mt-1 text-xs leading-5 text-muted-foreground">Open the email on this device to continue. The link expires in 24 hours.</p></div>
+                </div>
+                <Button variant="outline" className="w-full" onClick={() => { setSent(false); setEmail('') }}>Use a different email</Button>
               </div>
-
-              {/* Email form */}
-              <form onSubmit={handlePasswordSignIn} className="space-y-3">
-                <div className="space-y-1.5">
-                  <Label htmlFor="email" className="text-[13px]">
-                    Email address
-                  </Label>
-                  <Input
-                    id="email"
-                    type="email"
-                    placeholder="you@company.com"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    className="h-11 border-border/80 text-[14px] transition-colors focus:border-primary/60"
-                    required
-                    autoFocus
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="password" className="text-[13px]">
-                    Password
-                  </Label>
-                  <Input
-                    id="password"
-                    type="password"
-                    placeholder="Your password"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    className="h-11 border-border/80 text-[14px] transition-colors focus:border-primary/60"
-                    required
-                  />
-                </div>
-
-                {error && (
-                  <p className="text-[12px] text-destructive">{error}</p>
-                )}
-
-                <Button
-                  className="h-11 w-full text-[13px]"
-                  type="submit"
-                  disabled={loading}
-                >
-                  {loading ? (
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  ) : (
-                    <KeyRound className="mr-2 h-4 w-4" />
-                  )}
-                  Sign in and continue setup
+            ) : (
+              <div className="space-y-4">
+                <Button variant="outline" className="group h-11 w-full justify-between" onClick={handleGitHub} disabled={githubLoading}>
+                  <span className="flex items-center gap-2.5">{githubLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Github className="h-4 w-4" />}Continue with GitHub</span>
+                  <ArrowRight className="h-3.5 w-3.5 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
                 </Button>
-              </form>
 
-              <form onSubmit={handleMagicLink}>
-                <Button
-                  variant="ghost"
-                  className="h-10 w-full text-[13px] text-muted-foreground"
-                  type="submit"
-                  disabled={magicLoading || !email}
-                >
-                  {magicLoading ? (
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  ) : (
-                    <Mail className="mr-2 h-4 w-4" />
-                  )}
-                  Email me a magic link instead
-                </Button>
-              </form>
-            </div>
-          )}
+                <div className="flex items-center gap-3"><Separator className="flex-1" /><span className="text-[11px] text-muted-foreground">or use email</span><Separator className="flex-1" /></div>
 
-          {/* Footer */}
-          <p className="mt-8 text-center text-xs text-muted-foreground">
-            By continuing, you agree to our{' '}
-            <Link href="/terms" prefetch={false} className="underline underline-offset-2 transition-colors hover:text-foreground">
-              Terms
-            </Link>{' '}
-            and{' '}
-            <Link href="/privacy" prefetch={false} className="underline underline-offset-2 transition-colors hover:text-foreground">
-              Privacy Policy
-            </Link>
-          </p>
-        </div>
+                <form onSubmit={handlePasswordSignIn} className="space-y-4">
+                  <div className="space-y-1.5"><Label htmlFor="email">Email address</Label><Input id="email" type="email" autoComplete="email" placeholder="you@company.com" value={email} onChange={(event) => setEmail(event.target.value)} className="h-11" required autoFocus /></div>
+                  <div className="space-y-1.5"><Label htmlFor="password">Password <span className="font-normal text-muted-foreground">for existing accounts</span></Label><Input id="password" type="password" autoComplete="current-password" placeholder="Your password" value={password} onChange={(event) => setPassword(event.target.value)} className="h-11" required /></div>
+                  {error && <p role="alert" className="rounded-md border border-destructive/25 bg-destructive/5 px-3 py-2 text-xs text-destructive">{error}</p>}
+                  <Button className="h-11 w-full" type="submit" disabled={loading}>{loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <KeyRound className="mr-2 h-4 w-4" />}Sign in with password</Button>
+                </form>
+
+                <form onSubmit={handleMagicLink}>
+                  <Button variant="secondary" className={cn('h-11 w-full', !email && 'opacity-60')} type="submit" disabled={magicLoading || !email}>{magicLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Mail className="mr-2 h-4 w-4" />}Email me a secure sign-in link</Button>
+                </form>
+                <p className="text-center text-xs leading-5 text-muted-foreground">No account yet? Enter your email above and choose the secure sign-in link. We will create the account for you.</p>
+              </div>
+            )}
+
+            <p className="mt-8 text-center text-[11px] leading-5 text-muted-foreground">By continuing, you agree to our <Link href="/terms" prefetch={false} className="underline underline-offset-2 hover:text-foreground">Terms</Link> and <Link href="/privacy" prefetch={false} className="underline underline-offset-2 hover:text-foreground">Privacy Policy</Link>.</p>
+          </div>
+        </section>
       </div>
-    </div>
+    </main>
   )
 }
 
 export default function AuthPage() {
-  return (
-    <Suspense>
-      <AuthPageInner />
-    </Suspense>
-  )
+  return <Suspense><AuthPageInner /></Suspense>
 }

--- a/packages/dashboard/src/app/boards/page.tsx
+++ b/packages/dashboard/src/app/boards/page.tsx
@@ -22,7 +22,7 @@ export default async function BoardsPage({
   const authHref = `${publicEnv.NEXT_PUBLIC_APP_ORIGIN}/auth`
 
   return (
-    <div className="min-h-screen bg-[linear-gradient(180deg,_hsl(var(--background))_0%,_hsl(var(--muted))_100%)]">
+    <div className="min-h-screen bg-[linear-gradient(180deg,_oklch(var(--background))_0%,_oklch(var(--muted))_100%)]">
       <header className="border-b bg-background/85 backdrop-blur">
         <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4 sm:px-6">
           <Link href="/" className="font-bold transition-opacity active:opacity-70">

--- a/packages/dashboard/src/app/globals.css
+++ b/packages/dashboard/src/app/globals.css
@@ -4,58 +4,57 @@
 
 @layer base {
   :root {
-    /* Acid green palette — neutrals tinted toward brand hue for cohesion */
-    --background: 90 18% 98%;
-    --foreground: 85 28% 9%;
-    --card: 85 18% 99.5%;
-    --card-foreground: 85 28% 9%;
-    --popover: 85 18% 99.5%;
-    --popover-foreground: 85 28% 9%;
-    --primary: 85 80% 27%;
-    --primary-foreground: 85 30% 98%;
-    --secondary: 85 22% 94%;
-    --secondary-foreground: 85 30% 18%;
-    --muted: 85 16% 93.5%;
-    --muted-foreground: 85 10% 38%;
-    --accent: 85 20% 91.5%;
-    --accent-foreground: 85 30% 18%;
-    --destructive: 0 84% 60%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 85 14% 90%;
-    --input: 85 14% 90%;
-    --ring: 85 80% 35%;
-    --radius: 0.625rem;
+    /* Warm, precise neutrals with one controlled product-green accent. */
+    --background: 0.985 0.006 105;
+    --foreground: 0.205 0.012 105;
+    --card: 0.997 0.003 105;
+    --card-foreground: 0.205 0.012 105;
+    --popover: 0.997 0.003 105;
+    --popover-foreground: 0.205 0.012 105;
+    --primary: 0.49 0.145 127;
+    --primary-foreground: 0.985 0.01 110;
+    --secondary: 0.952 0.011 105;
+    --secondary-foreground: 0.29 0.018 105;
+    --muted: 0.955 0.009 105;
+    --muted-foreground: 0.49 0.016 105;
+    --accent: 0.935 0.021 112;
+    --accent-foreground: 0.27 0.022 110;
+    --destructive: 0.58 0.218 27;
+    --destructive-foreground: 0.985 0.005 27;
+    --border: 0.89 0.012 105;
+    --input: 0.87 0.014 105;
+    --ring: 0.49 0.145 127;
+    --radius: 0.55rem;
 
     /* Brand tokens */
-    --brand: 85 80% 35%;
-    --brand-subtle: 85 50% 95%;
+    --brand: 0.49 0.145 127;
+    --brand-subtle: 0.95 0.035 120;
   }
 
   .dark {
-    /* Clear neutral elevation keeps dark surfaces readable without spending green on decoration. */
-    --background: 80 3% 7.5%;
-    --foreground: 80 6% 95%;
-    --card: 80 5% 15.5%;
-    --card-foreground: 80 6% 95%;
-    --popover: 80 5% 18.5%;
-    --popover-foreground: 80 6% 95%;
-    --primary: 85 72% 50%;
-    --primary-foreground: 85 40% 6%;
-    --secondary: 80 6% 21%;
-    --secondary-foreground: 80 5% 91%;
-    --muted: 80 5% 20%;
-    --muted-foreground: 80 6% 72%;
-    --accent: 80 6% 24.5%;
-    --accent-foreground: 80 5% 95%;
-    --destructive: 0 62% 38%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 80 5% 34%;
-    --input: 80 6% 38%;
-    --ring: 85 72% 50%;
+    --background: 0.155 0.009 105;
+    --foreground: 0.94 0.009 105;
+    --card: 0.19 0.01 105;
+    --card-foreground: 0.94 0.009 105;
+    --popover: 0.22 0.011 105;
+    --popover-foreground: 0.94 0.009 105;
+    --primary: 0.78 0.19 126;
+    --primary-foreground: 0.18 0.032 120;
+    --secondary: 0.235 0.012 105;
+    --secondary-foreground: 0.9 0.009 105;
+    --muted: 0.225 0.011 105;
+    --muted-foreground: 0.69 0.014 105;
+    --accent: 0.265 0.017 110;
+    --accent-foreground: 0.94 0.009 105;
+    --destructive: 0.55 0.19 27;
+    --destructive-foreground: 0.97 0.008 27;
+    --border: 0.31 0.012 105;
+    --input: 0.34 0.014 105;
+    --ring: 0.78 0.19 126;
 
     /* Brand tokens dark */
-    --brand: 85 72% 50%;
-    --brand-subtle: 85 18% 16%;
+    --brand: 0.78 0.19 126;
+    --brand-subtle: 0.23 0.035 120;
   }
 }
 
@@ -67,11 +66,13 @@
   body {
     @apply bg-background text-foreground;
     font-feature-settings: "rlig" 1, "calt" 1;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
   }
 
   ::selection {
-    background-color: hsl(var(--primary) / 0.15);
-    color: hsl(var(--foreground));
+    background-color: oklch(var(--primary) / 0.18);
+    color: oklch(var(--foreground));
   }
 
   *:focus-visible {
@@ -102,12 +103,14 @@
   --ease-out-quart: cubic-bezier(0.25, 1, 0.5, 1);
   --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
   --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+  --shadow-card: 0 1px 2px rgb(15 18 13 / 0.04), 0 8px 28px rgb(15 18 13 / 0.035);
+  --shadow-float: 0 20px 60px rgb(8 12 7 / 0.16);
 }
 
 /* ─── Keyframes ───────────────────────────────────────────────────────────── */
 
 @keyframes fade-in {
-  from { opacity: 0; transform: translateY(4px); }
+  from { opacity: 0; transform: translateY(3px); }
   to   { opacity: 1; transform: translateY(0); }
 }
 
@@ -136,17 +139,6 @@
   to   { background-position: -200% 0; }
 }
 
-@keyframes brand-mark-intro {
-  0% { transform: translateX(42px) scale(1.04); filter: drop-shadow(0 0 0 hsl(var(--primary) / 0)); }
-  55% { transform: translateX(42px) scale(1.04); filter: drop-shadow(0 8px 16px hsl(var(--primary) / 0.22)); }
-  100% { transform: translateX(0) scale(1); filter: drop-shadow(0 0 0 hsl(var(--primary) / 0)); }
-}
-
-@keyframes brand-text-intro {
-  0%, 45% { opacity: 0; transform: translateX(-8px); }
-  100% { opacity: 1; transform: translateX(0); }
-}
-
 @keyframes logo-load-pop {
   0%, 100% { transform: translateY(0) scale(1); }
   45% { transform: translateY(-4px) scale(1.035); }
@@ -158,7 +150,7 @@
   /* Scrollbar */
   .scrollbar-thin {
     scrollbar-width: thin;
-    scrollbar-color: hsl(var(--border)) transparent;
+    scrollbar-color: oklch(var(--border)) transparent;
   }
 
   .scrollbar-thin::-webkit-scrollbar {
@@ -171,13 +163,13 @@
   }
 
   .scrollbar-thin::-webkit-scrollbar-thumb {
-    background-color: hsl(var(--border));
+    background-color: oklch(var(--border));
     border-radius: 9999px;
     transition: background-color 150ms;
   }
 
   .scrollbar-thin::-webkit-scrollbar-thumb:hover {
-    background-color: hsl(var(--muted-foreground) / 0.4);
+    background-color: oklch(var(--muted-foreground) / 0.4);
   }
 
   @media (max-width: 767px) {
@@ -206,7 +198,7 @@
     background: linear-gradient(
       105deg,
       transparent 40%,
-      hsl(var(--primary) / 0.07) 50%,
+      oklch(var(--primary) / 0.07) 50%,
       transparent 60%
     );
     background-size: 200% 100%;
@@ -222,9 +214,9 @@
     animation: skeleton-wave 1.6s linear infinite;
     background: linear-gradient(
       90deg,
-      hsl(var(--muted)) 25%,
-      hsl(var(--muted-foreground) / 0.08) 50%,
-      hsl(var(--muted)) 75%
+      oklch(var(--muted)) 25%,
+      oklch(var(--muted-foreground) / 0.08) 50%,
+      oklch(var(--muted)) 75%
     );
     background-size: 400% 100%;
     border-radius: var(--radius);
@@ -234,21 +226,13 @@
   .bg-grid-pattern {
     background-image: radial-gradient(
       circle,
-      hsl(var(--border)) 1px,
+      oklch(var(--border)) 1px,
       transparent 1px
     );
     background-size: 24px 24px;
   }
 
-  .brand-wordmark-mark-intro {
-    animation: brand-mark-intro 0.72s var(--ease-out-expo) both;
-    transform-origin: center;
-  }
-
-  .brand-wordmark-text-intro {
-    animation: brand-text-intro 0.72s var(--ease-out-expo) both;
-    will-change: opacity, transform;
-  }
+  .surface-card { box-shadow: var(--shadow-card); }
 
   .animate-logo-load-pop {
     animation: logo-load-pop 1.1s var(--ease-out-expo) infinite;

--- a/packages/dashboard/src/app/layout.tsx
+++ b/packages/dashboard/src/app/layout.tsx
@@ -9,10 +9,10 @@ const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
   title: {
-    default: 'feedbacks.dev — Developer-first feedback collection',
+    default: 'feedbacks.dev | Feedback forms and release notes',
     template: '%s | feedbacks.dev',
   },
-  description: 'Collect meaningful in-product feedback in minutes. Lightweight widget, triage dashboard, workflow integrations.',
+  description: 'Collect in-product feedback and publish release notes with one lightweight embed. Install once, verify, and manage remotely.',
   icons: {
     icon: [
       { url: '/new_logo_feedbacks.dev.svg', type: 'image/svg+xml' },

--- a/packages/dashboard/src/app/p/[slug]/public-board.tsx
+++ b/packages/dashboard/src/app/p/[slug]/public-board.tsx
@@ -289,7 +289,7 @@ export function PublicBoard({
   return (
     <div
       data-public-board-ready={ready ? 'true' : 'false'}
-      className="min-h-screen bg-[linear-gradient(180deg,_hsl(var(--background))_0%,_hsl(var(--muted))_100%)]"
+      className="min-h-screen bg-[linear-gradient(180deg,_oklch(var(--background))_0%,_oklch(var(--muted))_100%)]"
     >
       {board.customCss ? <style>{board.customCss}</style> : null}
       {viewerSignedIn && (

--- a/packages/dashboard/src/app/page.tsx
+++ b/packages/dashboard/src/app/page.tsx
@@ -1,33 +1,27 @@
 import Link from 'next/link'
-import Image from 'next/image'
 import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
 import { BrandWordmark } from '@/components/brand-wordmark'
 import { PLAN_MATRIX, generateInstallSnippets } from '@feedbacks/shared'
 import { CodeSnippet } from '@/components/code-snippet'
 import { publicEnv } from '@/lib/public-env'
-import { createServerSupabase } from '@/lib/supabase-server'
 import {
   ArrowRight,
-  Check,
-  Github,
-  Zap,
   Bot,
-  MessageSquare,
-  Shield,
-  Sparkles,
+  Bug,
+  Check,
+  CheckCircle2,
   Code2,
-  LayoutDashboard,
-  Webhook,
-  Terminal,
-  Globe,
-  SlidersHorizontal,
-  PanelTop,
+  Github,
+  Inbox,
+  Lightbulb,
+  Megaphone,
+  MessageSquare,
+  MousePointer2,
+  ShieldCheck,
+  Sparkles,
 } from 'lucide-react'
 import { ScrollHeader, WidgetDemo } from './widget-demo-client'
 import { AuthenticatedRedirect } from './authenticated-redirect'
-
-// ─── Code snippets ────────────────────────────────────────────────────────────
 
 const appOrigin = publicEnv.NEXT_PUBLIC_APP_ORIGIN
 const authHref = `${appOrigin}/auth`
@@ -41,506 +35,253 @@ const installSnippet = generateInstallSnippets({
 const freePlan = PLAN_MATRIX.free
 const proPlan = PLAN_MATRIX.pro
 
-function LandingHeroSystem() {
+const setupSteps = [
+  { number: '01', title: 'Create a project', body: 'Choose Feedback form, Release notes, or both.' },
+  { number: '02', title: 'Install one embed', body: 'Paste one stable snippet into your app shell.' },
+  { number: '03', title: 'Verify and manage', body: 'Send a test, then change both products remotely.' },
+]
+
+function ProductSystemPreview() {
   return (
-    <div className="overflow-hidden rounded-[15px] border border-border/70 bg-card shadow-2xl shadow-primary/10">
-      <Image
-        src="/hero_banner_image.png"
-        alt="feedbacks.dev feedback routing overview"
-        width={1080}
-        height={1080}
-        priority
-        className="h-auto w-full rounded-[15px] object-cover"
-      />
+    <div className="relative mx-auto max-w-[620px]" aria-label="feedbacks.dev product preview">
+      <div className="absolute -inset-8 -z-10 bg-[radial-gradient(circle,oklch(var(--primary)/0.15),transparent_64%)] blur-2xl" />
+      <div className="overflow-hidden rounded-xl border border-border/80 bg-card shadow-[var(--shadow-float)]">
+        <div className="flex h-11 items-center gap-2 border-b bg-muted/35 px-4">
+          <span className="h-2.5 w-2.5 rounded-full bg-foreground/15" />
+          <span className="h-2.5 w-2.5 rounded-full bg-foreground/15" />
+          <span className="h-2.5 w-2.5 rounded-full bg-foreground/15" />
+          <span className="ml-2 text-[11px] font-medium text-muted-foreground">Acme product workspace</span>
+        </div>
+        <div className="grid min-h-[330px] grid-cols-[122px_1fr] sm:grid-cols-[166px_1fr]">
+          <div className="border-r bg-muted/20 p-3">
+            <p className="px-2 text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">Products</p>
+            <div className="mt-2 space-y-1">
+              <div className="flex items-center gap-2 rounded-md bg-primary/10 px-2 py-2 text-[11px] font-semibold text-primary sm:text-xs">
+                <MessageSquare className="h-3.5 w-3.5" /> Feedback form
+              </div>
+              <div className="flex items-center gap-2 rounded-md px-2 py-2 text-[11px] text-muted-foreground sm:text-xs">
+                <Megaphone className="h-3.5 w-3.5" /> Release notes
+              </div>
+            </div>
+            <p className="mt-5 px-2 text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">Delivery</p>
+            <div className="mt-2 flex items-center gap-2 rounded-md px-2 py-2 text-[11px] text-muted-foreground sm:text-xs">
+              <Code2 className="h-3.5 w-3.5" /> One embed
+            </div>
+          </div>
+          <div className="min-w-0 p-4 sm:p-6">
+            <div className="flex items-start justify-between gap-4 border-b pb-4">
+              <div>
+                <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-primary">Feedback form</p>
+                <p className="mt-1 text-base font-semibold">Collect useful context</p>
+              </div>
+              <span className="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-1 text-[10px] font-medium text-muted-foreground">
+                <span className="h-1.5 w-1.5 rounded-full bg-primary" /> Live
+              </span>
+            </div>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              <div className="rounded-lg border bg-background p-3">
+                <Bug className="h-4 w-4 text-rose-500" />
+                <p className="mt-5 text-xs font-semibold">Export stalls on large files</p>
+                <p className="mt-1 text-[10px] leading-4 text-muted-foreground">/reports/export · Chrome · screenshot</p>
+              </div>
+              <div className="rounded-lg border bg-background p-3">
+                <Lightbulb className="h-4 w-4 text-amber-500" />
+                <p className="mt-5 text-xs font-semibold">Add saved dashboard views</p>
+                <p className="mt-1 text-[10px] leading-4 text-muted-foreground">/dashboard · rating 5/5</p>
+              </div>
+            </div>
+            <div className="mt-3 flex items-center gap-3 rounded-lg border border-primary/20 bg-primary/[0.055] p-3">
+              <CheckCircle2 className="h-4 w-4 shrink-0 text-primary" />
+              <p className="text-[11px] leading-4 text-muted-foreground"><span className="font-semibold text-foreground">Connected.</span> Saved form and release-note changes are now delivered remotely.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="absolute -bottom-7 -right-2 hidden items-center gap-2 rounded-lg border bg-card px-3 py-2 text-xs font-medium shadow-lg sm:flex">
+        <Inbox className="h-4 w-4 text-primary" /> New feedback received
+      </div>
     </div>
   )
 }
 
-// ─── Page (Server Component) ──────────────────────────────────────────────────
-
-export default async function LandingPage() {
-  const supabase = await createServerSupabase()
-  const { data: { user } } = await supabase.auth.getUser()
-  const isLoggedIn = !!user
+export default function LandingPage() {
   return (
     <div className="min-h-screen bg-background text-foreground">
       <AuthenticatedRedirect appOrigin={appOrigin} />
-      {/* ── Nav ─────────────────────────────────────────────────────────────── */}
       <ScrollHeader>
-        <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-6">
-          <Link href="/" className="font-bold transition-opacity active:opacity-70">
+        <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-5 sm:px-6">
+          <Link href="/" className="font-semibold transition-opacity hover:opacity-80">
             <BrandWordmark className="text-lg" priority />
           </Link>
-          <div className="flex items-center gap-2">
-            <Link href="/docs" prefetch={false} className="hidden sm:block">
-              <Button variant="ghost" size="sm">Docs</Button>
+          <nav className="hidden items-center gap-1 md:flex" aria-label="Main navigation">
+            <Link href="#products"><Button variant="ghost" size="sm">Products</Button></Link>
+            <Link href="#setup"><Button variant="ghost" size="sm">How it works</Button></Link>
+            <Link href="#pricing"><Button variant="ghost" size="sm">Pricing</Button></Link>
+            <Link href="/docs" prefetch={false}><Button variant="ghost" size="sm">Docs</Button></Link>
+          </nav>
+          <div className="flex items-center gap-1 sm:gap-2">
+            <Link href={authHref} className="hidden sm:block"><Button variant="ghost" size="sm">Sign in</Button></Link>
+            <Link href={authHref}>
+              <Button size="sm" className="gap-1.5">Start free <ArrowRight className="h-3.5 w-3.5" /></Button>
             </Link>
-            <Link href="/boards" prefetch={false} className="hidden sm:block">
-              <Button variant="ghost" size="sm">
-                Boards
-              </Button>
-            </Link>
-            <Link href="#features">
-              <Button variant="ghost" size="sm" className="hidden sm:inline-flex">
-                Features
-              </Button>
-            </Link>
-            <Link href="#pricing">
-              <Button variant="ghost" size="sm" className="hidden sm:inline-flex">
-                Pricing
-              </Button>
-            </Link>
-            <a
-              href="https://github.com/WarriorSushi/feedbacks.dev-2026"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hidden items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground sm:flex"
-            >
-              <Github className="h-4 w-4" />
-              GitHub
-            </a>
-            <div className="mx-2 hidden h-4 w-px bg-border sm:block" />
-            {isLoggedIn ? (
-              <Link href={dashboardHref}>
-                <Button size="sm" className="font-semibold">
-                  Go to Dashboard
-                  <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
-                </Button>
-              </Link>
-            ) : (
-              <>
-                <Link href={authHref} className="hidden sm:block">
-                  <Button variant="ghost" size="sm">
-                    Sign in
-                  </Button>
-                </Link>
-                <Link href={authHref}>
-                  <Button size="sm" className="font-semibold">
-                    Start free
-                    <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
-                  </Button>
-                </Link>
-              </>
-            )}
           </div>
         </div>
       </ScrollHeader>
 
-      {/* ── Hero ─────────────────────────────────────────────────────────────── */}
-      <section className="relative overflow-hidden border-b">
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_10%,hsl(var(--primary)/0.14),transparent_32%),linear-gradient(180deg,hsl(var(--primary)/0.055),transparent_42%)]" />
-        <div
-          className="absolute inset-0 opacity-[0.045] dark:opacity-[0.07]"
-          style={{
-            backgroundImage:
-              'linear-gradient(currentColor 1px, transparent 1px), linear-gradient(90deg, currentColor 1px, transparent 1px)',
-            backgroundSize: '42px 42px',
-          }}
-        />
-
-        <div className="relative mx-auto max-w-6xl px-6 pb-10 pt-8 md:pb-14 md:pt-10">
-          <div className="grid gap-10 lg:grid-cols-[minmax(0,0.9fr)_minmax(460px,1.1fr)] lg:items-center">
-            <div className="min-w-0">
-              <div className="mb-5 flex flex-nowrap items-center gap-1.5 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-                <Badge variant="secondary" className="shrink-0 gap-1 border-primary/20 bg-primary/[0.09] px-2.5 py-0.5 text-[11px] font-semibold text-primary">
-                  <Sparkles className="h-2.5 w-2.5" />
-                  Install-first feedback stack
-                </Badge>
-                <Badge variant="outline" className="shrink-0 gap-1 bg-card/70 px-2.5 py-0.5 text-[11px] font-medium text-muted-foreground">
-                  <Bot className="h-2.5 w-2.5" />
-                  Agent-ready setup path
-                </Badge>
+      <main>
+        <section className="relative overflow-hidden border-b">
+          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_22%_12%,oklch(var(--primary)/0.1),transparent_34%)]" />
+          <div className="relative mx-auto grid max-w-7xl gap-14 px-5 pb-20 pt-16 sm:px-6 sm:pt-24 lg:grid-cols-[0.86fr_1.14fr] lg:items-center lg:pb-28">
+            <div>
+              <div className="inline-flex items-center gap-2 border-l-2 border-primary pl-3 text-xs font-semibold text-muted-foreground">
+                <Sparkles className="h-3.5 w-3.5 text-primary" /> Built for product teams that ship
               </div>
-
-              <h1 className="max-w-3xl text-3xl font-black leading-[1.04] tracking-tighter sm:text-4xl lg:text-[2.8rem]">
-                <span className="text-[#88C916]">Collecting user feedbacks & more</span>
-                <span>, just became ridiculously simple</span>
+              <h1 className="mt-6 max-w-2xl text-4xl font-semibold leading-[1.02] tracking-[-0.045em] sm:text-5xl lg:text-[3.75rem]">
+                Hear users clearly.<br />Show them what shipped.
               </h1>
-
-              <p className="mt-6 max-w-xl text-base leading-7 text-muted-foreground md:text-lg">
-                Copy, paste, and start collecting from your userbase. Route every useful signal
-                anywhere you work.
+              <p className="mt-6 max-w-xl text-base leading-7 text-muted-foreground sm:text-lg">
+                Add an in-product feedback form and a clear “What’s new” feed with one lightweight embed. Install once, verify it works, then manage everything remotely.
               </p>
-
-              <div className="mt-7 grid grid-cols-2 gap-2 sm:flex sm:flex-wrap sm:gap-3">
-                <Link href={isLoggedIn ? dashboardHref : authHref} className="min-w-0">
-                  <Button size="lg" className="group h-11 w-full gap-1.5 px-3 text-[13px] font-semibold shadow-lg shadow-primary/20 transition-all hover:shadow-xl hover:shadow-primary/25 sm:h-12 sm:w-auto sm:px-7 sm:text-sm">
-                    <span className="truncate">{isLoggedIn ? 'Go to Dashboard' : 'Start collecting'}</span>
-                    <ArrowRight className="h-3.5 w-3.5 shrink-0 transition-transform group-hover:translate-x-0.5 sm:h-4 sm:w-4" />
-                  </Button>
+              <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+                <Link href={authHref}>
+                  <Button size="lg" className="h-12 w-full gap-2 px-6 sm:w-auto">Create a free project <ArrowRight className="h-4 w-4" /></Button>
                 </Link>
-                <Link href="#install" className="min-w-0">
-                  <Button variant="outline" size="lg" className="h-11 w-full gap-1.5 bg-card/70 px-3 text-[13px] font-semibold sm:h-12 sm:w-auto sm:px-7 sm:text-sm">
-                    See the snippet
-                  </Button>
-                </Link>
+                <Link href="#setup"><Button variant="outline" size="lg" className="h-12 w-full bg-background/70 px-6 sm:w-auto">See the 3-step setup</Button></Link>
               </div>
-
-              <div className="mt-5 flex flex-nowrap gap-1.5 overflow-x-auto pb-1 text-xs text-muted-foreground [scrollbar-width:none] sm:text-[13px] [&::-webkit-scrollbar]:hidden">
-                {['No credit card', 'Website snippet first', 'Agent handoff ready'].map((item) => (
-                  <span key={item} className="shrink-0 rounded-full border bg-card/70 px-2.5 py-0.5">
-                    {item}
-                  </span>
+              <div className="mt-7 flex flex-wrap gap-x-5 gap-y-2 text-xs text-muted-foreground">
+                {['No credit card', 'Browser-safe project key', 'No snippet replacement'].map((item) => (
+                  <span key={item} className="inline-flex items-center gap-1.5"><Check className="h-3.5 w-3.5 text-primary" />{item}</span>
                 ))}
               </div>
             </div>
+            <ProductSystemPreview />
+          </div>
+        </section>
 
-            <div className="relative">
-              <div className="absolute -inset-6 rounded-[2rem] bg-primary/14 blur-3xl" />
-              <LandingHeroSystem />
+        <section id="products" className="border-b py-20 sm:py-28">
+          <div className="mx-auto max-w-7xl px-5 sm:px-6">
+            <div className="grid gap-12 lg:grid-cols-[0.7fr_1.3fr]">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.16em] text-primary">Two products, clearly separated</p>
+                <h2 className="mt-4 text-3xl font-semibold tracking-[-0.035em] sm:text-4xl">Feedback is the input.<br />Release notes are the response.</h2>
+                <p className="mt-5 max-w-md leading-7 text-muted-foreground">No vague “updates” label. Your team collects signals in the Feedback form, then tells users what changed through in-product Release notes.</p>
+              </div>
+              <div className="border-y">
+                <div className="grid gap-5 border-b py-7 sm:grid-cols-[48px_1fr_auto] sm:items-center">
+                  <span className="flex h-11 w-11 items-center justify-center rounded-lg bg-primary/10 text-primary"><MessageSquare className="h-5 w-5" /></span>
+                  <div><h3 className="text-lg font-semibold">Feedback form</h3><p className="mt-1 text-sm leading-6 text-muted-foreground">Collect bugs, ideas, questions, ratings, screenshots, URL, and browser context inside your product.</p></div>
+                  <span className="text-xs font-medium text-muted-foreground">Users → your team</span>
+                </div>
+                <div className="grid gap-5 py-7 sm:grid-cols-[48px_1fr_auto] sm:items-center">
+                  <span className="flex h-11 w-11 items-center justify-center rounded-lg bg-amber-500/10 text-amber-600 dark:text-amber-400"><Megaphone className="h-5 w-5" /></span>
+                  <div><h3 className="text-lg font-semibold">Release notes</h3><p className="mt-1 text-sm leading-6 text-muted-foreground">Publish “What’s new” announcements inside your product. This is not a log of feedbacks.dev website changes.</p></div>
+                  <span className="text-xs font-medium text-muted-foreground">Your team → users</span>
+                </div>
+              </div>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
 
-      {/* ── Install strip ────────────────────────────────────────────────────── */}
-      <section id="install" className="border-b bg-zinc-950 px-6 py-16 dark:bg-zinc-900/80">
-        <div className="mx-auto max-w-5xl">
-          <div className="mb-8 flex items-center gap-3">
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-primary/15">
-              <Terminal className="h-4 w-4 text-primary" />
+        <section id="setup" className="border-b bg-muted/20 py-20 sm:py-28">
+          <div className="mx-auto max-w-7xl px-5 sm:px-6">
+            <div className="grid gap-14 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.16em] text-primary">One-time setup</p>
+                <h2 className="mt-4 max-w-xl text-3xl font-semibold tracking-[-0.035em] sm:text-4xl">One embed. No configuration-code treadmill.</h2>
+                <p className="mt-5 max-w-xl leading-7 text-muted-foreground">Paste the generated Website snippet once. Colors, copy, fields, placement, feedback availability, and release notes are fetched from your saved project settings.</p>
+                <div className="mt-8 border-y">
+                  {setupSteps.map((step) => (
+                    <div key={step.number} className="grid grid-cols-[38px_1fr] gap-3 border-b py-4 last:border-b-0">
+                      <span className="font-mono text-xs text-primary">{step.number}</span>
+                      <div><p className="text-sm font-semibold">{step.title}</p><p className="mt-1 text-sm text-muted-foreground">{step.body}</p></div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              <div className="min-w-0 rounded-xl border border-zinc-800 bg-zinc-950 p-3 shadow-[var(--shadow-float)]">
+                <div className="flex items-center justify-between px-2 pb-3 pt-1">
+                  <div className="flex items-center gap-2 text-xs font-medium text-zinc-400"><Code2 className="h-3.5 w-3.5" /> Website snippet</div>
+                  <span className="text-[10px] font-medium text-zinc-400">Install once</span>
+                </div>
+                <CodeSnippet className="border-zinc-800 bg-zinc-900 text-zinc-100" tabs={[{ label: 'HTML', code: installSnippet, language: 'html' }]} wrap maxHeightClassName="max-h-56" />
+                <div className="grid gap-2 p-2 pt-4 sm:grid-cols-3">
+                  {['Copy', 'Verify', 'Manage remotely'].map((label, index) => (
+                    <div key={label} className="flex items-center gap-2 text-xs text-zinc-400"><span className="flex h-5 w-5 items-center justify-center rounded bg-primary/15 font-mono text-[10px] text-primary">{index + 1}</span>{label}</div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="border-b py-20 sm:py-28">
+          <div className="mx-auto grid max-w-7xl gap-14 px-5 sm:px-6 lg:grid-cols-[1.05fr_0.95fr] lg:items-center">
+            <div className="relative flex min-h-[440px] items-center justify-center overflow-hidden rounded-xl border bg-muted/25 p-8">
+              <div className="absolute inset-0 bg-grid-pattern opacity-35" />
+              <div className="relative"><WidgetDemo /></div>
             </div>
             <div>
-              <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">
-                Quick start
-              </p>
-              <h2 className="text-lg font-bold tracking-tight text-zinc-50">
-                Copy the Website snippet into your app.
-              </h2>
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-primary">Useful signal, less interrogation</p>
+              <h2 className="mt-4 text-3xl font-semibold tracking-[-0.035em] sm:text-4xl">The form feels native. The context arrives automatically.</h2>
+              <p className="mt-5 leading-7 text-muted-foreground">Choose the fields you need and keep the form short. Every submission can arrive with the page URL, browser context, rating, and screenshot, ready to triage.</p>
+              <div className="mt-8 space-y-4">
+                {[
+                  [MousePointer2, 'Remote presentation', 'Change the trigger, placement, labels, fields, and color without replacing the embed.'],
+                  [Inbox, 'Focused triage', 'Search, filter, tag, and route feedback from one project-aware inbox.'],
+                  [Bot, 'Agent-ready handoff', 'Give your coding agent a scoped setup packet instead of copying secrets into chat.'],
+                  [ShieldCheck, 'Trust by default', 'Browser-safe keys in public code. Private and service-role credentials stay server-side.'],
+                ].map(([Icon, title, body]) => {
+                  const ItemIcon = Icon as typeof Inbox
+                  return <div key={String(title)} className="flex gap-4"><ItemIcon className="mt-0.5 h-4 w-4 shrink-0 text-primary" /><div><h3 className="text-sm font-semibold">{String(title)}</h3><p className="mt-1 text-sm leading-6 text-muted-foreground">{String(body)}</p></div></div>
+                })}
+              </div>
             </div>
           </div>
-          <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
-            <div className="min-w-0 space-y-3">
-              <CodeSnippet
-                className="border-zinc-800 bg-zinc-900/90 text-zinc-50"
-                tabs={[{ label: 'HTML', code: installSnippet, language: 'html' }]}
-                wrap
-                maxHeightClassName="max-h-56"
-              />
-              <p className="text-sm text-zinc-500">
-                Website is the recommended default. React and Vue examples stay available after the
-                first install works.
-              </p>
-            </div>
-            <div className="rounded-2xl border border-zinc-800 bg-zinc-900/70 p-5">
-              <p className="text-sm font-semibold text-zinc-50">First-run loop</p>
-              <div className="mt-4 space-y-3 text-sm text-zinc-400">
-                {[
-                  'Create a project',
-                  'Paste this snippet where global scripts load',
-                  'Send one test report and confirm it lands in the inbox',
-                ].map((step, index) => (
-                  <div key={step} className="flex gap-3">
-                    <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/15 text-xs font-bold text-primary">
-                      {index + 1}
-                    </span>
-                    <span>{step}</span>
+        </section>
+
+        <section id="pricing" className="border-b bg-muted/20 py-20 sm:py-28">
+          <div className="mx-auto max-w-5xl px-5 sm:px-6">
+            <div className="grid gap-10 lg:grid-cols-[0.75fr_1.25fr]">
+              <div><p className="text-xs font-semibold uppercase tracking-[0.16em] text-primary">Straightforward pricing</p><h2 className="mt-4 text-3xl font-semibold tracking-[-0.035em] sm:text-4xl">Start free. Upgrade for scale, not basics.</h2><p className="mt-5 leading-7 text-muted-foreground">Both products, the install flow, and the dashboard are available from day one.</p></div>
+              <div className="overflow-hidden rounded-xl border bg-card shadow-[var(--shadow-card)]">
+                <div className="grid md:grid-cols-2">
+                  <div className="p-6 sm:p-8">
+                    <p className="text-sm font-semibold">Free</p><p className="mt-3 text-4xl font-semibold tracking-tight">${freePlan.monthlyPrice}<span className="text-sm font-normal text-muted-foreground"> / month</span></p>
+                    <p className="mt-2 text-sm text-muted-foreground">For one or two products getting started.</p>
+                    <ul className="mt-6 space-y-3 text-sm">{[`${freePlan.projectLimit} projects`, `${freePlan.feedbackMonthlyLimit} feedback / month`, 'Feedback form + release notes', 'One shared embed'].map(item => <li key={item} className="flex gap-2"><Check className="mt-0.5 h-4 w-4 text-primary" />{item}</li>)}</ul>
+                    <Link href={authHref} className="mt-7 block"><Button variant="outline" className="w-full">Start free</Button></Link>
                   </div>
-                ))}
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* ── Widget Preview ───────────────────────────────────────────────────── */}
-      <section id="features" className="border-b py-16 md:py-20">
-        <div className="mx-auto grid max-w-6xl gap-10 px-6 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
-          <div>
-            <p className="mb-2 text-[10px] font-bold uppercase tracking-[0.2em] text-primary">
-              The widget
-            </p>
-            <h2 className="text-3xl font-black tracking-tighter md:text-5xl">
-              A feedback form that fits your product.
-            </h2>
-            <p className="mt-4 max-w-xl text-muted-foreground">
-              Start with a floating button. Switch to modal, inline, or custom trigger when your
-              app needs it.
-            </p>
-            <div className="mt-6 grid gap-3 sm:grid-cols-2">
-              {[
-                { Icon: SlidersHorizontal, title: 'Custom fields', body: 'Ask for rating, email, type, or screenshot.' },
-                { Icon: PanelTop, title: 'Multiple placements', body: 'Floating button, inline form, or your own trigger.' },
-                { Icon: Shield, title: 'Privacy first', body: 'No analytics pixels. User email stays optional.' },
-                { Icon: Zap, title: 'Lightweight', body: 'Small script, fast load, no iframe maze.' },
-              ].map(({ Icon, title, body }) => (
-                <div key={title} className="rounded-xl border bg-card/55 p-4">
-                  <Icon className="mb-3 h-4 w-4 text-primary" />
-                  <p className="text-sm font-semibold">{title}</p>
-                  <p className="mt-1 text-sm text-muted-foreground">{body}</p>
+                  <div className="border-t border-primary/20 bg-primary/[0.045] p-6 sm:p-8 md:border-l md:border-t-0">
+                    <div className="flex items-center justify-between"><p className="text-sm font-semibold">Pro</p><span className="text-[10px] font-semibold uppercase tracking-[0.14em] text-primary">Full product</span></div>
+                    <p className="mt-3 text-4xl font-semibold tracking-tight">${proPlan.monthlyPrice}<span className="text-sm font-normal text-muted-foreground"> / month</span></p>
+                    <p className="mt-2 text-sm text-muted-foreground">For teams routing product signal every week.</p>
+                    <ul className="mt-6 space-y-3 text-sm">{[`${proPlan.projectLimit} projects`, 'Unlimited feedback history', 'Integrations, boards, API & MCP', 'Priority support'].map(item => <li key={item} className="flex gap-2"><Check className="mt-0.5 h-4 w-4 text-primary" />{item}</li>)}</ul>
+                    <Link href={authHref} className="mt-7 block"><Button className="w-full">Start with Pro</Button></Link>
+                  </div>
                 </div>
-              ))}
-            </div>
-          </div>
-          <div className="relative min-h-[430px] overflow-hidden rounded-3xl border bg-[radial-gradient(circle_at_25%_20%,hsl(var(--primary)/0.18),transparent_34%),hsl(var(--card))] p-8">
-            <Image
-              src="/new_logo_feedbacks.dev.svg"
-              alt=""
-              width={500}
-              height={500}
-              aria-hidden="true"
-              className="pointer-events-none absolute -right-24 -top-20 h-72 w-72 select-none opacity-[0.055] dark:opacity-[0.085] sm:h-96 sm:w-96"
-            />
-            <div
-              className="absolute inset-0 opacity-[0.05]"
-              style={{
-                backgroundImage:
-                  'linear-gradient(currentColor 1px, transparent 1px), linear-gradient(90deg, currentColor 1px, transparent 1px)',
-                backgroundSize: '36px 36px',
-              }}
-            />
-            <div className="relative mx-auto flex min-h-[360px] max-w-sm items-center justify-center">
-              <WidgetDemo />
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* ── Workflow ─────────────────────────────────────────────────────────── */}
-      <section className="border-b bg-muted/15 py-16 md:py-20">
-        <div className="mx-auto max-w-6xl px-6">
-          <div className="mb-10 max-w-2xl">
-            <p className="mb-2 text-[10px] font-bold uppercase tracking-[0.2em] text-primary">
-              The workflow
-            </p>
-            <h2 className="text-3xl font-black tracking-tighter md:text-5xl">
-              Capture once. Decide faster.
-            </h2>
-            <p className="mt-4 text-muted-foreground">
-              feedbacks.dev stays small at install, then gives you the surfaces you need when
-              feedback starts turning into work.
-            </p>
-          </div>
-          <div className="grid gap-px overflow-hidden rounded-2xl border bg-border md:grid-cols-3">
-            {[
-              {
-                Icon: LayoutDashboard,
-                title: 'Triage in one inbox',
-                body: 'Every item includes message, URL, browser, rating, and status.',
-              },
-              {
-                Icon: MessageSquare,
-                title: 'Publish what matters',
-                body: 'Turn repeated requests into public boards when the signal is worth sharing.',
-              },
-              {
-                Icon: Webhook,
-                title: 'Route into your stack',
-                body: 'Send high-priority feedback to webhooks, GitHub, or agent workflows.',
-              },
-            ].map(({ Icon, title, body }) => (
-              <div key={title} className="bg-card p-6 md:p-8">
-                <div className="mb-5 flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
-                  <Icon className="h-5 w-5" />
-                </div>
-                <h3 className="text-xl font-bold tracking-tight">{title}</h3>
-                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{body}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* ── Trust Strip ──────────────────────────────────────────────────────── */}
-      <section className="border-b py-10">
-        <div className="mx-auto grid max-w-6xl gap-3 px-6 sm:grid-cols-2 lg:grid-cols-4">
-          {[
-            { Icon: Code2, label: 'Plain HTML first' },
-            { Icon: Bot, label: 'Agent prompt included' },
-            { Icon: Globe, label: 'Source available' },
-            { Icon: Shield, label: 'No user tracking' },
-          ].map(({ Icon, label }) => (
-            <div key={label} className="flex items-center gap-3 rounded-xl border bg-card/55 px-4 py-3 text-sm font-semibold">
-              <Icon className="h-4 w-4 text-primary" />
-              {label}
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* ── Pricing ──────────────────────────────────────────────────────────── */}
-      <section id="pricing" className="border-b py-20 md:py-28">
-        <div className="mx-auto max-w-6xl px-6">
-          <div className="mb-14 text-center">
-            <p className="mb-2 text-[10px] font-bold uppercase tracking-[0.2em] text-muted-foreground">
-              Pricing
-            </p>
-            <h2 className="mb-3 text-4xl font-black tracking-tighter md:text-5xl">
-              Simple. Honest. No traps.
-            </h2>
-            <p className="mx-auto max-w-md text-muted-foreground">
-              Start free, upgrade when you need more. Two tiers, webhook-backed billing truth, and no usage-based surprises.
-            </p>
-          </div>
-
-          <div className="mx-auto grid max-w-3xl gap-6 md:grid-cols-2">
-            <div className="rounded-2xl border bg-card p-8 transition-all hover:shadow-lg">
-              <p className="mb-1 text-sm font-medium text-muted-foreground">Free</p>
-              <p className="mb-1 text-5xl font-black tracking-tighter">
-                ${freePlan.monthlyPrice}
-              </p>
-              <p className="mb-6 text-sm text-muted-foreground">Free forever. No credit card.</p>
-              <ul className="mb-8 space-y-3">
-                {[
-                  `${freePlan.projectLimit} projects`,
-                  `${freePlan.feedbackMonthlyLimit} feedback / month`,
-                  'Dashboard + widget install',
-                  'Optional public board',
-                  `${freePlan.historyDays}-day history`,
-                  'Community support',
-                ].map((item) => (
-                  <li key={item} className="flex items-center gap-2.5 text-sm text-muted-foreground">
-                    <Check className="h-4 w-4 flex-shrink-0 text-primary" />
-                    {item}
-                  </li>
-                ))}
-              </ul>
-              <Link href={isLoggedIn ? dashboardHref : authHref}>
-                <Button variant="outline" className="w-full font-semibold">
-                  {isLoggedIn ? 'Go to Dashboard' : 'Get started'}
-                </Button>
-              </Link>
-            </div>
-
-            <div className="relative rounded-2xl border-2 border-primary bg-card p-8 shadow-xl shadow-primary/10 transition-all hover:shadow-2xl hover:shadow-primary/15">
-              <Badge className="absolute -top-3 left-6 bg-primary px-3.5 py-1 text-xs font-bold shadow-lg shadow-primary/30">
-                Pro
-              </Badge>
-              <p className="mb-1 text-sm font-medium text-muted-foreground">Pro</p>
-              <p className="mb-1 text-5xl font-black tracking-tighter">
-                ${proPlan.monthlyPrice}
-                <span className="text-lg font-normal text-muted-foreground">/mo</span>
-              </p>
-              <p className="mb-6 text-sm text-muted-foreground">Everything, unlimited.</p>
-              <ul className="mb-8 space-y-3">
-                {[
-                  'Unlimited projects',
-                  'Unlimited feedback',
-                  'Webhook integrations',
-                  'MCP server + AI agent API',
-                  'Custom widget branding',
-                  'Unlimited history',
-                  'Priority support',
-                ].map((item) => (
-                  <li key={item} className="flex items-center gap-2.5 text-sm text-muted-foreground">
-                    <Check className="h-4 w-4 flex-shrink-0 text-primary" />
-                    {item}
-                  </li>
-                ))}
-              </ul>
-              <Link href={isLoggedIn ? dashboardHref : authHref}>
-                <Button className="w-full font-semibold shadow-lg shadow-primary/20">
-                  {isLoggedIn ? 'Go to Dashboard' : 'Start free trial'}
-                  <ArrowRight className="ml-2 h-4 w-4" />
-                </Button>
-              </Link>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* ── Final CTA ────────────────────────────────────────────────────────── */}
-      <section className="px-6 py-20 md:py-28">
-        <div className="mx-auto max-w-6xl">
-          <div className="relative overflow-hidden rounded-3xl border bg-card px-8 py-20 text-center shadow-2xl shadow-black/[0.05] md:px-16">
-            <div className="relative z-10 mb-8 flex justify-center">
-              <Image
-                src="/new_logo_feedbacks.dev.svg"
-                alt=""
-                width={100}
-                height={100}
-                aria-hidden="true"
-                className="h-20 w-20 sm:h-[100px] sm:w-[100px]"
-              />
-            </div>
-            {/* Dot grid texture */}
-            <div
-              className="pointer-events-none absolute inset-0 opacity-[0.05]"
-              style={{
-                backgroundImage: 'radial-gradient(circle, currentColor 1px, transparent 1px)',
-                backgroundSize: '24px 24px',
-              }}
-            />
-            <div className="relative">
-              <h2 className="mb-4 text-4xl font-black tracking-tighter text-foreground md:text-5xl">
-                Install the widget.
-                <br />
-                Verify the first submission.
-              </h2>
-              <p className="mx-auto mb-8 max-w-md text-muted-foreground">
-                Start free, keep the setup path small, and add the public and automation layers
-                only after the core loop is working.
-              </p>
-              <div className="flex flex-wrap items-center justify-center gap-3">
-                <Link href={isLoggedIn ? dashboardHref : authHref}>
-                  <Button
-                    size="lg"
-                    className="h-12 px-8 font-semibold shadow-lg shadow-primary/20"
-                  >
-                    {isLoggedIn ? 'Go to Dashboard' : 'Start Free'}
-                    <ArrowRight className="ml-2 h-4 w-4" />
-                  </Button>
-                </Link>
-                <a
-                  href="https://github.com/WarriorSushi/feedbacks.dev-2026"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <Button
-                    variant="outline"
-                    size="lg"
-                    className="h-12 gap-2 bg-background/70 font-semibold text-foreground hover:bg-muted"
-                  >
-                    <Github className="h-4 w-4" />
-                    Star on GitHub
-                  </Button>
-                </a>
               </div>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
 
-      {/* ── Footer ───────────────────────────────────────────────────────────── */}
-      <footer className="border-t px-6 py-8">
-        <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 md:flex-row">
-          <span className="font-bold">
-            <BrandWordmark className="text-sm" markClassName="h-5 w-5" />
-          </span>
-          <div className="flex items-center gap-6 text-xs text-muted-foreground">
-            <Link href="/docs" prefetch={false} className="transition-colors hover:text-foreground">
-              Docs
-            </Link>
-            <Link href="/boards" prefetch={false} className="transition-colors hover:text-foreground">
-              Boards
-            </Link>
-            <Link href="#pricing" className="transition-colors hover:text-foreground">
-              Pricing
-            </Link>
-            <a
-              href="https://github.com/WarriorSushi/feedbacks.dev-2026"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="transition-colors hover:text-foreground"
-            >
-              GitHub
-            </a>
+        <section className="px-5 py-20 sm:px-6 sm:py-28">
+          <div className="mx-auto max-w-4xl text-center">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-primary">Ready when you are</p>
+            <h2 className="mt-4 text-3xl font-semibold tracking-[-0.035em] sm:text-5xl">Install once. Start listening today.</h2>
+            <p className="mx-auto mt-5 max-w-xl leading-7 text-muted-foreground">Create a project, paste one safe snippet, and verify the first submission. The product guides the rest.</p>
+            <div className="mt-8 flex flex-col justify-center gap-3 sm:flex-row"><Link href={authHref}><Button size="lg" className="h-12 w-full gap-2 px-7 sm:w-auto">Create a free project <ArrowRight className="h-4 w-4" /></Button></Link><Link href="/docs" prefetch={false}><Button size="lg" variant="outline" className="h-12 w-full px-7 sm:w-auto">Read the docs</Button></Link></div>
           </div>
-          <div className="flex items-center gap-3">
-            <p className="text-xs text-muted-foreground">
-              Source available &middot; FSL-1.1-MIT
-            </p>
-            <a
-              href="https://github.com/WarriorSushi/feedbacks.dev-2026"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-muted-foreground transition-colors hover:text-foreground"
-            >
-              <Github className="h-4 w-4" />
-            </a>
-          </div>
+        </section>
+      </main>
+
+      <footer className="border-t px-5 py-8 sm:px-6">
+        <div className="mx-auto flex max-w-7xl flex-col items-center justify-between gap-5 sm:flex-row">
+          <BrandWordmark className="text-sm font-semibold" markClassName="h-5 w-5" />
+          <div className="flex flex-wrap justify-center gap-x-6 gap-y-2 text-xs text-muted-foreground"><Link href="/docs" prefetch={false}>Docs</Link><Link href="/boards" prefetch={false}>Public boards</Link><Link href="/privacy">Privacy</Link><Link href="/terms">Terms</Link></div>
+          <a href="https://github.com/WarriorSushi/feedbacks.dev-2026" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground"><Github className="h-4 w-4" /> Source available</a>
         </div>
       </footer>
+      <a href={dashboardHref} className="sr-only">Open dashboard</a>
     </div>
   )
 }

--- a/packages/dashboard/src/components/brand-wordmark.tsx
+++ b/packages/dashboard/src/components/brand-wordmark.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import Image from 'next/image'
 import { cn } from '@/lib/utils'
 
@@ -33,11 +31,11 @@ export function BrandWordmark({
         aria-hidden="true"
         className={cn(
           'h-6 w-6 shrink-0 rounded-md object-contain',
-          intro && 'brand-wordmark-mark-intro',
+          intro && 'animate-fade-in',
           markClassName,
         )}
       />
-      <span className={cn('tracking-tight', intro && 'brand-wordmark-text-intro', textClassName)}>
+      <span className={cn('tracking-tight', intro && 'animate-fade-in', textClassName)}>
         feedbacks<span className={cn('text-primary', dotClassName)}>.dev</span>
       </span>
     </span>

--- a/packages/dashboard/src/components/code-snippet.tsx
+++ b/packages/dashboard/src/components/code-snippet.tsx
@@ -50,6 +50,8 @@ export function CodeSnippet({ tabs, className, wrap = false, maxHeightClassName 
           className="absolute right-2 top-2 z-10 h-8 bg-background/95 px-2 text-xs shadow-sm backdrop-blur"
         />
         <pre
+          tabIndex={0}
+          aria-label={`${tabs[activeTab].label} code`}
           className={cn(
             'p-4 pr-24 text-sm',
             wrap ? 'overflow-x-hidden overflow-y-auto whitespace-pre-wrap break-words' : 'overflow-x-auto',

--- a/packages/dashboard/src/components/product-tour.tsx
+++ b/packages/dashboard/src/components/product-tour.tsx
@@ -427,10 +427,10 @@ export function ProductTour({
             height={spotlight.height}
             rx={spotlight.radius}
             fill="none"
-            stroke="hsl(var(--primary))"
+            stroke="oklch(var(--primary))"
             strokeWidth="2"
             vectorEffect="non-scaling-stroke"
-            style={{ filter: 'drop-shadow(0 0 8px hsl(var(--primary) / 0.65))' }}
+            style={{ filter: 'drop-shadow(0 0 8px oklch(var(--primary) / 0.5))' }}
           />
         </svg>
       ) : (

--- a/packages/dashboard/src/components/sidebar.tsx
+++ b/packages/dashboard/src/components/sidebar.tsx
@@ -52,12 +52,12 @@ type NavItem = {
 }
 
 const primaryNavItems: NavItem[] = [
-  { href: '/dashboard', label: 'Project home', icon: LayoutDashboard, exact: true, tourId: 'nav-dashboard', projectTab: 'home' },
+  { href: '/dashboard', label: 'Overview', icon: LayoutDashboard, exact: true, tourId: 'nav-dashboard', projectTab: 'home' },
   { href: '/feedback-form', label: 'Feedback form', icon: MessageSquare, tourId: 'nav-feedback-form', projectTab: 'feedback-form' },
   { href: '/feedback', label: 'Feedback inbox', icon: MessageSquare, tourId: 'nav-feedback' },
   { href: '/release-notes', label: 'Release notes', icon: Megaphone, tourId: 'nav-updates', projectTab: 'release-notes' },
   { href: '/board', label: 'Public board', icon: Globe, tourId: 'nav-boards', projectTab: 'board' },
-  { href: '/install', label: 'Embed installation', icon: Code2, tourId: 'nav-install', projectTab: 'install' },
+  { href: '/install', label: 'Install & verify', icon: Code2, tourId: 'nav-install', projectTab: 'install' },
   { href: '/integrations', label: 'Integrations', icon: Webhook, tourId: 'nav-integrations', projectTab: 'integrations' },
   { href: '/api', label: 'API & MCP', icon: Code2, tourId: 'nav-api', projectTab: 'api' },
 ]
@@ -374,7 +374,7 @@ export function Sidebar({ user, projects, currentProjectId, boardSlugs = {}, bil
             return (
               <React.Fragment key={item.href}>
                 {!collapsed && index === 1 && <p className="mb-1 mt-3 px-3 text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/70">Products</p>}
-                {!collapsed && index === 5 && <p className="mb-1 mt-3 px-3 text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/70">Delivery</p>}
+                {!collapsed && index === 5 && <p className="mb-1 mt-3 px-3 text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/70">Setup & delivery</p>}
                 {!collapsed && index === 7 && <p className="mb-1 mt-3 px-3 text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/70">Developers</p>}
                 <Link
                   href={scopedHref}
@@ -391,7 +391,7 @@ export function Sidebar({ user, projects, currentProjectId, boardSlugs = {}, bil
                     'transition-all duration-150 active:scale-[0.98]',
                     collapsed ? 'justify-center px-2' : 'px-3',
                     isActive
-                      ? ['bg-primary/8 text-primary', 'before:absolute before:inset-y-1 before:left-0 before:w-[3px] before:rounded-r-full', 'before:bg-primary before:shadow-[0_0_8px_hsl(var(--primary)/0.5)]']
+                      ? ['bg-primary/[0.09] text-primary', 'before:absolute before:inset-y-1.5 before:left-0 before:w-0.5 before:rounded-r-full', 'before:bg-primary']
                       : 'text-muted-foreground hover:bg-accent hover:text-foreground'
                   )}
                 >
@@ -492,8 +492,8 @@ export function Sidebar({ user, projects, currentProjectId, boardSlugs = {}, bil
           <div
             className={cn(
               'flex h-7 w-7 shrink-0 items-center justify-center rounded-full',
-              'bg-[hsl(var(--primary)/0.12)] text-[12px] font-semibold text-primary',
-              'ring-1 ring-[hsl(var(--primary)/0.15)]'
+              'bg-primary/10 text-[12px] font-semibold text-primary',
+              'ring-1 ring-primary/15'
             )}
           >
             {displayName[0].toUpperCase()}
@@ -546,7 +546,7 @@ export function Sidebar({ user, projects, currentProjectId, boardSlugs = {}, bil
           ) : (
             <CircleHelp className="h-3.5 w-3.5 shrink-0 transition-transform duration-150 group-hover:scale-[1.08]" />
           )}
-          {!collapsed && <span className="truncate">Take product tour</span>}
+          {!collapsed && <span className="truncate">Tour this workspace</span>}
         </Link>
       </div>
     </>
@@ -597,9 +597,9 @@ export function Sidebar({ user, projects, currentProjectId, boardSlugs = {}, bil
       {/* ── Desktop sidebar (static flex child, full height from parent) ─ */}
       <aside
         className={cn(
-          'hidden md:flex md:flex-col md:border-r md:bg-card',
+          'hidden md:flex md:flex-col md:border-r md:bg-card/80 md:backdrop-blur-xl',
           'transition-[width] duration-300 [transition-timing-function:cubic-bezier(0.25,1,0.5,1)]',
-          collapsed ? 'md:w-[60px]' : 'md:w-60'
+          collapsed ? 'md:w-[60px]' : 'md:w-[232px]'
         )}
       >
         {sidebarContent}

--- a/packages/dashboard/src/components/ui/button.tsx
+++ b/packages/dashboard/src/components/ui/button.tsx
@@ -4,11 +4,11 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-[background-color,color,border-color,box-shadow,transform,filter] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 active:scale-[0.98] active:brightness-95 disabled:pointer-events-none disabled:opacity-50 disabled:active:scale-100",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-semibold ring-offset-background transition-[background-color,color,border-color,box-shadow,transform,filter] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:ring-offset-2 active:translate-y-px active:brightness-95 disabled:pointer-events-none disabled:opacity-50 disabled:active:translate-y-0",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default: "bg-primary text-primary-foreground shadow-sm shadow-black/10 hover:bg-primary/90 hover:shadow-md",
         destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",

--- a/packages/dashboard/src/components/ui/card.tsx
+++ b/packages/dashboard/src/components/ui/card.tsx
@@ -6,7 +6,7 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
     <div
       ref={ref}
       className={cn(
-        "rounded-lg border bg-card text-card-foreground shadow-sm shadow-black/[0.03] dark:shadow-black/20",
+        "rounded-lg border border-border/80 bg-card text-card-foreground shadow-[var(--shadow-card)]",
         className,
       )}
       {...props}

--- a/packages/dashboard/src/lib/docs-content.ts
+++ b/packages/dashboard/src/lib/docs-content.ts
@@ -15,11 +15,11 @@ export interface DocsPage {
   blocks: DocsBlock[]
 }
 
-const websiteSnippet = `<script
+const websiteSnippet = `<div data-feedbacks-host="YOUR_PROJECT_KEY"></div>
+
+<script
   src="https://app.feedbacks.dev/widget/latest.js"
   data-project="YOUR_PROJECT_KEY"
-  data-api-url="https://app.feedbacks.dev/api/feedback"
-  data-config-version="1"
   defer
 ></script>`
 
@@ -64,19 +64,19 @@ export const DOCS_PAGES: DocsPage[] = [
     blocks: [
       { type: 'heading', id: 'create', title: '1. Create the project' },
       { type: 'paragraph', text: 'Open Projects, choose New Project, and use the name your team already uses for the product. The domain is optional. Creating the project opens its product home.' },
-      { type: 'heading', id: 'customize', title: '2. Save the form you want' },
-      { type: 'paragraph', text: 'Install the shared embed first. Then choose floating button, custom trigger, or inline form from Feedback form. Saved changes are delivered remotely.' },
-      { type: 'heading', id: 'install', title: '3. Paste the generated snippet' },
+      { type: 'heading', id: 'install', title: '2. Paste the generated snippet' },
       { type: 'code', label: 'HTML', language: 'html', code: websiteSnippet },
       { type: 'callout', tone: 'warning', title: 'Use the generated project key', body: 'YOUR_PROJECT_KEY is a placeholder. Copy the complete snippet from your project Install tab. Never put a private REST API key in browser code.' },
-      { type: 'heading', id: 'verify', title: '4. Verify both environments' },
+      { type: 'heading', id: 'verify', title: '3. Verify both environments' },
       { type: 'steps', items: [
         { title: 'Run hosted verification', body: 'This confirms the saved form and browser-safe project key work independently of your website.' },
         { title: 'Open your real page', body: 'Load the page where you installed the snippet and submit a message you can recognize.' },
         { title: 'Check the inbox', body: 'Confirm the message, project, URL, and browser context. Opening it marks it read without changing workflow status.' },
       ] },
+      { type: 'heading', id: 'customize', title: '4. Customize remotely' },
+      { type: 'paragraph', text: 'Choose floating button, custom trigger, or inline form from Feedback form. Save placement, fields, labels, colors, screenshots, attachments, and captcha settings without replacing the installed snippet.' },
       { type: 'heading', id: 'next', title: '5. Add only what you need next' },
-      { type: 'list', items: ['Restrict allowed origins after the real site works.', 'Enable screenshots, attachments, required email, or captcha from Customize.', 'Add Slack, Discord, GitHub Issues, or a webhook from Integrations.', 'Publish a public board only when you want requests, votes, and replies to be visible.'] },
+      { type: 'list', items: ['Restrict allowed origins after the real site works.', 'Add Slack, Discord, GitHub Issues, or a webhook from Integrations.', 'Publish Release notes when you want to show users what shipped.', 'Publish a public board only when you want requests, votes, and replies to be visible.'] },
     ],
   },
   {
@@ -108,7 +108,8 @@ export const DOCS_PAGES: DocsPage[] = [
         ['trigger', 'Your own button should open the feedback modal.'],
         ['inline', 'The form should render inside a specific page container.'],
       ] },
-      { type: 'code', label: 'Custom trigger', language: 'html', code: `<button data-feedbacks-trigger>Send feedback</button>\n${websiteSnippet.replace('data-config-version="1"', 'data-config-version="1"\n  data-embed-mode="trigger"\n  data-target="[data-feedbacks-trigger]"')}` },
+      { type: 'code', label: 'Custom trigger', language: 'html', code: `<button data-feedbacks-trigger>Send feedback</button>\n\n${websiteSnippet}` },
+      { type: 'callout', tone: 'note', title: 'Set the mode in Feedback form', body: 'Choose Custom trigger and save [data-feedbacks-trigger] as the target. The installed snippet stays unchanged.' },
     ],
   },
   {
@@ -117,9 +118,9 @@ export const DOCS_PAGES: DocsPage[] = [
     blocks: [
       { type: 'heading', id: 'nextjs', title: 'Next.js App Router' },
       { type: 'paragraph', text: 'Add the generated Website script to the root layout. This avoids duplicate instances and keeps the form available across routes.' },
-      { type: 'code', label: 'app/layout.tsx', language: 'tsx', code: `import Script from 'next/script'\n\nexport default function RootLayout({ children }) {\n  return (\n    <html lang="en">\n      <body>{children}</body>\n      <Script\n        src="https://app.feedbacks.dev/widget/latest.js"\n        data-project="YOUR_PROJECT_KEY"\n        data-api-url="https://app.feedbacks.dev/api/feedback"\n        data-config-version="1"\n        strategy="afterInteractive"\n      />\n    </html>\n  )\n}` },
+      { type: 'code', label: 'app/layout.tsx', language: 'tsx', code: `import Script from 'next/script'\n\nexport default function RootLayout({ children }) {\n  return (\n    <html lang="en">\n      <body>\n        {children}\n        <div data-feedbacks-host="YOUR_PROJECT_KEY" />\n        <Script\n          src="https://app.feedbacks.dev/widget/latest.js"\n          data-project="YOUR_PROJECT_KEY"\n          strategy="afterInteractive"\n        />\n      </body>\n    </html>\n  )\n}` },
       { type: 'heading', id: 'react-vue', title: 'React and Vue' },
-      { type: 'paragraph', text: 'The project Install tab generates framework-specific code from the saved form configuration. Put the wrapper at the application root. If your package registry cannot resolve a wrapper, use the Website script in the root HTML instead.' },
+      { type: 'paragraph', text: 'The project Install tab generates framework-specific code with the project key and application origin. Put the wrapper at the application root. Saved product settings are resolved remotely. If your package registry cannot resolve a wrapper, use the Website script in the root HTML instead.' },
       { type: 'heading', id: 'wordpress', title: 'WordPress' },
       { type: 'steps', items: [
         { title: 'Open Embed installation', body: 'Select WordPress to see the stable Website snippet and placement guidance.' },
@@ -145,7 +146,7 @@ export const DOCS_PAGES: DocsPage[] = [
         ['Labels and success copy', 'Form title, prompts, buttons, and completion message'],
         ['Captcha', 'Cloudflare Turnstile or hCaptcha for public forms'],
       ] },
-      { type: 'callout', tone: 'note', title: 'Save before copying code', body: 'Generated snippets include the saved configuration version. If you change the form, save and copy the updated snippet when the install attributes changed.' },
+      { type: 'callout', tone: 'success', title: 'The installed snippet stays stable', body: 'Save changes in Feedback form to publish them remotely. You only need new code after rotating the browser-safe project key or moving the embed to a different project.' },
     ],
   },
   {
@@ -336,7 +337,7 @@ FEEDBACKS_API_URL=https://app.feedbacks.dev` },
       { type: 'heading', id: 'widget-missing', title: 'The widget does not appear' },
       { type: 'list', items: ['Confirm the script request returns 200 in browser developer tools.', 'Check that data-project contains the generated browser-safe key.', 'Remove duplicate script tags.', 'For trigger or inline mode, confirm the target selector exists.', 'Purge WordPress, CDN, and page-builder caches.', 'Check Content Security Policy errors in the console.'] },
       { type: 'heading', id: 'submission', title: 'The form opens but submission fails' },
-      { type: 'list', items: ['Run hosted verification to separate host-page issues from project issues.', 'Confirm data-api-url points to https://app.feedbacks.dev/api/feedback.', 'Check allowed-origin rules against the exact page origin.', 'Check captcha keys and provider configuration.', 'Review plan quota and attachment validation messages.'] },
+      { type: 'list', items: ['Run hosted verification to separate host-page issues from project issues.', 'Confirm the public widget bootstrap request succeeds for the project key.', 'Check allowed-origin rules against the exact page origin.', 'Check captcha keys and provider configuration.', 'Review plan quota and attachment validation messages.'] },
       { type: 'heading', id: 'lazy-content', title: 'Screenshots miss animated or lazy content' },
       { type: 'paragraph', text: 'Screenshot capture records the visible viewport at the moment the user submits. Ask the user to scroll until lazy or animated content is visible, then open the form and capture. Full-page capture is intentionally not used.' },
       { type: 'heading', id: 'webhook', title: 'A webhook is failing' },

--- a/packages/dashboard/src/lib/guided-tutorials.ts
+++ b/packages/dashboard/src/lib/guided-tutorials.ts
@@ -32,19 +32,15 @@ export const GUIDED_TUTORIAL_PROGRESS_KEY = 'feedbacks-guided-tutorial-progress'
 export const GUIDED_TUTORIALS: GuidedTutorialDefinition[] = [
   {
     id: 'navigation',
-    title: 'Dashboard map',
-    description: 'Learn where each main product area lives.',
+    title: 'Your workspace in 6 steps',
+    description: 'See the core loop first. Advanced tools stay available when you need them.',
     steps: [
-      { title: 'Project home', body: 'See the Feedback form and Release notes products, then install their shared embed once.', href: '/projects/{projectId}', target: '[data-tour="nav-dashboard"]' },
-      { title: 'Feedback form', body: 'Manage the in-product form, fields, placement, wording, and anti-spam settings remotely.', href: '/projects/{projectId}/feedback-form', target: '[data-tour="nav-feedback-form"]' },
-      { title: 'Feedback inbox', body: 'New messages land here. Search, filter, tag, and decide what needs action.', href: '/feedback', target: '[data-tour="nav-feedback"]' },
-      { title: 'Release notes', body: 'Publish “What’s new” announcements inside the product selected at the top of the sidebar.', href: '/projects/{projectId}/release-notes', target: '[data-tour="nav-updates"]' },
-      { title: 'Public board', body: 'Manage the public board for the project selected at the top of the sidebar.', href: '/projects/{projectId}/board', target: '[data-tour="nav-boards"]' },
-      { title: 'Embed installation', body: 'Install the shared embed once and confirm it is connected to the selected project.', href: '/projects/{projectId}/install', target: '[data-tour="nav-install"]' },
-      { title: 'Integrations', body: 'Route feedback for the selected project into your existing workflow.', href: '/projects/{projectId}/integrations', target: '[data-tour="nav-integrations"]' },
-      { title: 'API & MCP', body: 'Use REST and MCP tools for the project selected at the top of the sidebar.', href: '/projects/{projectId}/api', target: '[data-tour="nav-api"]' },
-      { title: 'Billing', body: 'Check usage, plan access, and billing management.', href: '/billing', target: '[data-tour="nav-billing"]' },
-      { title: 'Settings', body: 'Manage your profile, notifications, theme, account, and tutorial progress.', href: '/settings', target: '[data-tour="nav-settings"]' },
+      { title: 'Start from Overview', body: 'This project home separates your Feedback form and Release notes, and shows their shared install status.', href: '/projects/{projectId}', target: '[data-tour="nav-dashboard"]' },
+      { title: 'Shape the Feedback form', body: 'Choose the placement, wording, fields, color, and anti-spam settings. Saved changes reach the embed remotely.', href: '/projects/{projectId}/feedback-form', target: '[data-tour="nav-feedback-form"]' },
+      { title: 'Triage the Feedback inbox', body: 'User messages land here with page and browser context. Search, filter, tag, and decide what needs action.', href: '/feedback', target: '[data-tour="nav-feedback"]' },
+      { title: 'Publish Release notes', body: 'Tell users what shipped through the in-product “What’s new” feed. These are your product announcements.', href: '/projects/{projectId}/release-notes', target: '[data-tour="nav-updates"]' },
+      { title: 'Install and verify once', body: 'Add the shared embed, send one known-good test, and confirm the connection before customizing further.', href: '/projects/{projectId}/install', target: '[data-tour="nav-install"]' },
+      { title: 'Connect the rest when needed', body: 'Public boards, integrations, API access, billing, and settings stay in the sidebar without blocking first setup.', href: '/projects/{projectId}/integrations', target: '[data-tour="nav-integrations"]' },
     ],
   },
   {
@@ -64,8 +60,7 @@ export const GUIDED_TUTORIALS: GuidedTutorialDefinition[] = [
     description: 'Choose placement, fields, labels, and preview the result.',
     steps: [
       { title: 'Feedback form', body: 'Change placement, wording, fields, and anti-spam settings remotely.', href: '/projects/{projectId}/feedback-form', target: '[data-tour="nav-feedback-form"]' },
-      { title: 'Remote configuration', body: 'Save changes to publish them to every installed embed without replacing code.', href: '/projects/{projectId}/feedback-form', target: '[data-tour="widget-settings"]' },
-      { title: 'Widget settings', body: 'Choose placement first, then change only the labels, color, and optional fields you need.', href: '/projects/{projectId}/feedback-form', target: '[data-tour="widget-settings"]' },
+      { title: 'Remote configuration', body: 'Choose placement, labels, color, and optional fields, then save once to update every installed embed.', href: '/projects/{projectId}/feedback-form', target: '[data-tour="widget-settings"]' },
       { title: 'Live preview', body: 'Preview the form before publishing the remote configuration.', href: '/projects/{projectId}/feedback-form', target: '[data-tour="widget-preview"]' },
     ],
   },

--- a/packages/dashboard/src/middleware.ts
+++ b/packages/dashboard/src/middleware.ts
@@ -17,7 +17,7 @@ function buildContentSecurityPolicy(nonce: string): string {
     : 'https://test.dodopayments.com'
   const developmentScriptSource = process.env.NODE_ENV === 'development' ? " 'unsafe-eval'" : ''
 
-  return [
+  const directives = [
     "default-src 'self'",
     "base-uri 'self'",
     "object-src 'none'",
@@ -30,8 +30,9 @@ function buildContentSecurityPolicy(nonce: string): string {
     `connect-src 'self' ${appOrigin} ${supabaseOrigin} ${supabaseWsOrigin} ${dodoOrigin}`.trim(),
     "worker-src 'self' blob:",
     "frame-src 'self'",
-    'upgrade-insecure-requests',
-  ].join('; ')
+  ]
+  if (process.env.NODE_ENV !== 'development') directives.push('upgrade-insecure-requests')
+  return directives.join('; ')
 }
 
 export async function middleware(request: NextRequest) {

--- a/packages/dashboard/tailwind.config.cjs
+++ b/packages/dashboard/tailwind.config.cjs
@@ -14,38 +14,38 @@ module.exports = {
     },
     extend: {
       colors: {
-        border: 'hsl(var(--border))',
-        input: 'hsl(var(--input))',
-        ring: 'hsl(var(--ring))',
-        background: 'hsl(var(--background))',
-        foreground: 'hsl(var(--foreground))',
+        border: 'oklch(var(--border) / <alpha-value>)',
+        input: 'oklch(var(--input) / <alpha-value>)',
+        ring: 'oklch(var(--ring) / <alpha-value>)',
+        background: 'oklch(var(--background) / <alpha-value>)',
+        foreground: 'oklch(var(--foreground) / <alpha-value>)',
         primary: {
-          DEFAULT: 'hsl(var(--primary))',
-          foreground: 'hsl(var(--primary-foreground))',
+          DEFAULT: 'oklch(var(--primary) / <alpha-value>)',
+          foreground: 'oklch(var(--primary-foreground) / <alpha-value>)',
         },
         secondary: {
-          DEFAULT: 'hsl(var(--secondary))',
-          foreground: 'hsl(var(--secondary-foreground))',
+          DEFAULT: 'oklch(var(--secondary) / <alpha-value>)',
+          foreground: 'oklch(var(--secondary-foreground) / <alpha-value>)',
         },
         destructive: {
-          DEFAULT: 'hsl(var(--destructive))',
-          foreground: 'hsl(var(--destructive-foreground))',
+          DEFAULT: 'oklch(var(--destructive) / <alpha-value>)',
+          foreground: 'oklch(var(--destructive-foreground) / <alpha-value>)',
         },
         muted: {
-          DEFAULT: 'hsl(var(--muted))',
-          foreground: 'hsl(var(--muted-foreground))',
+          DEFAULT: 'oklch(var(--muted) / <alpha-value>)',
+          foreground: 'oklch(var(--muted-foreground) / <alpha-value>)',
         },
         accent: {
-          DEFAULT: 'hsl(var(--accent))',
-          foreground: 'hsl(var(--accent-foreground))',
+          DEFAULT: 'oklch(var(--accent) / <alpha-value>)',
+          foreground: 'oklch(var(--accent-foreground) / <alpha-value>)',
         },
         popover: {
-          DEFAULT: 'hsl(var(--popover))',
-          foreground: 'hsl(var(--popover-foreground))',
+          DEFAULT: 'oklch(var(--popover) / <alpha-value>)',
+          foreground: 'oklch(var(--popover-foreground) / <alpha-value>)',
         },
         card: {
-          DEFAULT: 'hsl(var(--card))',
-          foreground: 'hsl(var(--card-foreground))',
+          DEFAULT: 'oklch(var(--card) / <alpha-value>)',
+          foreground: 'oklch(var(--card-foreground) / <alpha-value>)',
         },
       },
       borderRadius: {

--- a/packages/dashboard/tests/e2e/accessibility.spec.ts
+++ b/packages/dashboard/tests/e2e/accessibility.spec.ts
@@ -6,6 +6,29 @@ import { createProjectViaApi } from './helpers/project'
 const env = skipE2EIfNeeded()
 test.skip(!env.ready, env.skipReason)
 
+test('landing and sign-in are accessible and fit a mobile viewport', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+
+  for (const route of ['/', '/auth']) {
+    await page.goto(route)
+    await expect(page.locator('main')).toBeVisible()
+    const result = await new AxeBuilder({ page })
+      .include('main')
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze()
+    const serious = result.violations.filter((violation) =>
+      violation.impact === 'serious' || violation.impact === 'critical',
+    )
+    expect(serious).toEqual([])
+
+    const sizes = await page.evaluate(() => ({
+      viewport: document.documentElement.clientWidth,
+      content: document.documentElement.scrollWidth,
+    }))
+    expect(sizes.content).toBeLessThanOrEqual(sizes.viewport)
+  }
+})
+
 for (const route of ['/dashboard', '/feedback']) {
   test(`${route} has no serious accessibility violations`, async ({ page }) => {
     await signInWithTestSession(page)

--- a/packages/dashboard/tests/e2e/account-surfaces.spec.ts
+++ b/packages/dashboard/tests/e2e/account-surfaces.spec.ts
@@ -8,7 +8,7 @@ test('protected routes require authentication and billing state loads after sign
   await page.context().clearCookies()
   await page.goto('/dashboard')
   await expect(page).toHaveURL(/\/auth\?redirect=/)
-  await expect(page.getByRole('heading', { name: 'Sign in to start setup' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Sign in or create an account' })).toBeVisible()
 
   await signInWithTestSession(page)
   await page.goto('/billing')

--- a/packages/dashboard/tests/e2e/product-tour.spec.ts
+++ b/packages/dashboard/tests/e2e/product-tour.spec.ts
@@ -8,16 +8,12 @@ test.skip(!env.ready, env.skipReason)
 const TOUR_STEP_TIMEOUT_MS = 60_000
 
 const tourSteps = [
-  { title: 'Project home', path: /\/projects\/[^/]+$/, target: 'nav-dashboard' },
-  { title: 'Feedback form', path: /\/projects\/[^/]+\/feedback-form$/, target: 'nav-feedback-form' },
-  { title: 'Feedback inbox', path: /\/feedback(?:\?.*)?$/, target: 'nav-feedback' },
-  { title: 'Release notes', path: /\/projects\/[^/]+\/release-notes$/, target: 'nav-updates' },
-  { title: 'Public board', path: /\/projects\/[^/]+\/board$/, target: 'nav-boards' },
-  { title: 'Embed installation', path: /\/projects\/[^/]+\/install$/, target: 'nav-install' },
-  { title: 'Integrations', path: /\/projects\/[^/]+\/integrations$/, target: 'nav-integrations' },
-  { title: 'API & MCP', path: /\/projects\/[^/]+\/api$/, target: 'nav-api' },
-  { title: 'Billing', path: /\/billing(?:\?.*)?$/, target: 'nav-billing' },
-  { title: 'Settings', path: /\/settings(?:\?.*)?$/, target: 'nav-settings' },
+  { title: 'Start from Overview', path: /\/projects\/[^/]+$/, target: 'nav-dashboard' },
+  { title: 'Shape the Feedback form', path: /\/projects\/[^/]+\/feedback-form$/, target: 'nav-feedback-form' },
+  { title: 'Triage the Feedback inbox', path: /\/feedback(?:\?.*)?$/, target: 'nav-feedback' },
+  { title: 'Publish Release notes', path: /\/projects\/[^/]+\/release-notes$/, target: 'nav-updates' },
+  { title: 'Install and verify once', path: /\/projects\/[^/]+\/install$/, target: 'nav-install' },
+  { title: 'Connect the rest when needed', path: /\/projects\/[^/]+\/integrations$/, target: 'nav-integrations' },
 ]
 
 test.describe('product tour', () => {

--- a/packages/dashboard/tests/e2e/product-updates.spec.ts
+++ b/packages/dashboard/tests/e2e/product-updates.spec.ts
@@ -32,7 +32,7 @@ test('new Release-notes-only user verifies the embed, tests a draft, and publish
 
   await page.goto('/projects/new?goal=updates')
   await page.getByLabel('Project name').fill(`Playwright Updates ${Date.now().toString(36)}`)
-  await expect(page.getByRole('button', { name: 'Publish release notes' })).toHaveAttribute('aria-pressed', 'true')
+  await expect(page.getByRole('button', { name: 'Release notes', exact: true })).toHaveAttribute('aria-pressed', 'true')
   await page.getByRole('button', { name: 'Create project and set up release notes' }).click()
   await expect(page).toHaveURL(/\/projects\/([^/]+)\/release-notes$/, { timeout: 30_000 })
 

--- a/packages/dashboard/tests/unit/product-experience.test.ts
+++ b/packages/dashboard/tests/unit/product-experience.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const read = (path: string) => readFileSync(new URL(path, import.meta.url), 'utf8')
+
+test('landing page names both products and keeps the install-once architecture', () => {
+  const source = read('../../src/app/page.tsx')
+
+  assert.match(source, /Feedback form/)
+  assert.match(source, /Release notes/)
+  assert.match(source, /Install once, verify it works, then manage everything remotely/)
+  assert.match(source, /generateInstallSnippets/)
+  assert.doesNotMatch(source, /createServerSupabase/)
+  assert.doesNotMatch(source, /userbase|Collecting user feedbacks/)
+})
+
+test('sign-in explains account creation and the shared embed before setup', () => {
+  const source = read('../../src/app/auth/page.tsx')
+
+  assert.match(source, /Sign in or create an account/)
+  assert.match(source, /GitHub or a magic link creates your account/)
+  assert.match(source, /One embed for both/)
+  assert.doesNotMatch(source, /data-api-url/)
+})
+
+test('theme tokens use perceptual OKLCH colors in both themes', () => {
+  const css = read('../../src/app/globals.css')
+  const tailwind = read('../../tailwind.config.cjs')
+
+  assert.match(css, /--background: 0\.985/)
+  assert.match(css, /\.dark[\s\S]*--background: 0\.155/)
+  assert.match(tailwind, /oklch\(var\(--primary\)/)
+  assert.doesNotMatch(tailwind, /hsl\(var\(--primary\)/)
+})
+
+test('public docs use the stable canonical embed and remote customization language', () => {
+  const source = read('../../src/lib/docs-content.ts')
+
+  assert.match(source, /data-feedbacks-host/)
+  assert.match(source, /data-project=/)
+  assert.match(source, /Customize remotely/)
+  assert.match(source, /installed snippet stays stable/)
+  assert.doesNotMatch(source, /data-api-url/)
+  assert.doesNotMatch(source, /data-config-version/)
+})


### PR DESCRIPTION
## What changed

- rebuilt the landing page around the clear Feedback form + Release notes product story
- aligned sign-in, project creation, project home, navigation, and the workspace tour to the install-once flow
- introduced a restrained OKLCH theme with accessible contrast and consistent surfaces
- made the marketing route static and parallelized dashboard shell data loading
- corrected public installation docs so remote customization never asks users to replace the snippet
- added product-experience unit coverage and public/auth accessibility coverage

## User impact

New users now see one coherent path: create a project, install one shared embed, verify a real submission, then manage Feedback form and Release notes remotely. Advanced products remain available without blocking first value.

## Verification

- `pnpm type-check`
- `pnpm lint`
- `pnpm test:unit` (104 passed)
- `pnpm build`
- `pnpm widget:check-size` (16,480 bytes gzip)
- `git diff --check`
- required Playwright E2E: final complete run 24/25, followed by 5/5 passing accessibility rerun for the sole corrected failure; all 25 journeys pass in the final code state

## Notes

The existing untracked mockup file was preserved and is not part of this PR.