### PR TITLE
Align E2E journeys with redesigned copy

### DIFF
--- a/packages/dashboard/tests/e2e/board-submit.spec.ts
+++ b/packages/dashboard/tests/e2e/board-submit.spec.ts
@@ -18,19 +18,19 @@ test('publishes a board and exercises duplicate and spam submission checks', asy
 
   await page.goto(`/projects/${project.id}/board`, { waitUntil: 'domcontentloaded' })
   await expect(page.locator('[data-project-tabs-ready="true"]')).toBeVisible()
-  await expect(page.getByRole('heading', { name: 'Public board' })).toBeVisible()
-  await expect(page.getByRole('link', { name: 'Open public board' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Public feedback page' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Open page' })).toBeVisible()
 
   await page.goto(board.url, { waitUntil: 'domcontentloaded' })
   await expect(page.locator('[data-public-board-ready="true"]')).toBeVisible()
   await expect(page.getByRole('heading', { name: 'Playwright board' })).toBeVisible()
-  await page.getByRole('button', { name: /share feedback|submit feedback/i }).first().click()
-  const submitDialog = page.getByRole('dialog', { name: /post a request or bug report|submit feedback/i })
+  await page.getByRole('button', { name: 'Share an idea or bug' }).click()
+  const submitDialog = page.getByRole('dialog', { name: 'Share an idea or bug' })
   await expect(submitDialog).toBeVisible()
 
   const uniqueMessage = `Need clearer setup guidance ${Date.now().toString(36)}`
-  await submitDialog.getByLabel(/Your feedback/).fill(uniqueMessage)
-  await submitDialog.getByRole('button', { name: 'Submit feedback' }).click()
+  await submitDialog.getByLabel('What do you need?').fill(uniqueMessage)
+  await submitDialog.getByRole('button', { name: 'Post to board' }).click()
   await expect(submitDialog).toHaveCount(0)
   await expect(page.getByText(uniqueMessage)).toBeVisible()
 

--- a/packages/dashboard/tests/e2e/directory.spec.ts
+++ b/packages/dashboard/tests/e2e/directory.spec.ts
@@ -11,7 +11,7 @@ test('shows the public directory and category filters with realistic board activ
 
   await page.goto('/boards', { waitUntil: 'domcontentloaded' })
   await expect(page.locator('[data-board-directory-ready="true"]')).toBeVisible()
-  await expect(page.getByRole('heading', { name: 'Browse public feedback boards.' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'See what people want teams to build.' })).toBeVisible()
   await expect(page.getByRole('button', { name: 'Trending' })).toBeVisible()
   const analyticsFilter = page.getByRole('button', { name: 'analytics' })
   const firstBoardLink = page.locator(`a[href="/p/${boards.firstBoard.slug}"]`)

--- a/packages/dashboard/tests/e2e/install.spec.ts
+++ b/packages/dashboard/tests/e2e/install.spec.ts
@@ -9,8 +9,8 @@ test('creates a project and lands on a stable one-time embed installation', asyn
   await signInWithTestSession(page)
 
   await page.goto('/projects/new')
-  await page.getByLabel('Project name').fill(`Playwright Install ${Date.now().toString(36)}`)
-  await page.getByRole('button', { name: 'Create project and get install code' }).click()
+  await page.getByLabel('App or website name').fill(`Playwright Install ${Date.now().toString(36)}`)
+  await page.getByRole('button', { name: 'Create project and make the form' }).click()
 
   await expect(page).toHaveURL(/\/projects\/[^/]+\/install\?created=1/, { timeout: 30_000 })
   await expect(page.getByRole('navigation', { name: 'Setup steps' })).toBeVisible()

--- a/packages/dashboard/tests/e2e/product-updates.spec.ts
+++ b/packages/dashboard/tests/e2e/product-updates.spec.ts
@@ -31,9 +31,8 @@ test('new Updates-only user verifies the embed, tests a draft, and publishes', a
   await signInWithTestSession(page)
 
   await page.goto('/projects/new?goal=updates')
-  await page.getByLabel('Project name').fill(`Playwright Updates ${Date.now().toString(36)}`)
-  await expect(page.getByRole('button', { name: 'Updates for users', exact: true })).toHaveAttribute('aria-pressed', 'true')
-  await page.getByRole('button', { name: 'Create project and set up user updates' }).click()
+  await page.getByLabel('App or website name').fill(`Playwright Updates ${Date.now().toString(36)}`)
+  await page.getByRole('button', { name: 'Create project and write a user message' }).click()
   await expect(page).toHaveURL(/\/projects\/([^/]+)\/release-notes$/, { timeout: 30_000 })
 
   const projectId = page.url().match(/\/projects\/([^/]+)\/release-notes$/)?.[1]


### PR DESCRIPTION
## Summary
- align four authenticated journey tests with the redesigned accessible labels and headings
- cover the updated public feedback form interaction through submission
- preserve production behavior; this follow-up changes tests only

## Validation
- `pnpm type-check` — passed
- `pnpm lint` — passed
- `git diff --check` — passed
- focused local Playwright invocation — not runnable because `E2E_AUTH_BYPASS_SECRET` is intentionally CI-only; GitHub Actions will run the authenticated gate

Follow-up to #14.