### PR TITLE
Fix production card shadows

### DIFF
--- a/packages/dashboard/src/app/globals.css
+++ b/packages/dashboard/src/app/globals.css
@@ -259,6 +259,9 @@
 
   .surface-card { box-shadow: var(--shadow-card); }
 
+  /* Tailwind does not emit this CSS-variable arbitrary shadow reliably in production. */
+  [class~="shadow-[var(--shadow-card)]"] { box-shadow: var(--shadow-card); }
+
   .animate-logo-load-pop {
     animation: logo-load-pop 1.1s var(--ease-out-expo) infinite;
     transform-origin: center;

--- a/packages/dashboard/tests/unit/product-experience.test.ts
+++ b/packages/dashboard/tests/unit/product-experience.test.ts
@@ -130,6 +130,7 @@ test('theme tokens use perceptual OKLCH colors in both themes', () => {
   assert.match(css, /\.dark[\s\S]*--background: 0\.135/)
   assert.match(css, /\.dark[\s\S]*--surface-raised: 0\.225/)
   assert.match(css, /\.dark[\s\S]*--card: 0\.195/)
+  assert.match(css, /\[class~="shadow-\[var\(--shadow-card\)\]"\]/)
   assert.match(css, /--surface-sidebar:/)
   assert.match(css, /--surface-selected:/)
   assert.match(tailwind, /surface:\s*\{/)


### PR DESCRIPTION
## Summary
- add a central production-safe rule for the shared card shadow token
- retain the tonal surface hierarchy while restoring subtle depth

## Focused verification
- product-experience unit tests: 10 passed
- git diff --check

No end-to-end suite was run.