### PR TITLE
Differentiate feedback sidebar icons

### DIFF
--- a/packages/dashboard/src/components/sidebar.tsx
+++ b/packages/dashboard/src/components/sidebar.tsx
@@ -8,7 +8,8 @@ import { Button } from '@/components/ui/button'
 import { BrandWordmark } from '@/components/brand-wordmark'
 import {
   House,
-  MessageSquare,
+  ClipboardPenLine,
+  Inbox,
   CreditCard,
   Settings,
   LogOut,
@@ -65,8 +66,8 @@ const primaryNavGroups: NavGroup[] = [
   {
     label: 'Collect',
     items: [
-      { href: '/feedback-form', label: 'Feedback form', icon: MessageSquare, tourId: 'nav-feedback-form', projectTab: 'feedback-form' },
-      { href: '/feedback', label: 'Feedback inbox', icon: MessageSquare, tourId: 'nav-feedback' },
+      { href: '/feedback-form', label: 'Feedback form', icon: ClipboardPenLine, tourId: 'nav-feedback-form', projectTab: 'feedback-form' },
+      { href: '/feedback', label: 'Feedback inbox', icon: Inbox, tourId: 'nav-feedback' },
     ],
   },
   {

--- a/packages/dashboard/tests/unit/product-experience.test.ts
+++ b/packages/dashboard/tests/unit/product-experience.test.ts
@@ -79,6 +79,8 @@ test('sidebar exposes a stable Home destination and groups project work by user 
   assert.match(sidebar, /label: 'Share with users'/)
   assert.match(sidebar, /label: 'Connect'/)
   assert.match(sidebar, /Public feedback board/)
+  assert.match(sidebar, /label: 'Feedback form', icon: ClipboardPenLine/)
+  assert.match(sidebar, /label: 'Feedback inbox', icon: Inbox/)
   assert.doesNotMatch(sidebar, /label: 'Overview'/)
   assert.doesNotMatch(sidebar, /projectTab: 'home'/)
 })


### PR DESCRIPTION
## Change
- use a clipboard and pen for Feedback form
- use an inbox tray for Feedback inbox
- add focused source assertions

## Verification
- dashboard type-check
- product experience unit test: 7/7
- git diff --check

No E2E suite was run.