### PR TITLE
Pass CSP nonce to theme bootstrap

### DIFF
--- a/packages/dashboard/src/app/layout.tsx
+++ b/packages/dashboard/src/app/layout.tsx
@@ -30,7 +30,7 @@ export default async function RootLayout({
 }) {
   // A nonce-based CSP only works when Next renders per request and can attach
   // the middleware nonce to framework and hydration scripts.
-  await headers()
+  const nonce = (await headers()).get('x-nonce') || undefined
 
   return (
     <html lang="en" data-scroll-behavior="smooth" suppressHydrationWarning>
@@ -40,6 +40,7 @@ export default async function RootLayout({
           defaultTheme="dark"
           enableSystem
           disableTransitionOnChange
+          nonce={nonce}
         >
           {children}
           <Toaster />

--- a/packages/dashboard/tests/unit/csp-rendering.test.ts
+++ b/packages/dashboard/tests/unit/csp-rendering.test.ts
@@ -12,5 +12,6 @@ test('nonce CSP uses request-aware rendering so Next can hydrate every route', (
   assert.match(middleware, /requestHeaders\.set\('Content-Security-Policy'/)
   assert.match(layout, /import \{ headers \} from 'next\/headers'/)
   assert.match(layout, /export default async function RootLayout/)
-  assert.match(layout, /await headers\(\)/)
+  assert.match(layout, /\(await headers\(\)\)\.get\('x-nonce'\)/)
+  assert.match(layout, /nonce=\{nonce\}/)
 })


### PR DESCRIPTION
Forward the middleware nonce to next-themes so its pre-hydration theme script is allowed by the strict production CSP. Extends the focused CSP rendering regression test. Targeted type-check, ESLint, unit test, and diff check pass.