### PR TITLE
Fix production CSP hydration

### DIFF
--- a/packages/dashboard/src/app/layout.tsx
+++ b/packages/dashboard/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import '@/lib/env' // validate env vars at startup
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
+import { headers } from 'next/headers'
 import './globals.css'
 import { ThemeProvider } from '@/components/theme-provider'
 import { Toaster } from '@/components/toaster'
@@ -22,11 +23,15 @@ export const metadata: Metadata = {
   },
 }
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
+  // A nonce-based CSP only works when Next renders per request and can attach
+  // the middleware nonce to framework and hydration scripts.
+  await headers()
+
   return (
     <html lang="en" data-scroll-behavior="smooth" suppressHydrationWarning>
       <body className={inter.className}>

--- a/packages/dashboard/tests/unit/csp-rendering.test.ts
+++ b/packages/dashboard/tests/unit/csp-rendering.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const read = (path: string) => readFileSync(new URL(path, import.meta.url), 'utf8')
+
+test('nonce CSP uses request-aware rendering so Next can hydrate every route', () => {
+  const middleware = read('../../src/middleware.ts')
+  const layout = read('../../src/app/layout.tsx')
+
+  assert.match(middleware, /'nonce-\$\{nonce\}' 'strict-dynamic'/)
+  assert.match(middleware, /requestHeaders\.set\('Content-Security-Policy'/)
+  assert.match(layout, /import \{ headers \} from 'next\/headers'/)
+  assert.match(layout, /export default async function RootLayout/)
+  assert.match(layout, /await headers\(\)/)
+})


### PR DESCRIPTION
## What changed

Force request-aware root rendering so Next.js can attach the middleware CSP nonce to framework and hydration scripts. Add a focused regression test for the nonce/dynamic-rendering contract.

## Why

Production static HTML had a per-request strict CSP header but nonce-less Next.js scripts, leaving the page visible but non-interactive.

## Verification

- Dashboard type-check
- Changed-file ESLint
- Focused CSP rendering unit test
- Required CI before merge