### PR TITLE
Overhaul dashboard surface hierarchy

### DIFF
--- a/packages/dashboard/src/app/(dashboard)/dashboard/boards/page.tsx
+++ b/packages/dashboard/src/app/(dashboard)/dashboard/boards/page.tsx
@@ -67,7 +67,7 @@ export default async function DashboardBoardsPage({
       </div>
 
       {!selectedProject ? (
-        <div className="border-y py-12 text-center">
+        <div className="rounded-xl border bg-card p-8 text-center shadow-[var(--shadow-card)] sm:p-12">
           <h2 className="text-lg font-semibold">Create a project first</h2>
           <p className="mt-2 text-sm text-muted-foreground">Each public page belongs to one project.</p>
           <Button className="mt-5" asChild><Link href="/projects/new">Create project</Link></Button>

--- a/packages/dashboard/src/app/(dashboard)/dashboard/page.tsx
+++ b/packages/dashboard/src/app/(dashboard)/dashboard/page.tsx
@@ -324,7 +324,7 @@ export default async function DashboardPage({
   return (
     <div className="animate-fade-in space-y-5">
       {/* ─── Header ───────────────────────────────────────── */}
-      <div className="grid gap-3 border-b pb-4 lg:grid-cols-[minmax(260px,1fr)_auto_minmax(220px,auto)] lg:items-center">
+      <div className="grid gap-4 rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6 lg:grid-cols-[minmax(260px,1fr)_auto_minmax(220px,auto)] lg:items-center">
         <div className="min-w-0">
           <h1 className="truncate text-2xl font-semibold tracking-[-0.035em] sm:text-3xl">
             Good {getGreeting()}, {displayName}
@@ -405,7 +405,7 @@ export default async function DashboardPage({
       </div>
 
       {total === 0 && primaryProject ? (
-        <div data-tour="dashboard-capabilities" className="flex flex-col gap-4 border-y border-primary/25 bg-primary/[0.04] px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+        <div data-tour="dashboard-capabilities" className="flex flex-col gap-4 rounded-xl border border-primary/25 bg-card p-5 shadow-[var(--shadow-card)] sm:flex-row sm:items-center sm:justify-between">
           <div className="flex min-w-0 gap-3">
             <Code2 className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
             <div>
@@ -500,7 +500,7 @@ export default async function DashboardPage({
       )}
 
       {/* ─── Stat Cards ───────────────────────────────────── */}
-      <div className="grid grid-cols-2 border-y border-foreground/10 sm:grid-cols-3 lg:grid-cols-6">
+      <div className="grid grid-cols-2 overflow-hidden rounded-xl border bg-card shadow-[var(--shadow-card)] sm:grid-cols-3 lg:grid-cols-6">
         {statCards.map((stat) => (
           <Link key={stat.id} href={stat.href} className={cn('block border-b border-r border-foreground/10 p-4 transition-colors hover:bg-muted/25 lg:border-b-0', stat.urgent && 'bg-amber-50/50 dark:bg-amber-950/15')}>
                 <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">

--- a/packages/dashboard/src/app/(dashboard)/feedback/feedback-project-scope.tsx
+++ b/packages/dashboard/src/app/(dashboard)/feedback/feedback-project-scope.tsx
@@ -22,7 +22,7 @@ export function FeedbackProjectScope({
   if (projects.length === 0) return null
 
   return (
-    <div className="border-y py-2.5">
+    <div className="rounded-xl border bg-card p-3 shadow-[var(--shadow-card)]">
       <div className="mb-2 px-0.5">
         <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">Project view</p>
         <p className="text-[11px] text-muted-foreground">Choose one project or include the whole workspace.</p>

--- a/packages/dashboard/src/app/(dashboard)/feedback/page.tsx
+++ b/packages/dashboard/src/app/(dashboard)/feedback/page.tsx
@@ -467,7 +467,7 @@ function FeedbackInboxInner() {
         />
 
         {showMoreFilters && (
-          <div className="space-y-3 border-y py-4">
+          <div className="space-y-3 rounded-xl border bg-[oklch(var(--surface-raised))] p-4">
             <div className="flex flex-wrap gap-1.5">
               {(['reviewed', 'in_progress', 'closed'] as FeedbackStatus[]).map((s) => <FilterPill key={s} active={status === s} onClick={() => updateParams({ status: status === s ? '' : s })}><span className={cn('h-1.5 w-1.5 rounded-full', statusMeta[s].dot)}/>{statusMeta[s].label}</FilterPill>)}
               {types.map((t) => <FilterPill key={t} active={type === t} onClick={() => updateParams({ type: type === t ? '' : t })}><TypeIcon type={t} className="h-3.5 w-3.5"/><span className="capitalize">{t}</span></FilterPill>)}

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/customize-tab.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/customize-tab.tsx
@@ -222,7 +222,7 @@ export function CustomizeTab({
 
   return (
     <div className="space-y-7">
-      <header className={`space-y-4 border-b pb-6 ${hasUnsavedChanges ? 'border-amber-400/60' : 'border-foreground/10'}`}>
+      <header className={`space-y-4 rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6 ${hasUnsavedChanges ? 'border-amber-400/60' : 'border-border/80'}`}>
           <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
             <div className="min-w-0 space-y-2">
               <div className="flex flex-wrap items-center gap-2">
@@ -299,14 +299,14 @@ export function CustomizeTab({
       )}
 
       <div className="grid gap-8 xl:grid-cols-[minmax(0,1fr)_420px]">
-        <Card data-tour="widget-settings" className="border-0 bg-transparent shadow-none">
-          <CardHeader className="border-b border-foreground/10 px-0 pb-5 pt-0">
+        <Card data-tour="widget-settings">
+          <CardHeader>
             <CardTitle className="text-lg">Widget settings</CardTitle>
             <CardDescription>
               Choose where feedback appears, then tune the form details below.
             </CardDescription>
           </CardHeader>
-          <CardContent className="space-y-7 px-0 pt-6">
+          <CardContent className="space-y-7">
             <div className="space-y-3">
               <div>
                 <p className="text-sm font-semibold text-foreground">Placement</p>
@@ -340,7 +340,7 @@ export function CustomizeTab({
                     type="button"
                     aria-pressed={embedMode === mode}
                     onClick={() => updateConfig('embedMode', mode)}
-                    className={`border-y p-4 text-left transition-colors ${
+                    className={`rounded-lg border p-4 text-left transition-colors ${
                       embedMode === mode
                         ? 'border-primary bg-primary/[0.06]'
                         : 'border-foreground/10 hover:bg-muted/25'
@@ -496,8 +496,8 @@ export function CustomizeTab({
           </CardContent>
         </Card>
 
-        <Card data-tour="widget-preview" className="overflow-hidden border-0 bg-muted/30 shadow-none xl:sticky xl:top-4 xl:max-h-[calc(100vh-2rem)] xl:overflow-y-auto">
-          <CardHeader className="border-b border-foreground/10">
+        <Card data-tour="widget-preview" className="xl:sticky xl:top-4 xl:max-h-[calc(100vh-2rem)] xl:overflow-y-auto">
+          <CardHeader>
             <CardTitle className="text-lg">Live form preview</CardTitle>
             <CardDescription>
               Placement, color, copy, and optional fields update as you edit.

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/install-tab.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/install-tab.tsx
@@ -17,6 +17,7 @@ import { Button } from '@/components/ui/button'
 import { CodeSnippet } from '@/components/code-snippet'
 import { CopyButton } from '@/components/copy-button'
 import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Bot, CheckCircle2, Code2, Loader2, RefreshCw, XCircle } from 'lucide-react'
 
 interface InstallTabProps {
@@ -321,17 +322,18 @@ export function FeedbacksWidgetScript() {
 
   return (
     <div className="space-y-8" data-tour="install-workspace">
-      <section className="grid gap-8 border-b border-foreground/10 pb-8 xl:grid-cols-[minmax(0,1fr)_360px]">
-        <div>
+      <section className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_360px]">
+        <Card>
+          <CardHeader>
           <div className="flex flex-wrap items-center gap-2 text-xs font-medium text-primary"><Code2 className="h-4 w-4" /> One shared connection</div>
-          <h2 className="mt-3 text-2xl font-semibold tracking-[-0.035em]">Install once. Keep the code unchanged.</h2>
+          <CardTitle className="mt-2 text-2xl tracking-[-0.035em]">Install once. Keep the code unchanged.</CardTitle>
           <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">
             This stable embed powers the feedback form and the product updates you show to users. Saved dashboard changes arrive remotely on the next page load.
           </p>
-
-          <div className="mt-6 divide-y border-y border-foreground/10">
+          </CardHeader>
+          <CardContent className="grid gap-3 sm:grid-cols-3">
               {installSteps.map((step, index) => (
-                <div key={step.title} className="flex gap-3 px-4 py-3">
+                <div key={step.title} className="flex gap-3 rounded-lg border bg-[oklch(var(--surface-raised))] p-4">
                   <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-foreground text-xs font-semibold text-background">
                     {index + 1}
                   </span>
@@ -341,15 +343,18 @@ export function FeedbacksWidgetScript() {
                   </div>
                 </div>
               ))}
-          </div>
-        </div>
+          </CardContent>
+        </Card>
 
-        <aside className="border-t border-foreground/10 pt-5 xl:border-l xl:border-t-0 xl:pl-6 xl:pt-0">
-              <div className="flex flex-wrap items-center justify-between gap-2">
-                <p className="text-xs font-semibold text-muted-foreground">Connection details</p>
+        <Card>
+          <CardHeader className="flex-row items-center justify-between space-y-0">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                <CardTitle className="text-base">Connection details</CardTitle>
+                </div>
                 <Badge variant="outline">{modeLabel}</Badge>
-              </div>
-              <div className="mt-5 grid gap-5 sm:grid-cols-2 xl:grid-cols-1">
+          </CardHeader>
+          <CardContent>
+              <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-1">
                 <div className="min-w-0">
                   <p className="text-xs font-medium text-muted-foreground">Project key</p>
                   {projectKey ? (
@@ -374,38 +379,41 @@ export function FeedbacksWidgetScript() {
                   <p className="mt-1 text-sm leading-5 text-muted-foreground">{verifyInstruction}</p>
                 </div>
               </div>
-        </aside>
+          </CardContent>
+        </Card>
       </section>
 
-      <section data-tour="install-snippet">
-        <header data-tour="install-snippet-header" className="flex flex-wrap items-end justify-between gap-4">
+      <Card data-tour="install-snippet">
+        <CardHeader data-tour="install-snippet-header" className="gap-4">
+          <div className="flex flex-wrap items-end justify-between gap-4">
           <div>
-            <h2 className="text-lg font-semibold">Choose where you are installing</h2>
+            <CardTitle className="text-lg">Choose where you are installing</CardTitle>
             <p className="mt-1 text-sm text-muted-foreground">
               Select your environment and add this once near the application root.
             </p>
           </div>
-          <div data-tour="install-platforms" className="flex flex-wrap gap-1 border-b" role="group" aria-label="Install platform">
+          </div>
+          <div data-tour="install-platforms" className="flex flex-wrap gap-1 rounded-lg bg-[oklch(var(--surface-raised))] p-1" role="group" aria-label="Install platform">
             {installTargets.map((target) => (
               <button
                 key={target.id}
                 type="button"
                 aria-pressed={activePlatform === target.id}
                 onClick={() => setActivePlatform(target.id)}
-                className={`min-h-9 border-b-2 px-3 text-sm font-medium transition-colors ${
+                className={`min-h-9 rounded-md px-3 text-sm font-medium transition-colors ${
                   activePlatform === target.id
-                    ? 'border-primary text-foreground'
-                    : 'border-transparent text-muted-foreground hover:text-foreground'
+                    ? 'bg-card text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:bg-card/60 hover:text-foreground'
                 }`}
               >
                 {target.label}
               </button>
             ))}
           </div>
-        </header>
+        </CardHeader>
 
-        <div className="mt-5 space-y-5">
-          <div className="flex flex-wrap items-start justify-between gap-3 border-y border-foreground/10 py-4">
+        <CardContent className="space-y-5">
+          <div className="flex flex-wrap items-start justify-between gap-3 rounded-lg border bg-[oklch(var(--surface-raised))] p-4">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div>
                 <p className="text-sm font-semibold text-foreground">{selectedTarget.title}</p>
@@ -458,7 +466,7 @@ export function FeedbacksWidgetScript() {
             </div>
           )}
 
-          <div className="divide-y border-y border-foreground/10">
+          <div className="divide-y overflow-hidden rounded-lg border bg-[oklch(var(--surface-raised))]">
             <div className="grid gap-1 px-4 py-3 md:grid-cols-[180px_minmax(0,1fr)]">
               <p className="text-sm font-medium text-foreground">Where this goes</p>
               <p className="text-sm leading-6 text-muted-foreground">{selectedTarget.placement}</p>
@@ -477,14 +485,14 @@ export function FeedbacksWidgetScript() {
             </div>
           </div>
 
-          <div className="flex items-start gap-3 bg-primary/[0.045] px-4 py-3 text-sm text-muted-foreground">
+          <div className="flex items-start gap-3 rounded-lg border border-primary/20 bg-primary/[0.055] px-4 py-3 text-sm text-muted-foreground">
             <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
             <p>After installation, change the button, fields, wording, placement, captcha, and user-facing product updates from the dashboard. <span className="font-medium text-foreground">You will not need a new snippet.</span></p>
           </div>
-        </div>
-      </section>
+        </CardContent>
+      </Card>
 
-      <details className="group rounded-xl border bg-card">
+      <details className="group rounded-xl border bg-card shadow-[var(--shadow-card)]">
         <summary className="flex cursor-pointer list-none flex-wrap items-start justify-between gap-3 px-6 py-5">
           <div>
             <div className="flex flex-wrap items-center gap-2">

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/project-flow-nav.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/project-flow-nav.tsx
@@ -84,7 +84,7 @@ export function SetupProgress({
   const nextAction = nextActionByStep[activeStep]
 
   return (
-    <nav aria-label="Setup steps" data-tour="setup-progress" className="border-b border-foreground/10 pb-6">
+    <nav aria-label="Setup steps" data-tour="setup-progress" className="rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
       <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
         <div className="min-w-0">
           <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-primary">
@@ -110,7 +110,7 @@ export function SetupProgress({
         </Link>
       </div>
 
-      <ol className="mt-5 grid grid-cols-3 border-y border-foreground/10">
+      <ol className="mt-5 grid grid-cols-3 overflow-hidden rounded-lg border border-foreground/10 bg-[oklch(var(--surface-raised))]">
         {steps.map((step, index) => {
           const current = activeStep === step.id
           const completed = index < activeIndex

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/project-home.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/project-home.tsx
@@ -2,13 +2,15 @@ import Link from 'next/link'
 import { ArrowRight, Check, Code2, FormInput, Megaphone } from 'lucide-react'
 import type { Project } from '@/lib/types'
 import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
 
 export function ProjectHome({ project }: { project: Project }) {
   const feedbackEnabled = project.settings?.widget_config?.feedbackEnabled !== false
 
   return (
-    <div className="animate-fade-in">
-      <header className="grid gap-5 border-b border-foreground/10 pb-7 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
+    <div className="animate-fade-in space-y-5">
+      <Card>
+      <CardHeader className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
         <div>
           <p className="text-sm font-medium text-primary">{project.name}</p>
           <h1 className="mt-2 text-3xl font-semibold tracking-[-0.04em]">Your product feedback loop</h1>
@@ -19,9 +21,10 @@ export function ProjectHome({ project }: { project: Project }) {
         <Button asChild>
           <Link href={`/projects/${project.id}/install`}>Install or verify connection <ArrowRight className="ml-2 h-4 w-4" /></Link>
         </Button>
-      </header>
+      </CardHeader>
+      </Card>
 
-      <div className="grid border-b border-foreground/10 lg:grid-cols-2">
+      <div className="grid gap-5 lg:grid-cols-2">
         <ProductLane
           icon={<FormInput className="h-5 w-5" />}
           direction="Users → your team"
@@ -38,11 +41,11 @@ export function ProjectHome({ project }: { project: Project }) {
           description="Create a polished “What’s new” popup that appears inside your product when there is something worth announcing."
           href={`/projects/${project.id}/release-notes`}
           action="Manage updates for users"
-          className="border-t border-foreground/10 lg:border-l lg:border-t-0"
         />
       </div>
 
-      <section className="grid gap-6 py-7 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
+      <Card>
+      <CardContent className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
         <div className="flex gap-4">
           <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-foreground text-background"><Code2 className="h-4 w-4" /></span>
           <div>
@@ -53,7 +56,8 @@ export function ProjectHome({ project }: { project: Project }) {
         <ol className="flex flex-wrap gap-x-5 gap-y-2 text-xs text-muted-foreground">
           {['Copy embed', 'Verify one test', 'Manage remotely'].map((label) => <li key={label} className="inline-flex items-center gap-1.5"><Check className="h-3.5 w-3.5 text-primary" />{label}</li>)}
         </ol>
-      </section>
+      </CardContent>
+      </Card>
     </div>
   )
 }
@@ -69,7 +73,8 @@ function ProductLane({ icon, direction, title, description, status, href, action
   className?: string
 }) {
   return (
-    <section className={`group py-8 lg:px-8 lg:first:pl-0 ${className}`}>
+    <Card className={`group ${className}`}>
+      <CardContent>
       <div className="flex items-center justify-between gap-4">
         <span className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">{icon}</span>
         {status && <span className="inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground"><span className="h-1.5 w-1.5 rounded-full bg-primary" />{status}</span>}
@@ -80,6 +85,7 @@ function ProductLane({ icon, direction, title, description, status, href, action
       <Link href={href} className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-foreground transition-colors hover:text-primary">
         {action}<ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
       </Link>
-    </section>
+      </CardContent>
+    </Card>
   )
 }

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/project-verify-client.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/project-verify-client.tsx
@@ -84,7 +84,7 @@ export function ProjectVerifyClient({
       <SetupProgress projectId={projectId} activeStep="verify" />
 
       {verifiedFeedbackId && (
-        <div className="flex flex-col gap-4 border-y border-primary/35 bg-primary/[0.055] px-4 py-4 sm:flex-row sm:items-center sm:justify-between" role="status">
+        <div className="flex flex-col gap-4 rounded-xl border border-primary/35 bg-card p-5 shadow-[var(--shadow-card)] sm:flex-row sm:items-center sm:justify-between" role="status">
           <div className="flex min-w-0 gap-3">
             <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
             <div>
@@ -103,7 +103,7 @@ export function ProjectVerifyClient({
         </div>
       )}
 
-      <header data-tour="verify-guide" className="flex flex-wrap items-end justify-between gap-4 border-b border-foreground/10 pb-6">
+      <header data-tour="verify-guide" className="flex flex-wrap items-end justify-between gap-4 rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
         <div>
           <h1 className="text-2xl font-semibold tracking-[-0.035em]">Send one test. Know the connection works.</h1>
           <p className="mt-1 max-w-3xl text-sm leading-6 text-muted-foreground">
@@ -120,15 +120,15 @@ export function ProjectVerifyClient({
         </div>
       </header>
 
-      <div className="grid gap-8 lg:grid-cols-[300px_minmax(0,1fr)]">
-        <aside className="lg:border-r lg:border-foreground/10 lg:pr-7">
+      <div className="grid gap-5 lg:grid-cols-[300px_minmax(0,1fr)]">
+        <aside className="rounded-xl border bg-card p-5 shadow-[var(--shadow-card)]">
             <div className="flex items-center gap-2">
               <Badge variant="secondary">Saved config</Badge>
               <Badge variant="outline">{modeLabel} mode</Badge>
             </div>
             <h2 className="mt-5 text-lg font-semibold">Three quick checks</h2>
             <p className="mt-1 text-sm text-muted-foreground">This hosted page tests your saved form and inbox path.</p>
-          <ol className="mt-5 divide-y border-y border-foreground/10 text-sm text-muted-foreground">
+          <ol className="mt-5 divide-y overflow-hidden rounded-lg border bg-[oklch(var(--surface-raised))] px-4 text-sm text-muted-foreground">
             <li className="grid grid-cols-[24px_1fr] gap-2 py-3">
               <span className="font-medium text-foreground">1</span><span>Find the form here. {verifyInstruction}</span>
             </li>
@@ -147,7 +147,7 @@ export function ProjectVerifyClient({
             </div>
         </aside>
 
-        <section className="min-w-0">
+        <section className="min-w-0 overflow-hidden rounded-xl border bg-card shadow-[var(--shadow-card)]">
             <div className="bg-muted/25 p-5 sm:p-7">
               <div className="max-w-xl space-y-3">
                 <p className="text-xs font-medium text-primary">Live saved configuration</p>

--- a/packages/dashboard/src/app/(dashboard)/projects/new/page.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/new/page.tsx
@@ -10,6 +10,7 @@ import { Check, Loader2, ArrowLeft, ArrowRight } from 'lucide-react'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
 import { DEFAULT_PROJECT_ICON, PROJECT_ICONS } from '@/lib/project-icons'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
 
 const productChoices = [
   { value: 'feedback', label: 'Feedback form', body: 'Let users send bugs and ideas.' },
@@ -99,13 +100,15 @@ export default function NewProjectPage() {
         <ArrowLeft className="h-4 w-4" /> Back to projects
       </Link>
 
-      <header className="mt-8">
+      <Card className="mt-6">
+      <CardHeader>
         <p className="text-xs font-semibold text-primary">New project</p>
         <h1 className="mt-3 text-3xl font-semibold tracking-[-0.035em]">Name your app or website</h1>
         <p className="mt-3 max-w-md text-sm leading-6 text-muted-foreground">That is all we need to start. You will make the feedback form on the next screen.</p>
-      </header>
+      </CardHeader>
 
-      <form data-tour="project-create-form" onSubmit={handleSubmit} className="mt-8 space-y-5 border-t pt-7">
+      <CardContent>
+      <form data-tour="project-create-form" onSubmit={handleSubmit} className="space-y-5">
             <div className="space-y-2">
               <Label htmlFor="name">App or website name</Label>
               <Input
@@ -123,7 +126,7 @@ export default function NewProjectPage() {
               </p>
             </div>
 
-            <details className="border-y">
+            <details className="overflow-hidden rounded-lg border bg-[oklch(var(--surface-raised))] px-4">
               <summary className="cursor-pointer py-3 text-sm font-medium text-muted-foreground hover:text-foreground">
                 Start with something else <span className="font-normal">· {productChoices.find((choice) => choice.value === goal)?.label}</span>
               </summary>
@@ -140,7 +143,7 @@ export default function NewProjectPage() {
               </fieldset>
             </details>
 
-            <details className="border-b">
+            <details className="overflow-hidden rounded-lg border bg-[oklch(var(--surface-raised))] px-4">
               <summary className="cursor-pointer py-3 text-sm font-medium text-muted-foreground hover:text-foreground">
                 Add an icon or domain <span className="font-normal">· optional</span>
               </summary>
@@ -214,6 +217,8 @@ export default function NewProjectPage() {
             </Button>
             <p className="text-center text-xs leading-5 text-muted-foreground">Next: make the form, add one code block, then send a test.</p>
       </form>
+      </CardContent>
+      </Card>
     </div>
   )
 }

--- a/packages/dashboard/src/app/(dashboard)/projects/page.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/page.tsx
@@ -40,7 +40,7 @@ export default async function ProjectsPage() {
 
   return (
     <div data-tour="project-surface" className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
         <div>
           <h1 className="text-2xl font-bold">Projects</h1>
           {billingSummary && (
@@ -100,7 +100,7 @@ export default async function ProjectsPage() {
           </CardContent>
         </Card>
       ) : (
-        <div className="overflow-hidden rounded-xl border bg-card">
+        <div className="overflow-hidden rounded-xl border bg-card shadow-[var(--shadow-card)]">
           {(projects as Project[]).map((project) => (
             <Link
               key={project.id}

--- a/packages/dashboard/src/app/(dashboard)/settings/page.tsx
+++ b/packages/dashboard/src/app/(dashboard)/settings/page.tsx
@@ -158,7 +158,7 @@ export default function SettingsPage() {
 
   return (
     <div className="mx-auto max-w-2xl space-y-8">
-      <header className="border-b pb-5">
+      <header className="rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
         <p className="text-xs font-semibold text-primary">Your account</p>
         <h1 className="mt-2 text-2xl font-semibold tracking-[-0.03em]">Settings</h1>
         <p className="mt-2 text-sm text-muted-foreground">Manage your profile, alerts, theme, and account.</p>

--- a/packages/dashboard/src/app/(dashboard)/tutorials/tutorial-center.tsx
+++ b/packages/dashboard/src/app/(dashboard)/tutorials/tutorial-center.tsx
@@ -56,7 +56,7 @@ export function TutorialCenter({
 
   return (
     <div className="mx-auto max-w-5xl space-y-6">
-      <div className="max-w-2xl">
+      <div className="max-w-2xl rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
         <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-primary">Tutorials</p>
         <h1 className="mt-2 text-2xl font-bold">Learn one job at a time</h1>
         <p className="mt-2 text-sm leading-6 text-muted-foreground">
@@ -64,7 +64,7 @@ export function TutorialCenter({
         </p>
       </div>
 
-      <div className="flex flex-col gap-3 border-y py-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-3 rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:flex-row sm:items-center sm:justify-between">
         <div>
           <p className="text-sm font-semibold">Your progress</p>
           <p className="mt-1 text-sm text-muted-foreground">{completed} of {GUIDED_TUTORIALS.length} tutorials completed</p>
@@ -85,7 +85,7 @@ export function TutorialCenter({
           const href = tutorialHref(tutorial.id, tutorial.steps[0].href, defaultProjectId)
 
           return (
-            <article key={tutorial.id} className="flex min-h-48 flex-col rounded-lg border bg-card p-4">
+            <article key={tutorial.id} className="flex min-h-48 flex-col rounded-xl border bg-card p-5 shadow-[var(--shadow-card)]">
               <div className="flex items-start justify-between gap-3">
                 <span className="flex h-9 w-9 items-center justify-center rounded-md border bg-background text-primary">
                   <Icon className="h-4 w-4" />

--- a/packages/dashboard/src/app/globals.css
+++ b/packages/dashboard/src/app/globals.css
@@ -9,10 +9,10 @@
     --foreground: 0.205 0.012 105;
     /* Tonal elevation: raised surfaces get gently deeper in light mode. */
     --surface-sidebar: 0.97 0.008 105;
-    --surface-raised: 0.965 0.01 105;
-    --surface-overlay: 0.95 0.012 105;
+    --surface-raised: 0.985 0.008 105;
+    --surface-overlay: 0.995 0.006 105;
     --surface-selected: 0.925 0.028 120;
-    --card: 0.975 0.007 105;
+    --card: 0.995 0.004 105;
     --card-foreground: 0.205 0.012 105;
     --popover: 0.95 0.012 105;
     --popover-foreground: 0.205 0.012 105;
@@ -37,14 +37,14 @@
   }
 
   .dark {
-    --background: 0.155 0.009 105;
+    --background: 0.135 0.009 105;
     --foreground: 0.94 0.009 105;
     /* Tonal elevation reverses in dark mode: higher surfaces become lighter. */
-    --surface-sidebar: 0.175 0.01 105;
-    --surface-raised: 0.205 0.011 105;
-    --surface-overlay: 0.235 0.012 105;
-    --surface-selected: 0.26 0.035 120;
-    --card: 0.19 0.01 105;
+    --surface-sidebar: 0.165 0.01 105;
+    --surface-raised: 0.225 0.011 105;
+    --surface-overlay: 0.255 0.012 105;
+    --surface-selected: 0.275 0.035 120;
+    --card: 0.195 0.01 105;
     --card-foreground: 0.94 0.009 105;
     --popover: 0.22 0.011 105;
     --popover-foreground: 0.94 0.009 105;
@@ -115,6 +115,11 @@
   --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
   --shadow-card: 0 1px 2px rgb(15 18 13 / 0.04), 0 8px 28px rgb(15 18 13 / 0.035);
   --shadow-float: 0 20px 60px rgb(8 12 7 / 0.16);
+}
+
+.dark {
+  --shadow-card: 0 0 0 1px rgb(255 255 255 / 0.025), 0 14px 36px rgb(0 0 0 / 0.2);
+  --shadow-float: 0 24px 72px rgb(0 0 0 / 0.4);
 }
 
 /* ─── Keyframes ───────────────────────────────────────────────────────────── */

--- a/packages/dashboard/src/components/product-updates/ProductUpdatesTab.tsx
+++ b/packages/dashboard/src/components/product-updates/ProductUpdatesTab.tsx
@@ -1,164 +1,226 @@
-'use client'
+"use client";
 
-import * as React from 'react'
-import { useRouter } from 'next/navigation'
-import { Archive, CalendarClock, Eye, Pencil, Plus, RotateCcw, Settings2, Trash2, X } from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { Textarea } from '@/components/ui/textarea'
-import { toast } from '@/hooks/use-toast'
-import { UpdatesOnboarding } from './UpdatesOnboarding'
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import {
+  Archive,
+  CalendarClock,
+  Eye,
+  Pencil,
+  Plus,
+  RotateCcw,
+  Settings2,
+  Trash2,
+  X,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { toast } from "@/hooks/use-toast";
+import { UpdatesOnboarding } from "./UpdatesOnboarding";
 
 type Update = {
-  id: string
-  status: 'draft' | 'published' | 'archived'
-  version_label: string | null
-  title: string
-  summary: string
-  highlights: string[]
-  cta_label: string | null
-  cta_url: string | null
-  imageUrl?: string
-  published_at: string | null
-  expires_at: string | null
-  metrics: { impressions: number; dismissals: number; ctaClicks: number }
-}
+  id: string;
+  status: "draft" | "published" | "archived";
+  version_label: string | null;
+  title: string;
+  summary: string;
+  highlights: string[];
+  cta_label: string | null;
+  cta_url: string | null;
+  imageUrl?: string;
+  published_at: string | null;
+  expires_at: string | null;
+  metrics: { impressions: number; dismissals: number; ctaClicks: number };
+};
 
 type Settings = {
-  enabled: boolean
-  autoShow: boolean
-  displayDelayMs: number
-  theme: 'auto' | 'light' | 'dark'
-  accentColor: string
-  includePaths: string[]
-  excludePaths: string[]
-  showPoweredBy: boolean
-}
+  enabled: boolean;
+  autoShow: boolean;
+  displayDelayMs: number;
+  theme: "auto" | "light" | "dark";
+  accentColor: string;
+  includePaths: string[];
+  excludePaths: string[];
+  showPoweredBy: boolean;
+};
 
 type Entitlements = {
-  scheduling: boolean
-  analyticsDays: number
-  activeLimit: number | null
-  customBranding: boolean
-}
+  scheduling: boolean;
+  analyticsDays: number;
+  activeLimit: number | null;
+  customBranding: boolean;
+};
 
 type FormValues = {
-  versionLabel: string
-  title: string
-  summary: string
-  highlights: string
-  ctaLabel: string
-  ctaUrl: string
-  expiresAt: string
-}
+  versionLabel: string;
+  title: string;
+  summary: string;
+  highlights: string;
+  ctaLabel: string;
+  ctaUrl: string;
+  expiresAt: string;
+};
 
-const blankForm: FormValues = { versionLabel: '', title: '', summary: '', highlights: '', ctaLabel: '', ctaUrl: '', expiresAt: '' }
+const blankForm: FormValues = {
+  versionLabel: "",
+  title: "",
+  summary: "",
+  highlights: "",
+  ctaLabel: "",
+  ctaUrl: "",
+  expiresAt: "",
+};
 
 function toForm(update: Update): FormValues {
   return {
-    versionLabel: update.version_label || '',
+    versionLabel: update.version_label || "",
     title: update.title,
     summary: update.summary,
-    highlights: update.highlights.join('\n'),
-    ctaLabel: update.cta_label || '',
-    ctaUrl: update.cta_url || '',
+    highlights: update.highlights.join("\n"),
+    ctaLabel: update.cta_label || "",
+    ctaUrl: update.cta_url || "",
     expiresAt: localDateTime(update.expires_at),
-  }
+  };
 }
 
 function localDateTime(iso: string | null) {
-  if (!iso) return ''
-  const date = new Date(iso)
-  const offset = date.getTimezoneOffset() * 60_000
-  return new Date(date.getTime() - offset).toISOString().slice(0, 16)
+  if (!iso) return "";
+  const date = new Date(iso);
+  const offset = date.getTimezoneOffset() * 60_000;
+  return new Date(date.getTime() - offset).toISOString().slice(0, 16);
 }
 
 function stateLabel(update: Update) {
-  if (update.status === 'archived') return 'Archived'
-  if (update.status === 'draft') return 'Draft'
-  if (update.expires_at && new Date(update.expires_at) <= new Date()) return 'Expired'
-  if (update.published_at && new Date(update.published_at) > new Date()) return 'Scheduled'
-  return 'Live'
+  if (update.status === "archived") return "Archived";
+  if (update.status === "draft") return "Draft";
+  if (update.expires_at && new Date(update.expires_at) <= new Date())
+    return "Expired";
+  if (update.published_at && new Date(update.published_at) > new Date())
+    return "Scheduled";
+  return "Live";
 }
 
-type Modules = { feedback: boolean; updates: boolean }
-type EmbedStatus = { state: 'not_detected' | 'connected' | 'stale'; lastSeenAt: string | null }
+type Modules = { feedback: boolean; updates: boolean };
+type EmbedStatus = {
+  state: "not_detected" | "connected" | "stale";
+  lastSeenAt: string | null;
+};
 
-export function ProductUpdatesTab({ projectId, projectKey, view = 'overview', updateId }: { projectId: string; projectKey: string | null; view?: 'overview' | 'composer' | 'settings'; updateId?: string }) {
-  const router = useRouter()
-  const [updates, setUpdates] = React.useState<Update[]>([])
-  const [settings, setSettings] = React.useState<Settings | null>(null)
-  const [entitlements, setEntitlements] = React.useState<Entitlements | null>(null)
-  const [form, setForm] = React.useState<FormValues>(blankForm)
-  const [selectedId, setSelectedId] = React.useState<string | null>(null)
-  const [publishAt, setPublishAt] = React.useState('')
-  const [previewMobile, setPreviewMobile] = React.useState(false)
-  const [previewDark, setPreviewDark] = React.useState(false)
-  const [loading, setLoading] = React.useState(true)
-  const [loadError, setLoadError] = React.useState<string | null>(null)
-  const [saving, setSaving] = React.useState(false)
-  const [modules, setModules] = React.useState<Modules | null>(null)
-  const [embedStatus, setEmbedStatus] = React.useState<EmbedStatus | null>(null)
-  const [privateTestOpen, setPrivateTestOpen] = React.useState(false)
-  const [publishConfirmation, setPublishConfirmation] = React.useState<'published' | 'scheduled' | null>(null)
-  const selected = updates.find((update) => update.id === selectedId) || null
+export function ProductUpdatesTab({
+  projectId,
+  projectKey,
+  view = "overview",
+  updateId,
+}: {
+  projectId: string;
+  projectKey: string | null;
+  view?: "overview" | "composer" | "settings";
+  updateId?: string;
+}) {
+  const router = useRouter();
+  const [updates, setUpdates] = React.useState<Update[]>([]);
+  const [settings, setSettings] = React.useState<Settings | null>(null);
+  const [entitlements, setEntitlements] = React.useState<Entitlements | null>(
+    null,
+  );
+  const [form, setForm] = React.useState<FormValues>(blankForm);
+  const [selectedId, setSelectedId] = React.useState<string | null>(null);
+  const [publishAt, setPublishAt] = React.useState("");
+  const [previewMobile, setPreviewMobile] = React.useState(false);
+  const [previewDark, setPreviewDark] = React.useState(false);
+  const [loading, setLoading] = React.useState(true);
+  const [loadError, setLoadError] = React.useState<string | null>(null);
+  const [saving, setSaving] = React.useState(false);
+  const [modules, setModules] = React.useState<Modules | null>(null);
+  const [embedStatus, setEmbedStatus] = React.useState<EmbedStatus | null>(
+    null,
+  );
+  const [privateTestOpen, setPrivateTestOpen] = React.useState(false);
+  const [publishConfirmation, setPublishConfirmation] = React.useState<
+    "published" | "scheduled" | null
+  >(null);
+  const selected = updates.find((update) => update.id === selectedId) || null;
 
   const load = React.useCallback(async () => {
-    setLoading(true)
-    setLoadError(null)
+    setLoading(true);
+    setLoadError(null);
     try {
       const [response, modulesResponse, statusResponse] = await Promise.all([
-        fetch(`/api/projects/${projectId}/updates`, { cache: 'no-store' }),
-        fetch(`/api/projects/${projectId}/modules`, { cache: 'no-store' }),
-        fetch(`/api/projects/${projectId}/embed-status`, { cache: 'no-store' }),
-      ])
+        fetch(`/api/projects/${projectId}/updates`, { cache: "no-store" }),
+        fetch(`/api/projects/${projectId}/modules`, { cache: "no-store" }),
+        fetch(`/api/projects/${projectId}/embed-status`, { cache: "no-store" }),
+      ]);
       const [data, moduleData, statusData] = await Promise.all([
         response.json(),
         modulesResponse.json(),
         statusResponse.json().catch(() => null),
-      ])
-      if (!response.ok) throw new Error(data.error || 'Unable to load updates for users.')
-      if (!modulesResponse.ok) throw new Error(moduleData.error || 'Unable to load product settings.')
-      setUpdates(data.updates || [])
-      setSettings(data.settings)
-      setEntitlements(data.entitlements)
-      setModules(moduleData)
-      setEmbedStatus(statusResponse.ok && statusData?.state
-        ? statusData
-        : { state: 'not_detected', lastSeenAt: null })
+      ]);
+      if (!response.ok)
+        throw new Error(data.error || "Unable to load updates for users.");
+      if (!modulesResponse.ok)
+        throw new Error(moduleData.error || "Unable to load product settings.");
+      setUpdates(data.updates || []);
+      setSettings(data.settings);
+      setEntitlements(data.entitlements);
+      setModules(moduleData);
+      setEmbedStatus(
+        statusResponse.ok && statusData?.state
+          ? statusData
+          : { state: "not_detected", lastSeenAt: null },
+      );
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Try again.'
-      setLoadError(message)
-      toast({ title: 'Could not load updates for users', description: message, variant: 'destructive' })
+      const message = error instanceof Error ? error.message : "Try again.";
+      setLoadError(message);
+      toast({
+        title: "Could not load updates for users",
+        description: message,
+        variant: "destructive",
+      });
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }, [projectId])
+  }, [projectId]);
 
-  React.useEffect(() => { void load() }, [load])
+  React.useEffect(() => {
+    void load();
+  }, [load]);
   React.useEffect(() => {
     void fetch(`/api/projects/${projectId}/activation`, {
-      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ event: 'updates_nav_opened' }),
-    }).catch(() => undefined)
-  }, [projectId])
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ event: "updates_nav_opened" }),
+    }).catch(() => undefined);
+  }, [projectId]);
   React.useEffect(() => {
-    if (view === 'composer' && updateId && updates.some((update) => update.id === updateId)) edit(updates.find((update) => update.id === updateId)!)
-  }, [updateId, updates, view])
+    if (
+      view === "composer" &&
+      updateId &&
+      updates.some((update) => update.id === updateId)
+    )
+      edit(updates.find((update) => update.id === updateId)!);
+  }, [updateId, updates, view]);
 
-  const updateForm = (key: keyof FormValues, value: string) => setForm((current) => ({ ...current, [key]: value }))
+  const updateForm = (key: keyof FormValues, value: string) =>
+    setForm((current) => ({ ...current, [key]: value }));
 
   function edit(update: Update) {
-    setSelectedId(update.id)
-    setForm(toForm(update))
-    setPublishAt(localDateTime(update.published_at))
+    setSelectedId(update.id);
+    setForm(toForm(update));
+    setPublishAt(localDateTime(update.published_at));
   }
 
   async function request(url: string, options?: RequestInit) {
-    const response = await fetch(url, options)
-    const data = await response.json().catch(() => null)
-    if (!response.ok) throw new Error(data?.error || Object.values(data?.errors || {}).join(' ') || 'Request failed.')
-    return data
+    const response = await fetch(url, options);
+    const data = await response.json().catch(() => null);
+    if (!response.ok)
+      throw new Error(
+        data?.error ||
+          Object.values(data?.errors || {}).join(" ") ||
+          "Request failed.",
+      );
+    return data;
   }
 
   function formBody() {
@@ -166,228 +228,1059 @@ export function ProductUpdatesTab({ projectId, projectKey, view = 'overview', up
       versionLabel: form.versionLabel,
       title: form.title,
       summary: form.summary,
-      highlights: form.highlights.split('\n').map((item) => item.trim()).filter(Boolean),
+      highlights: form.highlights
+        .split("\n")
+        .map((item) => item.trim())
+        .filter(Boolean),
       ctaLabel: form.ctaLabel,
       ctaUrl: form.ctaUrl,
-    }
+    };
   }
 
   async function saveDraft() {
-    setSaving(true)
+    setSaving(true);
     try {
-      const body = JSON.stringify(formBody())
+      const body = JSON.stringify(formBody());
       const data = selected
-        ? await request(`/api/projects/${projectId}/updates/${selected.id}`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body })
-        : await request(`/api/projects/${projectId}/updates`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body })
-      if (!selected && data.update?.id) setSelectedId(data.update.id)
-      toast({ title: selected ? 'Update saved' : 'Draft saved' })
-      await load()
+        ? await request(`/api/projects/${projectId}/updates/${selected.id}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body,
+          })
+        : await request(`/api/projects/${projectId}/updates`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body,
+          });
+      if (!selected && data.update?.id) setSelectedId(data.update.id);
+      toast({ title: selected ? "Update saved" : "Draft saved" });
+      await load();
     } catch (error) {
-      toast({ title: 'Could not save draft', description: error instanceof Error ? error.message : 'Check the fields and try again.', variant: 'destructive' })
+      toast({
+        title: "Could not save draft",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Check the fields and try again.",
+        variant: "destructive",
+      });
     } finally {
-      setSaving(false)
+      setSaving(false);
     }
   }
 
   async function publish(scheduled = false) {
-    if (!selected) return
+    if (!selected) return;
     if (scheduled && !publishAt) {
-      toast({ title: 'Choose a publication time', description: 'Scheduling requires a future local date and time.', variant: 'destructive' })
-      return
+      toast({
+        title: "Choose a publication time",
+        description: "Scheduling requires a future local date and time.",
+        variant: "destructive",
+      });
+      return;
     }
-    setSaving(true)
+    setSaving(true);
     try {
-      await request(`/api/projects/${projectId}/updates/${selected.id}/publish`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          publishedAt: scheduled ? new Date(publishAt).toISOString() : undefined,
-          expiresAt: form.expiresAt ? new Date(form.expiresAt).toISOString() : undefined,
-        }),
-      })
-      toast({ title: scheduled ? 'Update scheduled' : 'Update published', description: 'It is usually visible in the widget within a minute.' })
-      setPublishConfirmation(scheduled ? 'scheduled' : 'published')
-      await load()
+      await request(
+        `/api/projects/${projectId}/updates/${selected.id}/publish`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            publishedAt: scheduled
+              ? new Date(publishAt).toISOString()
+              : undefined,
+            expiresAt: form.expiresAt
+              ? new Date(form.expiresAt).toISOString()
+              : undefined,
+          }),
+        },
+      );
+      toast({
+        title: scheduled ? "Update scheduled" : "Update published",
+        description: "It is usually visible in the widget within a minute.",
+      });
+      setPublishConfirmation(scheduled ? "scheduled" : "published");
+      await load();
     } catch (error) {
-      toast({ title: 'Could not publish release note', description: error instanceof Error ? error.message : 'Try again.', variant: 'destructive' })
+      toast({
+        title: "Could not publish release note",
+        description: error instanceof Error ? error.message : "Try again.",
+        variant: "destructive",
+      });
     } finally {
-      setSaving(false)
+      setSaving(false);
     }
   }
 
   async function uploadImage(file: File | undefined) {
-    if (!file || !selected) return
-    setSaving(true)
+    if (!file || !selected) return;
+    setSaving(true);
     try {
-      await request(`/api/projects/${projectId}/updates/${selected.id}/image`, { method: 'POST', headers: { 'Content-Type': file.type }, body: file })
-      toast({ title: 'Image uploaded' })
-      await load()
+      await request(`/api/projects/${projectId}/updates/${selected.id}/image`, {
+        method: "POST",
+        headers: { "Content-Type": file.type },
+        body: file,
+      });
+      toast({ title: "Image uploaded" });
+      await load();
     } catch (error) {
-      toast({ title: 'Could not upload image', description: error instanceof Error ? error.message : 'Use JPEG, PNG, or WebP under 2 MB.', variant: 'destructive' })
+      toast({
+        title: "Could not upload image",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Use JPEG, PNG, or WebP under 2 MB.",
+        variant: "destructive",
+      });
     } finally {
-      setSaving(false)
+      setSaving(false);
     }
   }
 
   async function saveSettings(next: Settings) {
-    setSettings(next)
+    setSettings(next);
     try {
-      const result = await request(`/api/projects/${projectId}/updates/settings`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(next) })
-      setSettings(result)
+      const result = await request(
+        `/api/projects/${projectId}/updates/settings`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(next),
+        },
+      );
+      setSettings(result);
     } catch (error) {
-      toast({ title: 'Could not save settings', description: error instanceof Error ? error.message : 'Try again.', variant: 'destructive' })
-      void load()
+      toast({
+        title: "Could not save settings",
+        description: error instanceof Error ? error.message : "Try again.",
+        variant: "destructive",
+      });
+      void load();
     }
   }
 
   function openPrivateTest() {
-    setPrivateTestOpen(true)
+    setPrivateTestOpen(true);
     void fetch(`/api/projects/${projectId}/activation`, {
-      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ event: 'updates_private_test_opened' }),
-    }).catch(() => undefined)
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ event: "updates_private_test_opened" }),
+    }).catch(() => undefined);
   }
 
-  if (loading) return <div className="py-8 text-sm text-muted-foreground">Loading updates for users…</div>
-  if (loadError) return <div className="mx-auto max-w-2xl py-8"><h2 className="text-xl font-semibold">Updates for users could not load</h2><p className="mt-2 text-sm text-muted-foreground">{loadError}</p><Button className="mt-5" onClick={() => void load()}>Try again</Button></div>
-  if (!modules || !embedStatus || !settings) return null
-  if (!settings.enabled || (updates.length === 0 && embedStatus.state !== 'connected')) {
-    return <UpdatesOnboarding projectId={projectId} projectKey={projectKey} modules={modules} embedState={embedStatus.state} onRefresh={load} />
+  if (loading)
+    return (
+      <div className="py-8 text-sm text-muted-foreground">
+        Loading updates for users…
+      </div>
+    );
+  if (loadError)
+    return (
+      <div className="mx-auto max-w-2xl py-8">
+        <h2 className="text-xl font-semibold">
+          Updates for users could not load
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">{loadError}</p>
+        <Button className="mt-5" onClick={() => void load()}>
+          Try again
+        </Button>
+      </div>
+    );
+  if (!modules || !embedStatus || !settings) return null;
+  if (
+    !settings.enabled ||
+    (updates.length === 0 && embedStatus.state !== "connected")
+  ) {
+    return (
+      <UpdatesOnboarding
+        projectId={projectId}
+        projectKey={projectKey}
+        modules={modules}
+        embedState={embedStatus.state}
+        onRefresh={load}
+      />
+    );
   }
-  if (view === 'settings') {
-    return <UpdatesSettings settings={settings} entitlements={entitlements} onSave={saveSettings} onBack={() => router.push(`/projects/${projectId}/release-notes`)} />
+  if (view === "settings") {
+    return (
+      <UpdatesSettings
+        settings={settings}
+        entitlements={entitlements}
+        onSave={saveSettings}
+        onBack={() => router.push(`/projects/${projectId}/release-notes`)}
+      />
+    );
   }
-  if (view === 'overview') {
-    return <UpdatesOverview
-      updates={updates}
-      onNew={() => router.push(`/projects/${projectId}/release-notes/new`)}
-      onEdit={(id) => router.push(`/projects/${projectId}/release-notes/${id}`)}
-      onSettings={() => router.push(`/projects/${projectId}/release-notes/settings`)}
-      onAction={async (update, action) => {
-        if (action === 'delete' && !window.confirm(`Delete “${update.title}”? This cannot be undone.`)) return
-        setSaving(true)
-        try {
-          await request(`/api/projects/${projectId}/updates/${update.id}${action === 'archive' || action === 'restore' ? `/${action}` : ''}`, {
-            method: action === 'delete' ? 'DELETE' : 'POST',
-          })
-          toast({ title: action === 'delete' ? 'Update deleted' : action === 'archive' ? 'Update archived' : 'Update restored' })
-          await load()
-        } catch (error) {
-          toast({ title: `Could not ${action} update`, description: error instanceof Error ? error.message : 'Try again.', variant: 'destructive' })
-        } finally {
-          setSaving(false)
+  if (view === "overview") {
+    return (
+      <UpdatesOverview
+        updates={updates}
+        onNew={() => router.push(`/projects/${projectId}/release-notes/new`)}
+        onEdit={(id) =>
+          router.push(`/projects/${projectId}/release-notes/${id}`)
         }
-      }}
-      busy={saving}
-    />
+        onSettings={() =>
+          router.push(`/projects/${projectId}/release-notes/settings`)
+        }
+        onAction={async (update, action) => {
+          if (
+            action === "delete" &&
+            !window.confirm(`Delete “${update.title}”? This cannot be undone.`)
+          )
+            return;
+          setSaving(true);
+          try {
+            await request(
+              `/api/projects/${projectId}/updates/${update.id}${action === "archive" || action === "restore" ? `/${action}` : ""}`,
+              {
+                method: action === "delete" ? "DELETE" : "POST",
+              },
+            );
+            toast({
+              title:
+                action === "delete"
+                  ? "Update deleted"
+                  : action === "archive"
+                    ? "Update archived"
+                    : "Update restored",
+            });
+            await load();
+          } catch (error) {
+            toast({
+              title: `Could not ${action} update`,
+              description:
+                error instanceof Error ? error.message : "Try again.",
+              variant: "destructive",
+            });
+          } finally {
+            setSaving(false);
+          }
+        }}
+        busy={saving}
+      />
+    );
   }
 
   if (updateId && !updates.some((update) => update.id === updateId)) {
-    return <div className="mx-auto max-w-2xl py-8"><h2 className="text-xl font-semibold">Product update not found</h2><p className="mt-2 text-sm text-muted-foreground">It may have been deleted, or the link may be out of date.</p><Button className="mt-5" variant="outline" onClick={() => router.push(`/projects/${projectId}/release-notes`)}>Return to updates for users</Button></div>
+    return (
+      <div className="mx-auto max-w-2xl py-8">
+        <h2 className="text-xl font-semibold">Product update not found</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          It may have been deleted, or the link may be out of date.
+        </p>
+        <Button
+          className="mt-5"
+          variant="outline"
+          onClick={() => router.push(`/projects/${projectId}/release-notes`)}
+        >
+          Return to updates for users
+        </Button>
+      </div>
+    );
   }
 
   if (publishConfirmation) {
-    const scheduled = publishConfirmation === 'scheduled'
-    return <><div className="mx-auto max-w-2xl py-8"><p className="text-xs font-semibold text-primary">Update for your users</p><h2 className="mt-2 text-2xl font-semibold">{scheduled ? 'Scheduled successfully' : 'Published successfully'}</h2><p className="mt-2 text-sm leading-6 text-muted-foreground">{scheduled ? `This product update becomes eligible at ${new Date(publishAt).toLocaleString()}.` : 'This product update is eligible now and will appear on matching pages for visitors who have not seen it.'}</p><div className="mt-6 flex flex-wrap gap-2"><Button onClick={openPrivateTest}>Open private test</Button><Button variant="outline" onClick={() => router.push(`/projects/${projectId}/release-notes`)}>Return to updates for users</Button></div></div>{privateTestOpen && <PrivateTestDialog form={form} settings={settings} onClose={() => setPrivateTestOpen(false)} />}</>
+    const scheduled = publishConfirmation === "scheduled";
+    return (
+      <>
+        <div className="mx-auto max-w-2xl py-8">
+          <p className="text-xs font-semibold text-primary">
+            Update for your users
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold">
+            {scheduled ? "Scheduled successfully" : "Published successfully"}
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            {scheduled
+              ? `This product update becomes eligible at ${new Date(publishAt).toLocaleString()}.`
+              : "This product update is eligible now and will appear on matching pages for visitors who have not seen it."}
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            <Button onClick={openPrivateTest}>Open private test</Button>
+            <Button
+              variant="outline"
+              onClick={() =>
+                router.push(`/projects/${projectId}/release-notes`)
+              }
+            >
+              Return to updates for users
+            </Button>
+          </div>
+        </div>
+        {privateTestOpen && (
+          <PrivateTestDialog
+            form={form}
+            settings={settings}
+            onClose={() => setPrivateTestOpen(false)}
+          />
+        )}
+      </>
+    );
   }
 
-  const impressions = selected?.metrics.impressions || 0
-  const ctaRate = impressions ? Math.round(((selected?.metrics.ctaClicks || 0) / impressions) * 100) : 0
-  const dismissalRate = impressions ? Math.round(((selected?.metrics.dismissals || 0) / impressions) * 100) : 0
+  const impressions = selected?.metrics.impressions || 0;
+  const ctaRate = impressions
+    ? Math.round(((selected?.metrics.ctaClicks || 0) / impressions) * 100)
+    : 0;
+  const dismissalRate = impressions
+    ? Math.round(((selected?.metrics.dismissals || 0) / impressions) * 100)
+    : 0;
 
-  return <div className="space-y-6">
-    <section className="flex flex-wrap items-start justify-between gap-4 border-b pb-5">
-      <div className="max-w-2xl"><p className="text-xs font-semibold text-primary">Update shown to your users</p><h2 className="mt-1 text-xl font-semibold">{selected ? 'Edit product update' : 'Create product update'}</h2><p className="mt-1 text-sm text-muted-foreground">Keep the announcement concise. You can review it privately before publishing.</p></div>
-      <Button variant="outline" onClick={() => router.push(`/projects/${projectId}/release-notes`)}>Back to updates</Button>
-    </section>
+  return (
+    <div className="space-y-6">
+      <section className="flex flex-wrap items-start justify-between gap-4 rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
+        <div className="max-w-2xl">
+          <p className="text-xs font-semibold text-primary">
+            Update shown to your users
+          </p>
+          <h2 className="mt-1 text-xl font-semibold">
+            {selected ? "Edit product update" : "Create product update"}
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Keep the announcement concise. You can review it privately before
+            publishing.
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          onClick={() => router.push(`/projects/${projectId}/release-notes`)}
+        >
+          Back to updates
+        </Button>
+      </section>
 
-    <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_360px]">
-      <div className="space-y-6">
-        <section className="border-b pb-6"><div className="mb-4 flex items-center justify-between"><div><h3 className="font-semibold">{selected ? 'Edit release note' : 'Draft details'}</h3><p className="mt-1 text-sm text-muted-foreground">Plain text only. A live release note keeps its existing seen state when edited.</p></div></div>
-          <div><Field label="Title"><Input value={form.title} maxLength={120} onChange={(event) => updateForm('title', event.target.value)} /></Field></div>
-          <div className="mt-4"><Field label="Summary"><Textarea value={form.summary} maxLength={280} rows={3} onChange={(event) => updateForm('summary', event.target.value)} /></Field></div>
-          <div className="mt-4"><Label htmlFor="update-image" className="text-sm">Image</Label><div className="mt-1 flex items-center gap-3">{selected?.imageUrl && <span className="whitespace-nowrap text-xs text-muted-foreground">Image uploaded</span>}<Input id="update-image" type="file" accept="image/jpeg,image/png,image/webp" disabled={saving || !selected} onChange={(event) => void uploadImage(event.currentTarget.files?.[0])} /><span className="whitespace-nowrap text-xs text-muted-foreground">{selected ? '2 MB max' : 'Save the draft before adding an image'}</span></div></div>
-          <div className="mt-4"><Field label="Highlights, one per line"><Textarea value={form.highlights} rows={5} onChange={(event) => updateForm('highlights', event.target.value)} /></Field></div>
-          <details className="mt-5 rounded-md border p-4"><summary className="cursor-pointer text-sm font-medium">Advanced details</summary><div className="mt-4 grid gap-4 sm:grid-cols-2"><Field label="Version label"><Input value={form.versionLabel} maxLength={32} placeholder="v2.4" onChange={(event) => updateForm('versionLabel', event.target.value)} /></Field><Field label="Expires"><Input type="datetime-local" value={form.expiresAt} onChange={(event) => updateForm('expiresAt', event.target.value)} /></Field><Field label="CTA label"><Input value={form.ctaLabel} maxLength={40} onChange={(event) => updateForm('ctaLabel', event.target.value)} /></Field><Field label="CTA URL"><Input value={form.ctaUrl} maxLength={2048} placeholder="/new-feature or https://example.com" onChange={(event) => updateForm('ctaUrl', event.target.value)} /></Field></div></details>
-          <div className="mt-5 flex flex-wrap gap-2"><Button onClick={() => void saveDraft()} disabled={saving}>{saving ? 'Saving…' : selected?.status === 'published' ? 'Update live post' : 'Save draft'}</Button>{selected && <Button variant="outline" onClick={openPrivateTest} disabled={saving}>Test</Button>}{selected?.status === 'draft' && <Button variant="outline" onClick={() => void publish(false)} disabled={saving}>Publish now</Button>}</div>
-          {selected?.status === 'draft' && <div className="mt-4 flex flex-wrap items-end gap-2 rounded-md bg-muted/40 p-3"><Field label="Publish later" className="min-w-[220px]"><Input type="datetime-local" value={publishAt} disabled={!entitlements?.scheduling} onChange={(event) => setPublishAt(event.target.value)} /></Field><Button variant="outline" disabled={saving || !entitlements?.scheduling} onClick={() => void publish(true)}><CalendarClock className="mr-2 h-4 w-4" />Schedule</Button>{!entitlements?.scheduling && <p className="pb-2 text-xs text-muted-foreground">Scheduling is available on Pro.</p>}</div>}
-        </section>
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_360px]">
+        <div className="space-y-6">
+          <section className="rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
+            <div className="mb-4 flex items-center justify-between">
+              <div>
+                <h3 className="font-semibold">
+                  {selected ? "Edit release note" : "Draft details"}
+                </h3>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Plain text only. A live release note keeps its existing seen
+                  state when edited.
+                </p>
+              </div>
+            </div>
+            <div>
+              <Field label="Title">
+                <Input
+                  value={form.title}
+                  maxLength={120}
+                  onChange={(event) => updateForm("title", event.target.value)}
+                />
+              </Field>
+            </div>
+            <div className="mt-4">
+              <Field label="Summary">
+                <Textarea
+                  value={form.summary}
+                  maxLength={280}
+                  rows={3}
+                  onChange={(event) =>
+                    updateForm("summary", event.target.value)
+                  }
+                />
+              </Field>
+            </div>
+            <div className="mt-4">
+              <Label htmlFor="update-image" className="text-sm">
+                Image
+              </Label>
+              <div className="mt-1 flex items-center gap-3">
+                {selected?.imageUrl && (
+                  <span className="whitespace-nowrap text-xs text-muted-foreground">
+                    Image uploaded
+                  </span>
+                )}
+                <Input
+                  id="update-image"
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp"
+                  disabled={saving || !selected}
+                  onChange={(event) =>
+                    void uploadImage(event.currentTarget.files?.[0])
+                  }
+                />
+                <span className="whitespace-nowrap text-xs text-muted-foreground">
+                  {selected
+                    ? "2 MB max"
+                    : "Save the draft before adding an image"}
+                </span>
+              </div>
+            </div>
+            <div className="mt-4">
+              <Field label="Highlights, one per line">
+                <Textarea
+                  value={form.highlights}
+                  rows={5}
+                  onChange={(event) =>
+                    updateForm("highlights", event.target.value)
+                  }
+                />
+              </Field>
+            </div>
+            <details className="mt-5 rounded-md border p-4">
+              <summary className="cursor-pointer text-sm font-medium">
+                Advanced details
+              </summary>
+              <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                <Field label="Version label">
+                  <Input
+                    value={form.versionLabel}
+                    maxLength={32}
+                    placeholder="v2.4"
+                    onChange={(event) =>
+                      updateForm("versionLabel", event.target.value)
+                    }
+                  />
+                </Field>
+                <Field label="Expires">
+                  <Input
+                    type="datetime-local"
+                    value={form.expiresAt}
+                    onChange={(event) =>
+                      updateForm("expiresAt", event.target.value)
+                    }
+                  />
+                </Field>
+                <Field label="CTA label">
+                  <Input
+                    value={form.ctaLabel}
+                    maxLength={40}
+                    onChange={(event) =>
+                      updateForm("ctaLabel", event.target.value)
+                    }
+                  />
+                </Field>
+                <Field label="CTA URL">
+                  <Input
+                    value={form.ctaUrl}
+                    maxLength={2048}
+                    placeholder="/new-feature or https://example.com"
+                    onChange={(event) =>
+                      updateForm("ctaUrl", event.target.value)
+                    }
+                  />
+                </Field>
+              </div>
+            </details>
+            <div className="mt-5 flex flex-wrap gap-2">
+              <Button onClick={() => void saveDraft()} disabled={saving}>
+                {saving
+                  ? "Saving…"
+                  : selected?.status === "published"
+                    ? "Update live post"
+                    : "Save draft"}
+              </Button>
+              {selected && (
+                <Button
+                  variant="outline"
+                  onClick={openPrivateTest}
+                  disabled={saving}
+                >
+                  Test
+                </Button>
+              )}
+              {selected?.status === "draft" && (
+                <Button
+                  variant="outline"
+                  onClick={() => void publish(false)}
+                  disabled={saving}
+                >
+                  Publish now
+                </Button>
+              )}
+            </div>
+            {selected?.status === "draft" && (
+              <div className="mt-4 flex flex-wrap items-end gap-2 rounded-md bg-muted/40 p-3">
+                <Field label="Publish later" className="min-w-[220px]">
+                  <Input
+                    type="datetime-local"
+                    value={publishAt}
+                    disabled={!entitlements?.scheduling}
+                    onChange={(event) => setPublishAt(event.target.value)}
+                  />
+                </Field>
+                <Button
+                  variant="outline"
+                  disabled={saving || !entitlements?.scheduling}
+                  onClick={() => void publish(true)}
+                >
+                  <CalendarClock className="mr-2 h-4 w-4" />
+                  Schedule
+                </Button>
+                {!entitlements?.scheduling && (
+                  <p className="pb-2 text-xs text-muted-foreground">
+                    Scheduling is available on Pro.
+                  </p>
+                )}
+              </div>
+            )}
+          </section>
+        </div>
 
+        <aside className="space-y-6 xl:sticky xl:top-6 xl:self-start">
+          <section className="rounded-xl border bg-card p-5 shadow-[var(--shadow-card)]">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold">Preview</h3>
+              <div className="flex gap-1">
+                <Button
+                  size="sm"
+                  variant={previewMobile ? "outline" : "secondary"}
+                  onClick={() => setPreviewMobile(false)}
+                >
+                  Desktop
+                </Button>
+                <Button
+                  size="sm"
+                  variant={previewMobile ? "secondary" : "outline"}
+                  onClick={() => setPreviewMobile(true)}
+                >
+                  Mobile
+                </Button>
+              </div>
+            </div>
+            <div className="mt-3 flex items-center justify-between">
+              <span className="text-xs text-muted-foreground">
+                {settings?.theme === "auto"
+                  ? "Auto theme"
+                  : `${settings?.theme || "Auto"} theme`}
+              </span>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => setPreviewDark((value) => !value)}
+              >
+                <Eye className="mr-1 h-3.5 w-3.5" />
+                {previewDark ? "Light" : "Dark"}
+              </Button>
+            </div>
+            <UpdatePreview
+              form={form}
+              dark={previewDark}
+              mobile={previewMobile}
+              accent={settings?.accentColor || "#6366f1"}
+            />
+            <Button
+              className="mt-3 w-full"
+              variant="outline"
+              onClick={openPrivateTest}
+            >
+              Open private test
+            </Button>
+          </section>
+          {selected && (
+            <section className="rounded-xl border bg-card p-5 shadow-[var(--shadow-card)]">
+              <h3 className="font-semibold">Approximate metrics</h3>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Last {entitlements?.analyticsDays || 7} days, aggregate only.
+              </p>
+              <dl className="mt-4 grid grid-cols-3 gap-2 text-center">
+                <Metric label="Views" value={impressions} />
+                <Metric label="CTR" value={`${ctaRate}%`} />
+                <Metric label="Dismissed" value={`${dismissalRate}%`} />
+              </dl>
+            </section>
+          )}
+          <Button
+            className="w-full"
+            variant="ghost"
+            onClick={() =>
+              router.push(`/projects/${projectId}/release-notes/settings`)
+            }
+          >
+            <Settings2 className="mr-2 h-4 w-4" />
+            Release note settings
+          </Button>
+        </aside>
       </div>
-
-      <aside className="space-y-6 xl:sticky xl:top-6 xl:self-start"><section className="border rounded-lg p-4"><div className="flex items-center justify-between"><h3 className="font-semibold">Preview</h3><div className="flex gap-1"><Button size="sm" variant={previewMobile ? 'outline' : 'secondary'} onClick={() => setPreviewMobile(false)}>Desktop</Button><Button size="sm" variant={previewMobile ? 'secondary' : 'outline'} onClick={() => setPreviewMobile(true)}>Mobile</Button></div></div><div className="mt-3 flex items-center justify-between"><span className="text-xs text-muted-foreground">{settings?.theme === 'auto' ? 'Auto theme' : `${settings?.theme || 'Auto'} theme`}</span><Button size="sm" variant="ghost" onClick={() => setPreviewDark((value) => !value)}><Eye className="mr-1 h-3.5 w-3.5" />{previewDark ? 'Light' : 'Dark'}</Button></div><UpdatePreview form={form} dark={previewDark} mobile={previewMobile} accent={settings?.accentColor || '#6366f1'} /><Button className="mt-3 w-full" variant="outline" onClick={openPrivateTest}>Open private test</Button></section>
-        {selected && <section className="border rounded-lg p-4"><h3 className="font-semibold">Approximate metrics</h3><p className="mt-1 text-xs text-muted-foreground">Last {entitlements?.analyticsDays || 7} days, aggregate only.</p><dl className="mt-4 grid grid-cols-3 gap-2 text-center"><Metric label="Views" value={impressions} /><Metric label="CTR" value={`${ctaRate}%`} /><Metric label="Dismissed" value={`${dismissalRate}%`} /></dl></section>}
-        <Button className="w-full" variant="ghost" onClick={() => router.push(`/projects/${projectId}/release-notes/settings`)}><Settings2 className="mr-2 h-4 w-4" />Release note settings</Button>
-      </aside>
+      {privateTestOpen && (
+        <PrivateTestDialog
+          form={form}
+          settings={settings}
+          onClose={() => setPrivateTestOpen(false)}
+        />
+      )}
     </div>
-    {privateTestOpen && <PrivateTestDialog form={form} settings={settings} onClose={() => setPrivateTestOpen(false)} />}
-  </div>
+  );
 }
 
-function UpdatesOverview({ updates, onNew, onEdit, onSettings, onAction, busy }: {
-  updates: Update[]
-  onNew: () => void
-  onEdit: (id: string) => void
-  onSettings: () => void
-  onAction: (update: Update, action: 'archive' | 'restore' | 'delete') => Promise<void>
-  busy: boolean
+function UpdatesOverview({
+  updates,
+  onNew,
+  onEdit,
+  onSettings,
+  onAction,
+  busy,
+}: {
+  updates: Update[];
+  onNew: () => void;
+  onEdit: (id: string) => void;
+  onSettings: () => void;
+  onAction: (
+    update: Update,
+    action: "archive" | "restore" | "delete",
+  ) => Promise<void>;
+  busy: boolean;
 }) {
-  if (!updates.length) return <div className="mx-auto max-w-3xl space-y-6"><section className="border-b border-foreground/10 pb-6"><p className="text-xs font-semibold text-primary">Updates for your users</p><h2 className="mt-2 text-2xl font-semibold tracking-[-0.035em]">Tell users what just improved</h2><p className="mt-2 text-sm leading-6 text-muted-foreground">Publish a “What’s new” popup inside your product. Your shared embed is already connected, so publishing here requires no code change.</p></section><section className="py-4"><h3 className="text-lg font-semibold">Create the first product update</h3><p className="mt-2 text-sm text-muted-foreground">Start with a title and summary. Add an image or delivery rules only if they help.</p><Button className="mt-5" onClick={onNew}><Plus className="mr-2 h-4 w-4" />Create first update</Button></section></div>
-  return <div className="space-y-6"><section className="flex flex-wrap items-start justify-between gap-4 border-b pb-5"><div><p className="text-xs font-semibold text-primary">Inside your product</p><h2 className="mt-2 text-2xl font-semibold tracking-[-0.035em]">Updates for your users</h2><p className="mt-1 text-sm text-muted-foreground">Publish clear “What’s new” messages through the connected embed.</p></div><div className="flex gap-2"><Button variant="outline" onClick={onSettings}><Settings2 className="mr-2 h-4 w-4" />Settings</Button><Button onClick={onNew}><Plus className="mr-2 h-4 w-4" />New product update</Button></div></section><div className="divide-y border-y border-foreground/10">{updates.map((update) => <div key={update.id} className="flex min-h-20 items-center gap-2 p-2 sm:p-3"><button className="min-w-0 flex-1 rounded-md p-2 text-left hover:bg-muted/40" onClick={() => onEdit(update.id)}><span className="flex items-center gap-2"><span className="truncate font-medium">{update.version_label ? `${update.version_label} · ` : ''}{update.title}</span><Pencil className="h-3.5 w-3.5 shrink-0 text-muted-foreground" /></span><span className="mt-1 block text-xs text-muted-foreground">{stateLabel(update)} · {update.published_at ? new Date(update.published_at).toLocaleDateString() : 'Not published'} · {update.metrics.impressions} views · {update.metrics.ctaClicks} CTA clicks · {update.metrics.dismissals} dismissals</span></button><div className="flex shrink-0 gap-1">{update.status === 'archived' ? <Button size="sm" variant="ghost" disabled={busy} aria-label={`Restore ${update.title}`} onClick={() => void onAction(update, 'restore')}><RotateCcw className="h-4 w-4" /></Button> : <Button size="sm" variant="ghost" disabled={busy} aria-label={`Archive ${update.title}`} onClick={() => void onAction(update, 'archive')}><Archive className="h-4 w-4" /></Button>}<Button size="sm" variant="ghost" disabled={busy} aria-label={`Delete ${update.title}`} onClick={() => void onAction(update, 'delete')}><Trash2 className="h-4 w-4" /></Button></div></div>)}</div></div>
+  if (!updates.length) {
+    return (
+      <div className="mx-auto max-w-3xl space-y-5">
+        <section className="rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
+          <p className="text-xs font-semibold text-primary">
+            Updates for your users
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-[-0.035em]">
+            Tell users what just improved
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            Publish a “What’s new” popup inside your product. Your shared embed
+            is already connected, so publishing here requires no code change.
+          </p>
+        </section>
+        <section className="rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
+          <h3 className="text-lg font-semibold">
+            Create the first product update
+          </h3>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Start with a title and summary. Add an image or delivery rules only
+            if they help.
+          </p>
+          <Button className="mt-5" onClick={onNew}>
+            <Plus className="mr-2 h-4 w-4" />
+            Create first update
+          </Button>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <section className="flex flex-wrap items-start justify-between gap-4 rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
+        <div>
+          <p className="text-xs font-semibold text-primary">
+            Inside your product
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-[-0.035em]">
+            Updates for your users
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Publish clear “What’s new” messages through the connected embed.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={onSettings}>
+            <Settings2 className="mr-2 h-4 w-4" />
+            Settings
+          </Button>
+          <Button onClick={onNew}>
+            <Plus className="mr-2 h-4 w-4" />
+            New product update
+          </Button>
+        </div>
+      </section>
+      <div className="divide-y overflow-hidden rounded-xl border bg-card shadow-[var(--shadow-card)]">
+        {updates.map((update) => (
+          <div
+            key={update.id}
+            className="flex min-h-20 items-center gap-2 p-2 sm:p-3"
+          >
+            <button
+              className="min-w-0 flex-1 rounded-md p-2 text-left hover:bg-muted/40"
+              onClick={() => onEdit(update.id)}
+            >
+              <span className="flex items-center gap-2">
+                <span className="truncate font-medium">
+                  {update.version_label ? `${update.version_label} · ` : ""}
+                  {update.title}
+                </span>
+                <Pencil className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              </span>
+              <span className="mt-1 block text-xs text-muted-foreground">
+                {stateLabel(update)} ·{" "}
+                {update.published_at
+                  ? new Date(update.published_at).toLocaleDateString()
+                  : "Not published"}{" "}
+                · {update.metrics.impressions} views ·{" "}
+                {update.metrics.ctaClicks} CTA clicks ·{" "}
+                {update.metrics.dismissals} dismissals
+              </span>
+            </button>
+            <div className="flex shrink-0 gap-1">
+              {update.status === "archived" ? (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  disabled={busy}
+                  aria-label={`Restore ${update.title}`}
+                  onClick={() => void onAction(update, "restore")}
+                >
+                  <RotateCcw className="h-4 w-4" />
+                </Button>
+              ) : (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  disabled={busy}
+                  aria-label={`Archive ${update.title}`}
+                  onClick={() => void onAction(update, "archive")}
+                >
+                  <Archive className="h-4 w-4" />
+                </Button>
+              )}
+              <Button
+                size="sm"
+                variant="ghost"
+                disabled={busy}
+                aria-label={`Delete ${update.title}`}
+                onClick={() => void onAction(update, "delete")}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }
 
-function UpdatesSettings({ settings, entitlements, onSave, onBack }: { settings: Settings; entitlements: Entitlements | null; onSave: (settings: Settings) => Promise<void>; onBack: () => void }) {
-  const [draft, setDraft] = React.useState(settings)
-  const delaySeconds = draft.displayDelayMs / 1000
-  const hasCustomDelay = ![0, 3, 5].includes(delaySeconds)
-  return <div className="mx-auto max-w-3xl space-y-6"><section className="flex flex-wrap items-start justify-between gap-4 border-b pb-5"><div><p className="text-xs font-semibold text-primary">Updates for your users</p><h2 className="mt-2 text-2xl font-semibold tracking-[-0.035em]">Display settings</h2><p className="mt-1 text-sm text-muted-foreground">Control how “What’s new” announcements appear inside your product.</p></div><Button variant="outline" onClick={onBack}>Back to updates</Button></section><div className="space-y-5"><Check label="Show product updates to users" value={draft.enabled} onChange={(enabled) => setDraft({ ...draft, enabled })} /><Check label="Auto-show the newest unseen update" value={draft.autoShow} onChange={(autoShow) => setDraft({ ...draft, autoShow })} /><Field label="Appearance"><select className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm" value={draft.theme} onChange={(event) => setDraft({ ...draft, theme: event.target.value as Settings['theme'] })}><option value="auto">Match visitor device</option><option value="light">Light</option><option value="dark">Dark</option></select></Field><Field label="Show after"><select className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm" value={delaySeconds} onChange={(event) => setDraft({ ...draft, displayDelayMs: Number(event.target.value) * 1000 })}>{hasCustomDelay && <option value={delaySeconds}>{delaySeconds} seconds (current)</option>}<option value="0">Immediately</option><option value="3">3 seconds</option><option value="5">5 seconds</option></select></Field><Field label="Accent color"><Input value={draft.accentColor} onChange={(event) => setDraft({ ...draft, accentColor: event.target.value })} /></Field><details className="rounded-md border p-4"><summary className="cursor-pointer text-sm font-medium">Page targeting</summary><p className="mt-2 text-xs leading-5 text-muted-foreground">Use pathname prefixes such as /dashboard or /settings. Leave both lists empty to show updates everywhere.</p><div className="mt-4 grid gap-4 sm:grid-cols-2"><Field label="Show on specific pages"><Textarea rows={4} placeholder={'/dashboard\n/changelog'} value={draft.includePaths.join('\n')} onChange={(event) => setDraft({ ...draft, includePaths: event.target.value.split('\n').map((item) => item.trim()).filter(Boolean) })} /></Field><Field label="Hide on specific pages"><Textarea rows={4} placeholder={'/checkout\n/admin'} value={draft.excludePaths.join('\n')} onChange={(event) => setDraft({ ...draft, excludePaths: event.target.value.split('\n').map((item) => item.trim()).filter(Boolean) })} /></Field></div></details><Check label="Show feedbacks.dev branding" value={draft.showPoweredBy} disabled={!entitlements?.customBranding} onChange={(showPoweredBy) => setDraft({ ...draft, showPoweredBy })} /><Button onClick={() => void onSave(draft)}>Save settings</Button></div></div>
+function UpdatesSettings({
+  settings,
+  entitlements,
+  onSave,
+  onBack,
+}: {
+  settings: Settings;
+  entitlements: Entitlements | null;
+  onSave: (settings: Settings) => Promise<void>;
+  onBack: () => void;
+}) {
+  const [draft, setDraft] = React.useState(settings);
+  const delaySeconds = draft.displayDelayMs / 1000;
+  const hasCustomDelay = ![0, 3, 5].includes(delaySeconds);
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <section className="flex flex-wrap items-start justify-between gap-4 rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
+        <div>
+          <p className="text-xs font-semibold text-primary">
+            Updates for your users
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-[-0.035em]">
+            Display settings
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Control how “What’s new” announcements appear inside your product.
+          </p>
+        </div>
+        <Button variant="outline" onClick={onBack}>
+          Back to updates
+        </Button>
+      </section>
+      <div className="space-y-5 rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
+        <Check
+          label="Show product updates to users"
+          value={draft.enabled}
+          onChange={(enabled) => setDraft({ ...draft, enabled })}
+        />
+        <Check
+          label="Auto-show the newest unseen update"
+          value={draft.autoShow}
+          onChange={(autoShow) => setDraft({ ...draft, autoShow })}
+        />
+        <Field label="Appearance">
+          <select
+            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            value={draft.theme}
+            onChange={(event) =>
+              setDraft({
+                ...draft,
+                theme: event.target.value as Settings["theme"],
+              })
+            }
+          >
+            <option value="auto">Match visitor device</option>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </Field>
+        <Field label="Show after">
+          <select
+            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            value={delaySeconds}
+            onChange={(event) =>
+              setDraft({
+                ...draft,
+                displayDelayMs: Number(event.target.value) * 1000,
+              })
+            }
+          >
+            {hasCustomDelay && (
+              <option value={delaySeconds}>
+                {delaySeconds} seconds (current)
+              </option>
+            )}
+            <option value="0">Immediately</option>
+            <option value="3">3 seconds</option>
+            <option value="5">5 seconds</option>
+          </select>
+        </Field>
+        <Field label="Accent color">
+          <Input
+            value={draft.accentColor}
+            onChange={(event) =>
+              setDraft({ ...draft, accentColor: event.target.value })
+            }
+          />
+        </Field>
+        <details className="rounded-md border p-4">
+          <summary className="cursor-pointer text-sm font-medium">
+            Page targeting
+          </summary>
+          <p className="mt-2 text-xs leading-5 text-muted-foreground">
+            Use pathname prefixes such as /dashboard or /settings. Leave both
+            lists empty to show updates everywhere.
+          </p>
+          <div className="mt-4 grid gap-4 sm:grid-cols-2">
+            <Field label="Show on specific pages">
+              <Textarea
+                rows={4}
+                placeholder={"/dashboard\n/changelog"}
+                value={draft.includePaths.join("\n")}
+                onChange={(event) =>
+                  setDraft({
+                    ...draft,
+                    includePaths: event.target.value
+                      .split("\n")
+                      .map((item) => item.trim())
+                      .filter(Boolean),
+                  })
+                }
+              />
+            </Field>
+            <Field label="Hide on specific pages">
+              <Textarea
+                rows={4}
+                placeholder={"/checkout\n/admin"}
+                value={draft.excludePaths.join("\n")}
+                onChange={(event) =>
+                  setDraft({
+                    ...draft,
+                    excludePaths: event.target.value
+                      .split("\n")
+                      .map((item) => item.trim())
+                      .filter(Boolean),
+                  })
+                }
+              />
+            </Field>
+          </div>
+        </details>
+        <Check
+          label="Show feedbacks.dev branding"
+          value={draft.showPoweredBy}
+          disabled={!entitlements?.customBranding}
+          onChange={(showPoweredBy) => setDraft({ ...draft, showPoweredBy })}
+        />
+        <Button onClick={() => void onSave(draft)}>Save settings</Button>
+      </div>
+    </div>
+  );
 }
 
-function PrivateTestDialog({ form, settings, onClose }: { form: FormValues; settings: Settings; onClose: () => void }) {
-  const dialogRef = React.useRef<HTMLDivElement>(null)
-  const closeRef = React.useRef<HTMLButtonElement>(null)
-  const previousFocus = React.useRef<HTMLElement | null>(null)
+function PrivateTestDialog({
+  form,
+  settings,
+  onClose,
+}: {
+  form: FormValues;
+  settings: Settings;
+  onClose: () => void;
+}) {
+  const dialogRef = React.useRef<HTMLDivElement>(null);
+  const closeRef = React.useRef<HTMLButtonElement>(null);
+  const previousFocus = React.useRef<HTMLElement | null>(null);
 
   React.useEffect(() => {
-    previousFocus.current = document.activeElement instanceof HTMLElement ? document.activeElement : null
-    closeRef.current?.focus()
-    return () => previousFocus.current?.focus()
-  }, [])
+    previousFocus.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    closeRef.current?.focus();
+    return () => previousFocus.current?.focus();
+  }, []);
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
-    if (event.key === 'Escape') {
-      event.preventDefault()
-      onClose()
-      return
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onClose();
+      return;
     }
-    if (event.key !== 'Tab') return
-    const focusable = Array.from(dialogRef.current?.querySelectorAll<HTMLElement>('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])') || []).filter((element) => !element.hasAttribute('disabled'))
-    if (!focusable.length) return
-    const first = focusable[0]
-    const last = focusable[focusable.length - 1]
+    if (event.key !== "Tab") return;
+    const focusable = Array.from(
+      dialogRef.current?.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      ) || [],
+    ).filter((element) => !element.hasAttribute("disabled"));
+    if (!focusable.length) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
     if (event.shiftKey && document.activeElement === first) {
-      event.preventDefault()
-      last.focus()
+      event.preventDefault();
+      last.focus();
     } else if (!event.shiftKey && document.activeElement === last) {
-      event.preventDefault()
-      first.focus()
+      event.preventDefault();
+      first.focus();
     }
   }
 
-  return <div ref={dialogRef} className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 p-4 backdrop-blur-sm" role="dialog" aria-modal="true" aria-label="Private release note test" onKeyDown={handleKeyDown}><div className="w-full max-w-lg rounded-lg border bg-background p-5 shadow-xl"><div className="flex items-center justify-between"><div><p className="text-xs font-semibold uppercase tracking-[0.16em] text-primary">Private test</p><h3 className="mt-1 font-semibold">Visitor preview</h3></div><Button ref={closeRef} size="sm" variant="ghost" aria-label="Close private test" onClick={onClose}><X className="h-4 w-4" /></Button></div><UpdatePreview form={form} dark={settings.theme === 'dark'} mobile={false} accent={settings.accentColor} /><p className="mt-4 text-xs text-muted-foreground">Only you can see this preview. Nothing has been published by opening it.</p></div></div>
+  return (
+    <div
+      ref={dialogRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 p-4 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Private release note test"
+      onKeyDown={handleKeyDown}
+    >
+      <div className="w-full max-w-lg rounded-lg border bg-background p-5 shadow-xl">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-primary">
+              Private test
+            </p>
+            <h3 className="mt-1 font-semibold">Visitor preview</h3>
+          </div>
+          <Button
+            ref={closeRef}
+            size="sm"
+            variant="ghost"
+            aria-label="Close private test"
+            onClick={onClose}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+        <UpdatePreview
+          form={form}
+          dark={settings.theme === "dark"}
+          mobile={false}
+          accent={settings.accentColor}
+        />
+        <p className="mt-4 text-xs text-muted-foreground">
+          Only you can see this preview. Nothing has been published by opening
+          it.
+        </p>
+      </div>
+    </div>
+  );
 }
 
-function Field({ label, children, className }: { label: string; children: React.ReactNode; className?: string }) {
-  return <label className={`block space-y-1.5 ${className || ''}`}><span className="text-sm font-medium">{label}</span>{children}</label>
+function Field({
+  label,
+  children,
+  className,
+}: {
+  label: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <label className={`block space-y-1.5 ${className || ""}`}>
+      <span className="text-sm font-medium">{label}</span>
+      {children}
+    </label>
+  );
 }
 
-function Check({ label, value, onChange, disabled }: { label: string; value: boolean; onChange: (value: boolean) => void; disabled?: boolean }) {
-  return <label className={`flex items-center gap-2 text-sm ${disabled ? 'text-muted-foreground' : ''}`}><input type="checkbox" checked={value} disabled={disabled} onChange={(event) => onChange(event.target.checked)} />{label}</label>
+function Check({
+  label,
+  value,
+  onChange,
+  disabled,
+}: {
+  label: string;
+  value: boolean;
+  onChange: (value: boolean) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <label
+      className={`flex items-center gap-2 text-sm ${disabled ? "text-muted-foreground" : ""}`}
+    >
+      <input
+        type="checkbox"
+        checked={value}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.checked)}
+      />
+      {label}
+    </label>
+  );
 }
 
 function Metric({ label, value }: { label: string; value: string | number }) {
-  return <div><dt className="text-[11px] uppercase tracking-wide text-muted-foreground">{label}</dt><dd className="mt-1 text-base font-semibold">{value}</dd></div>
+  return (
+    <div>
+      <dt className="text-[11px] uppercase tracking-wide text-muted-foreground">
+        {label}
+      </dt>
+      <dd className="mt-1 text-base font-semibold">{value}</dd>
+    </div>
+  );
 }
 
-function UpdatePreview({ form, dark, mobile, accent }: { form: FormValues; dark: boolean; mobile: boolean; accent: string }) {
-  return <div className={`mx-auto mt-4 rounded-lg border p-5 shadow-sm ${mobile ? 'max-w-[280px]' : ''} ${dark ? 'border-slate-700 bg-slate-950 text-slate-100' : 'bg-white text-slate-900'}`}><p className="text-xs font-semibold uppercase tracking-[0.12em]" style={{ color: accent }}>{form.versionLabel || 'What’s New'}</p><h4 className="mt-2 text-lg font-semibold">{form.title || 'Your release note title'}</h4><p className={`mt-2 text-sm leading-6 ${dark ? 'text-slate-300' : 'text-slate-600'}`}>{form.summary || 'A concise summary of the release appears here.'}</p>{form.highlights && <ul className="mt-3 list-disc space-y-1 pl-5 text-sm">{form.highlights.split('\n').filter(Boolean).map((item) => <li key={item}>{item}</li>)}</ul>}{form.ctaLabel && <span className="mt-4 inline-flex rounded-md px-3 py-2 text-sm font-semibold text-white" style={{ backgroundColor: accent }}>{form.ctaLabel}</span>}</div>
+function UpdatePreview({
+  form,
+  dark,
+  mobile,
+  accent,
+}: {
+  form: FormValues;
+  dark: boolean;
+  mobile: boolean;
+  accent: string;
+}) {
+  return (
+    <div
+      className={`mx-auto mt-4 rounded-lg border p-5 shadow-sm ${mobile ? "max-w-[280px]" : ""} ${dark ? "border-slate-700 bg-slate-950 text-slate-100" : "bg-white text-slate-900"}`}
+    >
+      <p
+        className="text-xs font-semibold uppercase tracking-[0.12em]"
+        style={{ color: accent }}
+      >
+        {form.versionLabel || "What’s New"}
+      </p>
+      <h4 className="mt-2 text-lg font-semibold">
+        {form.title || "Your release note title"}
+      </h4>
+      <p
+        className={`mt-2 text-sm leading-6 ${dark ? "text-slate-300" : "text-slate-600"}`}
+      >
+        {form.summary || "A concise summary of the release appears here."}
+      </p>
+      {form.highlights && (
+        <ul className="mt-3 list-disc space-y-1 pl-5 text-sm">
+          {form.highlights
+            .split("\n")
+            .filter(Boolean)
+            .map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+        </ul>
+      )}
+      {form.ctaLabel && (
+        <span
+          className="mt-4 inline-flex rounded-md px-3 py-2 text-sm font-semibold text-white"
+          style={{ backgroundColor: accent }}
+        >
+          {form.ctaLabel}
+        </span>
+      )}
+    </div>
+  );
 }

--- a/packages/dashboard/src/components/product-updates/UpdatesOnboarding.tsx
+++ b/packages/dashboard/src/components/product-updates/UpdatesOnboarding.tsx
@@ -1,23 +1,23 @@
-'use client'
+"use client";
 
-import * as React from 'react'
-import { useRouter } from 'next/navigation'
-import { generateInstallSnippets } from '@feedbacks/shared'
-import { Bot, CheckCircle2, Code2, Copy, RefreshCw } from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
-import { toast } from '@/hooks/use-toast'
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { generateInstallSnippets } from "@feedbacks/shared";
+import { Bot, CheckCircle2, Code2, Copy, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { toast } from "@/hooks/use-toast";
 
-type ModuleState = { feedback: boolean; updates: boolean }
-type EmbedState = 'not_detected' | 'connected' | 'stale'
-type Choice = 'updates' | 'feedback' | 'both'
-type Method = 'AI assistant' | 'Script tag' | 'React' | 'Vue'
+type ModuleState = { feedback: boolean; updates: boolean };
+type EmbedState = "not_detected" | "connected" | "stale";
+type Choice = "updates" | "feedback" | "both";
+type Method = "AI assistant" | "Script tag" | "React" | "Vue";
 
 const choiceModules: Record<Choice, ModuleState> = {
   updates: { feedback: false, updates: true },
   feedback: { feedback: true, updates: false },
   both: { feedback: true, updates: true },
-}
+};
 
 export function UpdatesOnboarding({
   projectId,
@@ -26,141 +26,362 @@ export function UpdatesOnboarding({
   embedState,
   onRefresh,
 }: {
-  projectId: string
-  projectKey: string | null
-  modules: ModuleState
-  embedState: EmbedState
-  onRefresh: () => Promise<void>
+  projectId: string;
+  projectKey: string | null;
+  modules: ModuleState;
+  embedState: EmbedState;
+  onRefresh: () => Promise<void>;
 }) {
-  const router = useRouter()
-  const [choice, setChoice] = React.useState<Choice>('updates')
-  const [method, setMethod] = React.useState<Method>('AI assistant')
-  const [saving, setSaving] = React.useState(false)
-  const [polling, setPolling] = React.useState(false)
-  const [currentEmbedState, setCurrentEmbedState] = React.useState(embedState)
+  const router = useRouter();
+  const [choice, setChoice] = React.useState<Choice>("updates");
+  const [method, setMethod] = React.useState<Method>("AI assistant");
+  const [saving, setSaving] = React.useState(false);
+  const [polling, setPolling] = React.useState(false);
+  const [currentEmbedState, setCurrentEmbedState] = React.useState(embedState);
 
-  const record = React.useCallback((event: string) => {
-    void fetch(`/api/projects/${projectId}/activation`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ event }),
-    }).catch(() => undefined)
-  }, [projectId])
+  const record = React.useCallback(
+    (event: string) => {
+      void fetch(`/api/projects/${projectId}/activation`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ event }),
+      }).catch(() => undefined);
+    },
+    [projectId],
+  );
 
-  React.useEffect(() => { record('updates_setup_started') }, [record])
-  React.useEffect(() => { setCurrentEmbedState(embedState) }, [embedState])
-  React.useEffect(() => { if (currentEmbedState === 'connected') record('updates_embed_verified') }, [currentEmbedState, record])
   React.useEffect(() => {
-    if (currentEmbedState === 'connected' && modules.updates) router.replace(`/projects/${projectId}/updates/new`)
-  }, [currentEmbedState, modules.updates, projectId, router])
+    record("updates_setup_started");
+  }, [record]);
+  React.useEffect(() => {
+    setCurrentEmbedState(embedState);
+  }, [embedState]);
+  React.useEffect(() => {
+    if (currentEmbedState === "connected") record("updates_embed_verified");
+  }, [currentEmbedState, record]);
+  React.useEffect(() => {
+    if (currentEmbedState === "connected" && modules.updates)
+      router.replace(`/projects/${projectId}/updates/new`);
+  }, [currentEmbedState, modules.updates, projectId, router]);
 
   const checkConnection = React.useCallback(async () => {
     try {
-      const response = await fetch(`/api/projects/${projectId}/embed-status`, { cache: 'no-store' })
-      const data = await response.json().catch(() => null)
-      if (!response.ok) throw new Error(data?.error || 'Unable to check the embed connection.')
-      const nextState = data?.state as EmbedState
-      if (['not_detected', 'connected', 'stale'].includes(nextState)) setCurrentEmbedState(nextState)
-      return nextState === 'connected'
+      const response = await fetch(`/api/projects/${projectId}/embed-status`, {
+        cache: "no-store",
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok)
+        throw new Error(data?.error || "Unable to check the embed connection.");
+      const nextState = data?.state as EmbedState;
+      if (["not_detected", "connected", "stale"].includes(nextState))
+        setCurrentEmbedState(nextState);
+      return nextState === "connected";
     } catch (error) {
-      toast({ title: 'Could not check the connection', description: error instanceof Error ? error.message : 'Try again.', variant: 'destructive' })
-      return false
+      toast({
+        title: "Could not check the connection",
+        description: error instanceof Error ? error.message : "Try again.",
+        variant: "destructive",
+      });
+      return false;
     }
-  }, [projectId])
+  }, [projectId]);
 
   React.useEffect(() => {
-    if (!modules.updates || currentEmbedState === 'connected') return
-    let attempts = 0
-    let cancelled = false
-    let timer: number | null = null
+    if (!modules.updates || currentEmbedState === "connected") return;
+    let attempts = 0;
+    let cancelled = false;
+    let timer: number | null = null;
     const poll = async () => {
-      if (cancelled || attempts >= 6) { setPolling(false); return }
-      attempts += 1
-      setPolling(true)
-      const connected = await checkConnection()
-      if (!cancelled && !connected && attempts < 6) timer = window.setTimeout(poll, 10_000)
-      else if (!cancelled) setPolling(false)
-    }
-    timer = window.setTimeout(poll, 10_000)
+      if (cancelled || attempts >= 6) {
+        setPolling(false);
+        return;
+      }
+      attempts += 1;
+      setPolling(true);
+      const connected = await checkConnection();
+      if (!cancelled && !connected && attempts < 6)
+        timer = window.setTimeout(poll, 10_000);
+      else if (!cancelled) setPolling(false);
+    };
+    timer = window.setTimeout(poll, 10_000);
     return () => {
-      cancelled = true
-      if (timer !== null) window.clearTimeout(timer)
-    }
-  }, [checkConnection, currentEmbedState, modules.updates])
+      cancelled = true;
+      if (timer !== null) window.clearTimeout(timer);
+    };
+  }, [checkConnection, currentEmbedState, modules.updates]);
 
   const saveModules = async (next: ModuleState): Promise<boolean> => {
-    setSaving(true)
+    setSaving(true);
     try {
       const response = await fetch(`/api/projects/${projectId}/modules`, {
-        method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(next),
-      })
-      const data = await response.json().catch(() => null)
-      if (!response.ok) throw new Error(data?.error || 'Unable to update products.')
-      await onRefresh()
-      return true
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(next),
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok)
+        throw new Error(data?.error || "Unable to update products.");
+      await onRefresh();
+      return true;
     } catch (error) {
-      toast({ title: 'Could not save product choice', description: error instanceof Error ? error.message : 'Try again.', variant: 'destructive' })
-      return false
-    } finally { setSaving(false) }
-  }
+      toast({
+        title: "Could not save product choice",
+        description: error instanceof Error ? error.message : "Try again.",
+        variant: "destructive",
+      });
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  };
 
-  const activate = async () => { if (await saveModules({ ...modules, updates: true })) record('updates_activated') }
+  const activate = async () => {
+    if (await saveModules({ ...modules, updates: true }))
+      record("updates_activated");
+  };
   const startSetup = async () => {
-    if (!await saveModules(choiceModules[choice])) return
-    if (choice === 'feedback') router.push(`/projects/${projectId}/install`)
+    if (!(await saveModules(choiceModules[choice]))) return;
+    if (choice === "feedback") router.push(`/projects/${projectId}/install`);
+  };
+
+  if (currentEmbedState === "connected" && !modules.updates) {
+    return (
+      <ConnectionState
+        title="Your shared embed is connected"
+        description="Turn on product updates for users remotely. Your existing installation does not need a code change."
+        action="Activate updates for users"
+        onAction={activate}
+        busy={saving}
+      />
+    );
   }
 
-  if (currentEmbedState === 'connected' && !modules.updates) {
-    return <ConnectionState title="Your shared embed is connected" description="Turn on product updates for users remotely. Your existing installation does not need a code change." action="Activate updates for users" onAction={activate} busy={saving} />
-  }
+  if (modules.updates && currentEmbedState === "connected") return null;
 
-  if (modules.updates && currentEmbedState === 'connected') return null
+  return (
+    <div className="mx-auto max-w-4xl space-y-5">
+      <section className="rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
+        <p className="text-xs font-semibold text-primary">
+          Updates for your users
+        </p>
+        <h2 className="text-2xl font-semibold tracking-[-0.035em]">
+          Show what changed inside your product
+        </h2>
+        <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+          Publish a focused “What’s new” popup for your users. This is where you
+          announce improvements to your product, not changes to the
+          feedbacks.dev website.
+        </p>
+      </section>
 
-  return <div className="mx-auto max-w-4xl space-y-5">
-    <section className="rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
-      <p className="text-xs font-semibold text-primary">Updates for your users</p>
-      <h2 className="text-2xl font-semibold tracking-[-0.035em]">Show what changed inside your product</h2>
-      <p className="max-w-2xl text-sm leading-6 text-muted-foreground">Publish a focused “What’s new” popup for your users. This is where you announce improvements to your product, not changes to the feedbacks.dev website.</p>
-    </section>
+      <section className="space-y-5 rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
+        <Step title="Choose what the shared embed should do" />
+        <div className="grid gap-3 sm:grid-cols-3">
+          <ChoiceButton
+            active={choice === "updates"}
+            title="Show updates only"
+            description="Announce improvements without a feedback launcher."
+            onClick={() => setChoice("updates")}
+          />
+          <ChoiceButton
+            active={choice === "feedback"}
+            title="Collect feedback only"
+            description="Listen to users without publishing announcements."
+            onClick={() => setChoice("feedback")}
+          />
+          <ChoiceButton
+            active={choice === "both"}
+            title="Collect + close the loop"
+            description="Use one embed for both user experiences."
+            onClick={() => setChoice("both")}
+          />
+        </div>
+        <Button onClick={() => void startSetup()} disabled={saving}>
+          {saving
+            ? "Saving…"
+            : choice === "feedback"
+              ? "Continue to install"
+              : "Set up updates for users"}
+        </Button>
+      </section>
 
-    <section className="space-y-5 rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
-      <Step title="Choose what the shared embed should do" />
-      <div className="grid gap-3 sm:grid-cols-3">
-        <ChoiceButton active={choice === 'updates'} title="Show updates only" description="Announce improvements without a feedback launcher." onClick={() => setChoice('updates')} />
-        <ChoiceButton active={choice === 'feedback'} title="Collect feedback only" description="Listen to users without publishing announcements." onClick={() => setChoice('feedback')} />
-        <ChoiceButton active={choice === 'both'} title="Collect + close the loop" description="Use one embed for both user experiences." onClick={() => setChoice('both')} />
-      </div>
-      <Button onClick={() => void startSetup()} disabled={saving}>{saving ? 'Saving…' : choice === 'feedback' ? 'Continue to install' : 'Set up updates for users'}</Button>
-    </section>
-
-    {modules.updates && <section className="space-y-5 rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
-      <Step title="Install the shared embed" />
-      <div className="flex flex-wrap gap-2">{(['AI assistant', 'Script tag', 'React', 'Vue'] as Method[]).map((item) => <Button key={item} variant={method === item ? 'secondary' : 'outline'} size="sm" onClick={() => { setMethod(item); record('updates_install_method_selected') }}>{item === 'AI assistant' && <Bot className="mr-1.5 h-3.5 w-3.5" />}{item}</Button>)}</div>
-      {projectKey ? <InstallInstructions method={method} projectKey={projectKey} choice={choice} /> : <p className="rounded-md bg-muted/60 p-3 text-sm text-muted-foreground">Your browser-safe project key is hidden. Generate a fresh key in <a className="underline" href={`/projects/${projectId}/install`}>Embed installation</a>, then return here to copy the exact instructions.</p>}
-      <div className="border-t pt-5"><Step title="Verify the connection" /><p className="mt-2 text-sm text-muted-foreground">{polling ? 'Checking for your embed for up to one minute…' : currentEmbedState === 'stale' ? 'The last connection is stale. Load the page with the embed again, then check.' : 'Add the embed to your app and load that page once. We will detect it automatically.'}</p><Button className="mt-3" variant="outline" onClick={() => void checkConnection()}><RefreshCw className="mr-2 h-4 w-4" />Check connection</Button></div>
-    </section>}
-  </div>
+      {modules.updates && (
+        <section className="space-y-5 rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
+          <Step title="Install the shared embed" />
+          <div className="flex flex-wrap gap-2">
+            {(["AI assistant", "Script tag", "React", "Vue"] as Method[]).map(
+              (item) => (
+                <Button
+                  key={item}
+                  variant={method === item ? "secondary" : "outline"}
+                  size="sm"
+                  onClick={() => {
+                    setMethod(item);
+                    record("updates_install_method_selected");
+                  }}
+                >
+                  {item === "AI assistant" && (
+                    <Bot className="mr-1.5 h-3.5 w-3.5" />
+                  )}
+                  {item}
+                </Button>
+              ),
+            )}
+          </div>
+          {projectKey ? (
+            <InstallInstructions
+              method={method}
+              projectKey={projectKey}
+              choice={choice}
+            />
+          ) : (
+            <p className="rounded-md bg-muted/60 p-3 text-sm text-muted-foreground">
+              Your browser-safe project key is hidden. Generate a fresh key in{" "}
+              <a className="underline" href={`/projects/${projectId}/install`}>
+                Embed installation
+              </a>
+              , then return here to copy the exact instructions.
+            </p>
+          )}
+          <div className="border-t pt-5">
+            <Step title="Verify the connection" />
+            <p className="mt-2 text-sm text-muted-foreground">
+              {polling
+                ? "Checking for your embed for up to one minute…"
+                : currentEmbedState === "stale"
+                  ? "The last connection is stale. Load the page with the embed again, then check."
+                  : "Add the embed to your app and load that page once. We will detect it automatically."}
+            </p>
+            <Button
+              className="mt-3"
+              variant="outline"
+              onClick={() => void checkConnection()}
+            >
+              <RefreshCw className="mr-2 h-4 w-4" />
+              Check connection
+            </Button>
+          </div>
+        </section>
+      )}
+    </div>
+  );
 }
 
-function ConnectionState({ title, description, action, onAction, busy }: { title: string; description: string; action: string; onAction: () => void; busy: boolean }) {
-  return <Card className="mx-auto max-w-2xl"><CardContent className="p-6"><CheckCircle2 className="h-6 w-6 text-primary" /><h2 className="mt-4 text-xl font-semibold">{title}</h2><p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">{description}</p><Button className="mt-5" onClick={onAction} disabled={busy}>{busy ? 'Activating…' : action}</Button></CardContent></Card>
+function ConnectionState({
+  title,
+  description,
+  action,
+  onAction,
+  busy,
+}: {
+  title: string;
+  description: string;
+  action: string;
+  onAction: () => void;
+  busy: boolean;
+}) {
+  return (
+    <Card className="mx-auto max-w-2xl">
+      <CardContent className="p-6">
+        <CheckCircle2 className="h-6 w-6 text-primary" />
+        <h2 className="mt-4 text-xl font-semibold">{title}</h2>
+        <p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
+          {description}
+        </p>
+        <Button className="mt-5" onClick={onAction} disabled={busy}>
+          {busy ? "Activating…" : action}
+        </Button>
+      </CardContent>
+    </Card>
+  );
 }
 
-function Step({ title }: { title: string }) { return <h3 className="font-semibold">{title}</h3> }
-function ChoiceButton({ active, title, description, onClick }: { active: boolean; title: string; description: string; onClick: () => void }) { return <button type="button" onClick={onClick} className={`min-h-28 border-y p-4 text-left transition-colors ${active ? 'border-primary bg-primary/[0.06]' : 'border-foreground/10 hover:bg-muted/30'}`}><span className="block font-medium">{title}</span><span className="mt-1 block text-sm leading-5 text-muted-foreground">{description}</span></button> }
+function Step({ title }: { title: string }) {
+  return <h3 className="font-semibold">{title}</h3>;
+}
+function ChoiceButton({
+  active,
+  title,
+  description,
+  onClick,
+}: {
+  active: boolean;
+  title: string;
+  description: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`min-h-28 rounded-lg border p-4 text-left transition-colors ${active ? "border-primary bg-primary/[0.06]" : "border-border bg-[oklch(var(--surface-raised))] hover:bg-muted/30"}`}
+    >
+      <span className="block font-medium">{title}</span>
+      <span className="mt-1 block text-sm leading-5 text-muted-foreground">
+        {description}
+      </span>
+    </button>
+  );
+}
 
-function InstallInstructions({ method, projectKey, choice }: { method: Method; projectKey: string; choice: Choice }) {
-  const origin = typeof window === 'undefined' ? undefined : window.location.origin
-  const snippets = generateInstallSnippets({ projectKey, appOrigin: origin })
-  const snippet = method === 'Script tag' ? snippets.find((item) => item.label === 'Website') : snippets.find((item) => item.label === method)
-  const websiteSnippet = snippets.find((item) => item.label === 'Website')?.code || ''
-  const productLabel = choice === 'both' ? 'feedback collection and user-facing product updates' : choice === 'updates' ? 'user-facing product updates only' : 'feedback collection only'
-  const prompt = `Install the feedbacks.dev embed in this app. Use the browser-safe project key ${projectKey}. Enable ${productLabel}. Place the embed in the app shell so it loads once, preserve the existing design and dependencies, and do not add any private server key. Use this verified browser embed as the source of truth:\n\n${websiteSnippet}\n\nAfter installing, load a page and confirm the embed is detected in feedbacks.dev.`
-  const content = method === 'AI assistant' ? prompt : snippet?.code || ''
-  return <CodeSample title={method === 'AI assistant' ? 'Give this to your AI coding assistant' : `${method} instructions`} content={content} />
+function InstallInstructions({
+  method,
+  projectKey,
+  choice,
+}: {
+  method: Method;
+  projectKey: string;
+  choice: Choice;
+}) {
+  const origin =
+    typeof window === "undefined" ? undefined : window.location.origin;
+  const snippets = generateInstallSnippets({ projectKey, appOrigin: origin });
+  const snippet =
+    method === "Script tag"
+      ? snippets.find((item) => item.label === "Website")
+      : snippets.find((item) => item.label === method);
+  const websiteSnippet =
+    snippets.find((item) => item.label === "Website")?.code || "";
+  const productLabel =
+    choice === "both"
+      ? "feedback collection and user-facing product updates"
+      : choice === "updates"
+        ? "user-facing product updates only"
+        : "feedback collection only";
+  const prompt = `Install the feedbacks.dev embed in this app. Use the browser-safe project key ${projectKey}. Enable ${productLabel}. Place the embed in the app shell so it loads once, preserve the existing design and dependencies, and do not add any private server key. Use this verified browser embed as the source of truth:\n\n${websiteSnippet}\n\nAfter installing, load a page and confirm the embed is detected in feedbacks.dev.`;
+  const content = method === "AI assistant" ? prompt : snippet?.code || "";
+  return (
+    <CodeSample
+      title={
+        method === "AI assistant"
+          ? "Give this to your AI coding assistant"
+          : `${method} instructions`
+      }
+      content={content}
+    />
+  );
 }
 
 function CodeSample({ title, content }: { title: string; content: string }) {
-  const copy = async () => { await navigator.clipboard.writeText(content); toast({ title: 'Copied to clipboard' }) }
-  return <div className="rounded-md border"><div className="flex items-center justify-between gap-3 border-b px-3 py-2"><span className="flex items-center gap-2 text-sm font-medium"><Code2 className="h-4 w-4" />{title}</span><Button size="sm" variant="ghost" onClick={() => void copy()}><Copy className="mr-1.5 h-3.5 w-3.5" />Copy</Button></div><pre className="max-h-72 overflow-auto whitespace-pre-wrap p-3 text-xs leading-5"><code>{content}</code></pre></div>
+  const copy = async () => {
+    await navigator.clipboard.writeText(content);
+    toast({ title: "Copied to clipboard" });
+  };
+  return (
+    <div className="rounded-md border">
+      <div className="flex items-center justify-between gap-3 border-b px-3 py-2">
+        <span className="flex items-center gap-2 text-sm font-medium">
+          <Code2 className="h-4 w-4" />
+          {title}
+        </span>
+        <Button size="sm" variant="ghost" onClick={() => void copy()}>
+          <Copy className="mr-1.5 h-3.5 w-3.5" />
+          Copy
+        </Button>
+      </div>
+      <pre className="max-h-72 overflow-auto whitespace-pre-wrap p-3 text-xs leading-5">
+        <code>{content}</code>
+      </pre>
+    </div>
+  );
 }

--- a/packages/dashboard/src/components/ui/card.tsx
+++ b/packages/dashboard/src/components/ui/card.tsx
@@ -6,7 +6,7 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
     <div
       ref={ref}
       className={cn(
-        "rounded-md border border-border/75 bg-card text-card-foreground",
+        "overflow-hidden rounded-xl border border-border/80 bg-card text-card-foreground shadow-[var(--shadow-card)]",
         className,
       )}
       {...props}
@@ -17,7 +17,7 @@ Card.displayName = "Card"
 
 const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+    <div ref={ref} className={cn("flex flex-col space-y-1.5 border-b bg-muted/25 p-5 sm:p-6", className)} {...props} />
   )
 )
 CardHeader.displayName = "CardHeader"
@@ -38,14 +38,14 @@ CardDescription.displayName = "CardDescription"
 
 const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+    <div ref={ref} className={cn("p-5 sm:p-6", className)} {...props} />
   )
 )
 CardContent.displayName = "CardContent"
 
 const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+    <div ref={ref} className={cn("flex items-center border-t bg-muted/15 p-5 sm:p-6", className)} {...props} />
   )
 )
 CardFooter.displayName = "CardFooter"

--- a/packages/dashboard/tests/unit/product-experience.test.ts
+++ b/packages/dashboard/tests/unit/product-experience.test.ts
@@ -81,7 +81,7 @@ test('navigation gives product updates user context instead of an ambiguous rele
 
   assert.match(sidebar, /Updates for users/)
   assert.match(projectHome, /Show product updates to users/)
-  assert.match(updatesOnboarding, /useState<Choice>\('updates'\)/)
+  assert.match(updatesOnboarding, /useState<Choice>\(["']updates["']\)/)
   assert.doesNotMatch(updatesOnboarding, /localStorage/)
   assert.doesNotMatch(sidebar, /label: 'Release notes'/)
 })
@@ -127,12 +127,32 @@ test('theme tokens use perceptual OKLCH colors in both themes', () => {
   const tailwind = read('../../tailwind.config.cjs')
 
   assert.match(css, /--background: 0\.985/)
-  assert.match(css, /\.dark[\s\S]*--background: 0\.155/)
+  assert.match(css, /\.dark[\s\S]*--background: 0\.135/)
+  assert.match(css, /\.dark[\s\S]*--surface-raised: 0\.225/)
+  assert.match(css, /\.dark[\s\S]*--card: 0\.195/)
   assert.match(css, /--surface-sidebar:/)
   assert.match(css, /--surface-selected:/)
   assert.match(tailwind, /surface:\s*\{/)
   assert.match(tailwind, /oklch\(var\(--primary\)/)
   assert.doesNotMatch(tailwind, /hsl\(var\(--primary\)/)
+})
+
+test('authenticated workspaces use elevated cards instead of flat divider-only canvases', () => {
+  const card = read('../../src/components/ui/card.tsx')
+  const install = read('../../src/app/(dashboard)/projects/[id]/install-tab.tsx')
+  const projectHome = read('../../src/app/(dashboard)/projects/[id]/project-home.tsx')
+  const customize = read('../../src/app/(dashboard)/projects/[id]/customize-tab.tsx')
+  const verify = read('../../src/app/(dashboard)/projects/[id]/project-verify-client.tsx')
+
+  assert.match(card, /rounded-xl border border-border\/80 bg-card/)
+  assert.match(card, /border-b bg-muted\/25/)
+  assert.match(card, /shadow-\[var\(--shadow-card\)\]/)
+  assert.match(install, /<Card data-tour="install-snippet">/)
+  assert.match(install, /surface-raised/)
+  assert.doesNotMatch(install, /grid gap-8 border-b/)
+  assert.match(projectHome, /<Card>/)
+  assert.match(customize, /rounded-xl border bg-card/)
+  assert.match(verify, /rounded-xl border bg-card/)
 })
 
 test('public docs use the stable canonical embed and remote customization language', () => {


### PR DESCRIPTION
## Summary
- introduce clearer light and dark surface elevation across the authenticated product
- restore purposeful card grouping across every main sidebar workflow
- convert install, verification, project setup, feedback, updates, settings, and tutorials away from divider-only canvases
- strengthen contained tabs and focused sub-panels without nested card clutter

## Focused verification
- pnpm --filter @feedbacks/dashboard type-check
- pnpm --filter @feedbacks/dashboard lint
- node --experimental-strip-types --test packages/dashboard/tests/unit/product-experience.test.ts
- git diff --check

No Playwright or end-to-end suite was run, per request.