### PR TITLE
Redesign dashboard experience

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -12,7 +12,7 @@ Developer-led teams, indie founders, and small SaaS builders. They should feel t
 
 ## Scene
 
-A developer is adding feedback collection during a normal build session, switching between code, docs, and the dashboard on a laptop or desktop monitor. The UI should default to dark mode for focus and continuity with developer tools, while keeping light mode available and equally usable.
+A developer is adding feedback collection during a normal build session, switching between code, docs, and the dashboard on a laptop or desktop monitor. The interface should default to a calm light canvas that keeps code and actions easy to distinguish. Dark mode remains fully supported for users who choose it.
 
 ## Principles
 
@@ -24,17 +24,19 @@ A developer is adding feedback collection during a normal build session, switchi
 
 ## Visual System
 
-- Theme: dark-first by default, with restrained contrast, crisp separation, and a fully usable light mode for users who choose it.
+- Theme: light-first by default. Both themes use visibly distinct canvas, sidebar, panel, raised, selected, popover, and code roles.
 - Typography: system sans or the existing app font stack. Fixed sizes, no viewport-scaled product text.
 - Accent: controlled green/primary accent for primary actions, active state, success, and focus. Do not use accent as decoration.
-- Structure: crisp 1px borders, neutral panels, compact spacing, and clear section separation.
-- Radius: keep product cards and controls modest. Avoid oversized rounded cards unless already established by a component.
+- Structure: crisp 1px borders, neutral panels, compact spacing, and clear section separation. Prefer page headers, rows, tables, and disclosures over card stacks.
+- Radius: keep panels and controls modest. Avoid oversized rounded containers and repeated pill shapes.
 - Icons: use the existing icon system for actions and status. Prefer icon plus label for unfamiliar actions.
 
 ## Component Rules
 
 - Primary actions should be obvious and singular on first-run screens.
 - Secondary actions should stay visible but quieter, especially verification, docs, billing, and integration settings.
+- Code and its copy action should appear before explanatory setup material.
+- Keep common controls open. Put advanced, security, agent, and reference content in disclosures.
 - Empty states must teach the next action: create project, copy snippet, verify install, add endpoint, publish board.
 - Loading states should preserve the layout with skeletons or in-place states.
 - Error states must say what failed and what to try next.

--- a/docs/2026-07-30-dashboard-experience-redesign.md
+++ b/docs/2026-07-30-dashboard-experience-redesign.md
@@ -1,0 +1,180 @@
+# Dashboard Experience Redesign
+
+Date: 2026-07-30
+
+Status: Implemented and verified
+
+## Outcome
+
+Make the first ten minutes feel obvious and make the ongoing dashboard feel calm, fast, and trustworthy.
+
+The intended first-run sequence is:
+
+1. Name the project.
+2. Copy one recommended snippet.
+3. Verify one test.
+4. See the test in the inbox.
+5. Customize or connect other tools only after the loop works.
+
+## Audit summary
+
+### What the screenshot reveals
+
+- The install code is below the first viewport even though copying it is the only important task.
+- The same three-step story appears in the setup banner and again inside the installation introduction.
+- The setup banner, installation explanation, connection details, platform chooser, and code surface all have similar weight.
+- Dark surfaces differ too little in practical use, so panels blend into a long black page.
+- The bright green accent appears across navigation, labels, steps, and the primary action. It stops identifying the primary action.
+- Seven platform choices appear before the user has copied anything.
+- Technical details and future capabilities are presented before first success.
+- The sidebar shows a broad product map during a moment that needs a narrow path.
+- The new-project route does not force the app shell to refresh after creation, which can leave the sidebar showing the wrong empty-project state.
+
+### Systemic findings
+
+The dashboard currently contains:
+
+- 170 card component usages
+- 95 `rounded-xl` usages
+- 75 `rounded-full` usages
+- 83 explicit `bg-card` usages
+- 349 `text-muted-foreground` usages
+
+The problem is cumulative. Cards, pills, muted paragraphs, badges, and bordered sub-containers are individually reasonable, but they are repeated until everything looks secondary and everything requires reading.
+
+### Product and implementation drift
+
+- `PRODUCT.md` calls for light-first presentation, while `DESIGN.md` and the root theme currently default to dark.
+- The PRD requires the recommended snippet above the fold, but the rendered install screen places it below two explanatory regions.
+- The product brief says advanced settings come later, but agent setup, connection details, deployment hardening, and seven target choices all compete on the install page.
+- The dashboard contains a second no-project onboarding branch after an earlier return, so that branch is unreachable.
+- Home repeats shortcuts in the header, setup prompt, metric strip, mobile shortcuts, desktop shortcuts, and recent-activity actions.
+
+## Reference patterns
+
+This redesign borrows operating principles, not visual imitation:
+
+- Vercel: prioritize the most common developer workflows, use the project as a filter, and keep navigation consistent between account and project contexts.
+- Stripe: keep guidance in situ, put common actions near the object being worked on, and preserve developer flow instead of sending users between explanatory pages.
+- Carbon Design System: progressively disclose non-critical content, use concise progress indicators only for real linear tasks, and make empty states lead directly to the next productive action.
+- Linear-style product discipline: dense where the data is useful, quiet where the user needs to decide, and one clear action per state.
+
+## Design direction
+
+### Scene
+
+A developer is installing feedback collection during a normal build session on a laptop, switching between an editor, a browser, and the dashboard. They need confidence, a copy button, and a clear verification result. They do not need a product tour embedded in every page.
+
+### Theme
+
+- Make light mode the default for new accounts.
+- Keep dark mode fully supported.
+- Increase the tonal difference between canvas, sidebar, raised panel, selected row, popover, and code surfaces.
+- Use green for the primary action, active navigation, focus, success, and small status signals only.
+- Use warm tinted neutrals instead of pure black, pure white, or undifferentiated gray.
+
+### Structure
+
+- Replace the default "card stack" with page headers, section panels, rows, tables, and disclosures.
+- Reduce the default corner radius and shadow strength.
+- Use borders and tonal layers to separate related regions.
+- Keep explanatory prose to one short sentence when possible.
+- Keep advanced material closed until requested.
+- Preserve 44px touch targets and visible focus states.
+
+## Implementation checklist
+
+### 1. Foundation and application shell
+
+- [x] Reconcile `DESIGN.md` with a light-first default and the new hierarchy rules.
+- [x] Replace the global light and dark tokens with clearly separated canvas, sidebar, panel, raised, selected, popover, code, and border roles.
+- [x] Make light mode the default for a new account while preserving the saved user choice.
+- [x] Simplify the theme control so its label and current state are unambiguous.
+- [x] Reduce the default card radius, shadow, and decorative header treatment.
+- [x] Add reusable page-header, section-panel, status-dot, and compact-step components.
+- [x] Make the dashboard content width and spacing consistent at desktop, tablet, and mobile sizes.
+- [x] Keep the project selector visually dominant in the sidebar and make account utilities quieter.
+- [x] Fix the stale sidebar after project creation by refreshing the app shell on success.
+
+### 2. First-run project creation
+
+- [x] Keep project name as the only visible required field.
+- [x] Keep product goal, icon, and domain behind optional disclosures.
+- [x] Rewrite the primary action and next-step copy so the destination is predictable.
+- [x] Remove decorative entrance motion from the task surface.
+- [x] Preserve inline plan-limit and failure recovery states.
+
+### 3. Install and verify
+
+- [x] Replace the large setup banner with a compact three-step progress row.
+- [x] Put the recommended Website snippet in the first viewport.
+- [x] Reduce platform selection to Website, React, Next.js, and Vue, with WordPress, HTML block, and native mobile under "Other".
+- [x] Give the active platform a clearly selected surface that is distinct from the page background.
+- [x] Put the copy action directly in the code surface header.
+- [x] Show only two immediate guidance rows: where to paste and what should appear.
+- [x] Keep one concise trust note explaining that future form changes do not require new code.
+- [x] Move the project key, agent setup, CSP, SRI, captcha, and native-mobile caveats into secondary disclosures.
+- [x] Make "Verify installation" the single next action after the snippet.
+- [x] Remove the duplicated installation overview and repeated three-step explanation.
+- [x] Keep missing-key recovery, setup-packet creation, revocation, and security guidance functional.
+
+### 4. Dashboard home
+
+- [x] Remove the unreachable duplicate no-project onboarding branch.
+- [x] Replace the six-cell metric strip with three decision-oriented metrics.
+- [x] Keep setup as the dominant home state until the first feedback arrives.
+- [x] After activation, prioritize unread feedback and recent activity.
+- [x] Remove duplicate shortcut groups and repeated calls to create a project.
+- [x] Keep project scope selection compact and obvious.
+- [x] Keep plan usage available but visually secondary.
+- [x] Show trends only when data exists.
+
+### 5. Feedback inbox and detail
+
+- [x] Replace pill-heavy filters with compact segmented controls and a single "More filters" disclosure.
+- [x] Strengthen unread, selected, status, priority, and source differences without adding more containers.
+- [x] Keep search, project scope, saved views, and bulk actions in one predictable toolbar.
+- [x] Make empty states point to install, clear filters, or create project as appropriate.
+- [x] Apply the new page header and panel hierarchy to feedback detail.
+- [x] Keep message content dominant and move metadata into a quieter secondary column or region.
+
+### 6. Feedback form customization
+
+- [x] Keep the live preview and edit controls as the two primary regions.
+- [x] Keep placement and appearance open.
+- [x] Move optional fields, trigger details, captcha, and advanced behavior into disclosures.
+- [x] Remove duplicate save and discard action groups.
+- [x] Keep one persistent save state when there are unsaved changes.
+- [x] Preserve preview-only versus saved-state language.
+
+### 7. Integrations, API, boards, updates, settings, billing, and projects
+
+- [x] Turn integration types into a compact catalog. Expand configured or selected destinations instead of showing every endpoint form.
+- [x] Keep endpoint health, test, save, failure, and replay states easy to scan.
+- [x] Keep API quick start visible and move trust-boundary reference, full endpoints, MCP tools, and prompts into disclosures.
+- [x] Apply the shared page header and section hierarchy to public-board settings and product updates.
+- [x] Replace repetitive settings and billing card stacks with section rows and clear destructive regions.
+- [x] Apply the same hierarchy to project list, project home, project settings, loading, and empty states.
+- [x] Keep all existing functional routes and entitlement rules intact.
+
+### 8. Copy, accessibility, responsive behavior, and quality
+
+- [x] Remove repeated headings, throat-clearing introductions, and future-feature explanations from critical paths.
+- [x] Use direct verbs: copy snippet, verify installation, open inbox, save changes, send test.
+- [x] Keep body copy within a readable line length.
+- [x] Verify keyboard focus, disclosure semantics, touch targets, contrast, and reduced motion.
+- [x] Verify the install, project creation, inbox, customization, navigation, settings, and billing tests.
+- [x] Run type checking, linting, unit tests, production build, and browser smoke checks.
+- [x] Reconcile every checklist item against the finished implementation.
+
+## Acceptance criteria
+
+- A new project lands on a screen where the recommended snippet and copy action are visible without scrolling at a 1440 by 900 viewport.
+- The first viewport contains one primary action.
+- The platform choice is visually distinct from both the page canvas and the code surface.
+- Dark mode exposes at least four visibly distinct neutral layers before accent color is used.
+- No critical first-run action depends on reading advanced setup material.
+- Project creation refreshes the sidebar state.
+- Home has one setup prompt before activation and one recent-activity focus after activation.
+- Secondary dashboard pages share the same header, section, control, loading, empty, and destructive-state vocabulary.
+- Existing product behavior, API paths, and plan enforcement remain intact.

--- a/packages/dashboard/src/app/(dashboard)/api-docs/loading.tsx
+++ b/packages/dashboard/src/app/(dashboard)/api-docs/loading.tsx
@@ -8,7 +8,7 @@ export default function ApiDocsLoading() {
         <Skeleton className="h-7 w-64" />
         <Skeleton className="h-4 w-[30rem] max-w-full" />
       </div>
-      <div className="overflow-hidden rounded-xl border bg-card">
+      <div className="overflow-hidden rounded-lg border bg-card">
         {Array.from({ length: 3 }).map((_, index) => (
           <div key={index} className="grid gap-3 border-b px-4 py-4 last:border-b-0 md:grid-cols-[minmax(0,1fr)_auto]">
             <div className="space-y-2">

--- a/packages/dashboard/src/app/(dashboard)/billing/billing-client.tsx
+++ b/packages/dashboard/src/app/(dashboard)/billing/billing-client.tsx
@@ -4,7 +4,6 @@ import * as React from 'react'
 import { useSearchParams } from 'next/navigation'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { toast } from '@/hooks/use-toast'
 import type { BillingSummary } from '@/lib/types'
 import { Loader2 } from 'lucide-react'
@@ -122,9 +121,9 @@ export function BillingClient({ initialSummary }: BillingClientProps) {
       : `Latest ${summary.entitlements.webhookDeliveryLogLimit} deliveries`
 
   return (
-    <div className="space-y-6">
-      <Card className="overflow-hidden rounded-xl shadow-[var(--shadow-card)]">
-        <CardHeader className="border-b bg-muted/25">
+    <div className="overflow-hidden rounded-lg border bg-card shadow-sm">
+      <section>
+        <header className="border-b bg-surface-raised px-5 py-5 sm:px-6">
           <div className="flex flex-wrap items-center gap-2">
             <Badge variant={summary.account.plan_tier === 'pro' ? 'default' : 'secondary'}>
               {summary.entitlements.label}
@@ -132,13 +131,13 @@ export function BillingClient({ initialSummary }: BillingClientProps) {
             <Badge variant="outline">{summary.account.billing_status}</Badge>
             {!summary.billingEnabled && <Badge variant="outline">Billing offline</Badge>}
           </div>
-          <CardTitle className="mt-3 text-lg">Billing and plan</CardTitle>
-          <CardDescription>
+          <h2 className="mt-3 text-lg font-semibold">Billing and plan</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
             See your plan, usage, limits, and renewal date in one place.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4 pt-6">
-          <div className="divide-y border-y bg-muted/10">
+          </p>
+        </header>
+        <div className="space-y-4 p-5 sm:p-6">
+          <div className="divide-y border-y bg-surface-raised/60">
             {[
               {
                 label: 'Projects',
@@ -181,17 +180,17 @@ export function BillingClient({ initialSummary }: BillingClientProps) {
               Refresh status
             </Button>
           </div>
-        </CardContent>
-      </Card>
+        </div>
+      </section>
 
-      <Card className="overflow-hidden rounded-xl shadow-[var(--shadow-card)]">
-        <CardHeader className="border-b bg-muted/25">
-          <CardTitle className="text-base">Entitlements</CardTitle>
-          <CardDescription>
+      <section className="border-t">
+        <header className="border-b bg-surface-raised px-5 py-4 sm:px-6">
+          <h2 className="font-semibold">Plan capabilities</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
             Free includes the core setup tools with smaller limits. Pro raises those limits for teams.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="grid pt-6 md:grid-cols-2 md:divide-x">
+          </p>
+        </header>
+        <div className="grid p-5 sm:p-6 md:grid-cols-2 md:divide-x">
           <div className="pb-4 text-sm md:pb-0 md:pr-6">
             <p className="font-medium">Included now</p>
             <ul className="mt-2 space-y-1 text-muted-foreground">
@@ -211,8 +210,8 @@ export function BillingClient({ initialSummary }: BillingClientProps) {
               <li>If billing looks stale after checkout, use Refresh status after a minute.</li>
             </ul>
           </div>
-        </CardContent>
-      </Card>
+        </div>
+      </section>
     </div>
   )
 }

--- a/packages/dashboard/src/app/(dashboard)/billing/loading.tsx
+++ b/packages/dashboard/src/app/(dashboard)/billing/loading.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 export default function BillingLoading() {
   return (
     <div className="space-y-6">
-      <div className="rounded-xl border bg-card p-6">
+      <div className="rounded-lg border bg-card p-6">
         <div className="flex gap-2">
           <Skeleton className="h-6 w-16 rounded-full" />
           <Skeleton className="h-6 w-24 rounded-full" />
@@ -21,8 +21,8 @@ export default function BillingLoading() {
         </div>
       </div>
       <div className="grid gap-3 md:grid-cols-2">
-        <Skeleton className="h-40 rounded-xl" />
-        <Skeleton className="h-40 rounded-xl" />
+        <Skeleton className="h-40 rounded-lg" />
+        <Skeleton className="h-40 rounded-lg" />
       </div>
     </div>
   )

--- a/packages/dashboard/src/app/(dashboard)/billing/page.tsx
+++ b/packages/dashboard/src/app/(dashboard)/billing/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation'
 import { getCurrentUserBillingSummary } from '@/lib/billing'
 import { BillingClient } from './billing-client'
+import { PageHeader } from '@/components/ui/workspace-shell'
 
 export const dynamic = 'force-dynamic'
 export const metadata = { title: 'Billing' }
@@ -13,12 +14,11 @@ export default async function BillingPage() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold">Billing</h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Plan state, usage, and self-serve upgrade or billing management.
-        </p>
-      </div>
+      <PageHeader
+        eyebrow="Account"
+        title="Billing"
+        description="Review plan usage, upgrade, or manage the active subscription."
+      />
 
       <BillingClient initialSummary={summary} />
     </div>

--- a/packages/dashboard/src/app/(dashboard)/dashboard/boards/page.tsx
+++ b/packages/dashboard/src/app/(dashboard)/dashboard/boards/page.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { getMarketingOrigin } from '@/lib/domain-routing'
 import { CURRENT_PROJECT_COOKIE } from '@/lib/project-selection'
+import { PageHeader } from '@/components/ui/workspace-shell'
 
 export const metadata = { title: 'Your Public Boards' }
 
@@ -50,24 +51,22 @@ export default async function DashboardBoardsPage({
 
   return (
     <div className="mx-auto max-w-6xl space-y-6" data-tour="owner-boards">
-      <div data-tour="owner-boards-summary" className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <p className="text-xs font-semibold text-primary">Public feedback page</p>
-          <h1 className="mt-2 text-2xl font-bold">{selectedProject ? selectedProject.name : 'Your public page'}</h1>
-          <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-            Let users share ideas, vote, and see your replies.
-          </p>
-        </div>
-        <Button variant="outline" asChild>
-          <a href={publicBoardsUrl}>
+      <div data-tour="owner-boards-summary">
+        <PageHeader
+          eyebrow="Public feedback page"
+          title={selectedProject ? selectedProject.name : 'Your public page'}
+          description="Let users share ideas, vote, and see your replies."
+          action={<Button variant="outline" asChild>
+            <a href={publicBoardsUrl}>
             <Globe className="mr-2 h-4 w-4" />
             See public pages
-          </a>
-        </Button>
+            </a>
+          </Button>}
+        />
       </div>
 
       {!selectedProject ? (
-        <div className="rounded-xl border bg-card p-8 text-center shadow-[var(--shadow-card)] sm:p-12">
+        <div className="rounded-lg border bg-card p-8 text-center shadow-[var(--shadow-card)] sm:p-12">
           <h2 className="text-lg font-semibold">Create a project first</h2>
           <p className="mt-2 text-sm text-muted-foreground">Each public page belongs to one project.</p>
           <Button className="mt-5" asChild><Link href="/projects/new">Create project</Link></Button>

--- a/packages/dashboard/src/app/(dashboard)/dashboard/page.tsx
+++ b/packages/dashboard/src/app/(dashboard)/dashboard/page.tsx
@@ -1,11 +1,9 @@
 import { createServerSupabase } from '@/lib/supabase-server'
 import { cookies } from 'next/headers'
 import { getCurrentUserBillingSummary, getHistoryCutoff } from '@/lib/billing'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { CollapsibleDashboardSection } from '@/components/collapsible-dashboard-section'
 import { DashboardRefresher } from '@/components/dashboard-refresher'
+import { PageHeader, SectionPanel } from '@/components/ui/workspace-shell'
 import { isFeedbackUnread } from '@/lib/feedback-read-state'
 import { cn, formatRelativeTime, truncate, getStatusColor } from '@/lib/utils'
 import type { Feedback } from '@/lib/types'
@@ -14,14 +12,12 @@ import { loadDashboardStats } from '@/lib/dashboard-stats'
 import Link from 'next/link'
 import {
   Star,
-  Bell,
   ArrowRight,
   Plus,
   Inbox,
   TrendingUp,
   Bot,
   Code2,
-  ShieldCheck,
   BarChart3,
   Bug,
   Lightbulb,
@@ -97,9 +93,6 @@ export default async function DashboardPage({
   let ratingQuery = historyCutoff
     ? supabase.from('feedback').select('rating').not('rating', 'is', null).eq('is_archived', false).gte('created_at', historyCutoff)
     : supabase.from('feedback').select('rating').not('rating', 'is', null).eq('is_archived', false)
-  let agentQuery = historyCutoff
-    ? supabase.from('feedback').select('*', { count: 'exact', head: true }).not('agent_name', 'is', null).eq('is_archived', false).gte('created_at', historyCutoff)
-    : supabase.from('feedback').select('*', { count: 'exact', head: true }).not('agent_name', 'is', null).eq('is_archived', false)
   let recentQuery = historyCutoff
     ? supabase.from('feedback').select('*, projects(id, name)').eq('is_archived', false).gte('created_at', historyCutoff).order('created_at', { ascending: false }).limit(8)
     : supabase.from('feedback').select('*, projects(id, name)').eq('is_archived', false).order('created_at', { ascending: false }).limit(8)
@@ -116,7 +109,6 @@ export default async function DashboardPage({
     totalQuery = totalQuery.eq('project_id', scopedProjectId)
     unreadQuery = unreadQuery.eq('project_id', scopedProjectId)
     ratingQuery = ratingQuery.eq('project_id', scopedProjectId)
-    agentQuery = agentQuery.eq('project_id', scopedProjectId)
     recentQuery = recentQuery.eq('project_id', scopedProjectId)
     typeQuery = typeQuery.eq('project_id', scopedProjectId)
     sparkQuery = sparkQuery.eq('project_id', scopedProjectId)
@@ -140,7 +132,6 @@ export default async function DashboardPage({
 
   let total = aggregateStats?.total || 0
   let unread = aggregateStats?.unread || 0
-  let agents = aggregateStats?.agentCount || 0
   let avgRating = aggregateStats?.averageRating ?? null
   let ratingCount = aggregateStats?.ratingCount || 0
   const typeCounts = { bug: 0, idea: 0, praise: 0, question: 0, other: 0 }
@@ -157,13 +148,11 @@ export default async function DashboardPage({
       { count: totalCount },
       { count: unreadCount },
       { data: ratingData },
-      { count: agentCount },
       { data: typeDist },
       { data: sparkData },
-    ] = await Promise.all([totalQuery, unreadQuery, ratingQuery, agentQuery, typeQuery, sparkQuery])
+    ] = await Promise.all([totalQuery, unreadQuery, ratingQuery, typeQuery, sparkQuery])
     total = totalCount || 0
     unread = unreadCount || 0
-    agents = agentCount || 0
     ratingCount = ratingData?.length || 0
     avgRating = ratingCount
       ? ratingData!.reduce((sum, feedback) => sum + (feedback.rating || 0), 0) / ratingCount
@@ -218,22 +207,6 @@ export default async function DashboardPage({
       sub: ratingCount ? `${ratingCount} rated` : 'no ratings yet',
       href: feedbackHref,
     },
-    ...(showingAllProjects ? [{
-        id: 'projects',
-        label: 'Projects',
-        value: projects,
-        urgent: false,
-        sub: 'active',
-        href: '/projects',
-      }] : []),
-    {
-      id: 'agents',
-      label: 'From agents',
-      value: agents,
-      urgent: false,
-      sub: agents > 0 ? 'AI submitted' : 'none yet',
-      href: feedbackLink({ agent: '1' }),
-    },
   ]
 
   const typeColorMap: Record<string, string> = {
@@ -246,166 +219,112 @@ export default async function DashboardPage({
 
   if (projects === 0) {
     return (
-      <div className="animate-fade-in mx-auto max-w-5xl space-y-6">
-        <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_320px]">
-          <Card className="overflow-hidden border-primary/25 bg-card">
-            <CardContent className="p-6 sm:p-8">
-              <Badge className="bg-primary/90 text-primary-foreground">First run</Badge>
-              <h1 className="mt-5 max-w-2xl text-2xl font-semibold tracking-tight sm:text-3xl">
-                Good {getGreeting()}, {displayName}. Create one project, copy the install, send one test.
-              </h1>
-              <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
-                Start with the basic setup path. Advanced settings, public boards, API access, and integrations can wait until feedback reaches the inbox.
+      <div className="mx-auto max-w-4xl space-y-6">
+        <PageHeader
+          eyebrow="Welcome"
+          title={`Good ${getGreeting()}, ${displayName}`}
+          description="Create one project, copy one snippet, and send one test. That is the whole first run."
+        />
+        <SectionPanel contentClassName="p-0">
+          <div className="grid lg:grid-cols-[minmax(0,1fr)_320px]">
+            <div className="p-6 sm:p-8">
+              <p className="text-sm font-medium text-primary">Start here</p>
+              <h2 className="mt-2 max-w-xl text-2xl font-semibold tracking-[-0.035em]">
+                Name the product that will collect feedback.
+              </h2>
+              <p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
+                Only the name is required. The recommended Website snippet appears on the next screen.
               </p>
-              <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+              <Button asChild size="lg" className="mt-6 gap-2">
                 <Link href="/projects/new">
-                  <Button size="lg" className="w-full gap-2 sm:w-auto">
-                    <Plus className="h-4 w-4" />
-                    Create your first project
-                  </Button>
+                  Create your first project
+                  <ArrowRight className="h-4 w-4" />
                 </Link>
-                <Link href="/projects">
-                  <Button size="lg" variant="outline" className="w-full sm:w-auto">
-                    View setup steps
-                  </Button>
-                </Link>
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base">What happens next</CardTitle>
-              <CardDescription>
-                The dashboard keeps the first setup run in order.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3">
+              </Button>
+            </div>
+            <ol className="divide-y border-t bg-surface-raised/55 lg:border-l lg:border-t-0">
               {[
-                ['1', 'Create project', 'Only the project name is required.'],
-                ['2', 'Install and test', 'Add the shared embed once, then check the inbox.'],
-                ['3', 'Manage remotely', 'Change the feedback form or publish updates to users without replacing code.'],
-              ].map(([step, title, body]) => (
-                <div key={step} className="flex gap-3 rounded-lg border bg-muted/20 p-3">
-                  <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
+                ['1', 'Name project'],
+                ['2', 'Copy snippet'],
+                ['3', 'Verify test'],
+              ].map(([step, label], index) => (
+                <li key={step} className="flex items-center gap-3 px-5 py-4">
+                  <span className={cn(
+                    'flex h-6 w-6 items-center justify-center rounded-full border text-xs font-semibold',
+                    index === 0 ? 'border-primary bg-primary text-primary-foreground' : 'border-border bg-card text-muted-foreground',
+                  )}>
                     {step}
                   </span>
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium">{title}</p>
-                    <p className="mt-0.5 text-xs leading-5 text-muted-foreground">{body}</p>
-                  </div>
-                </div>
+                  <span className={cn('text-sm font-medium', index === 0 ? 'text-foreground' : 'text-muted-foreground')}>{label}</span>
+                </li>
               ))}
-            </CardContent>
-          </Card>
-        </div>
-
-        <Card>
-          <CardContent className="divide-y p-0">
-            {[
-              { Icon: Code2, title: 'One stable embed', body: 'Install once. Saved feedback-form and release-note changes arrive remotely.' },
-              { Icon: ShieldCheck, title: 'Safe by default', body: 'The first snippet uses the browser-safe project key, not private server credentials.' },
-              { Icon: Inbox, title: 'One test proves the loop', body: 'Send a short test message, then use the inbox for triage and routing.' },
-            ].map(({ Icon, title, body }) => (
-              <div key={title} className="flex gap-3 px-5 py-4">
-                <Icon className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
-                <div className="min-w-0">
-                  <p className="text-sm font-medium">{title}</p>
-                  <p className="mt-0.5 text-sm leading-6 text-muted-foreground">{body}</p>
-                </div>
-              </div>
-            ))}
-          </CardContent>
-        </Card>
+            </ol>
+          </div>
+        </SectionPanel>
       </div>
     )
   }
 
   return (
-    <div className="animate-fade-in space-y-5">
-      {/* ─── Header ───────────────────────────────────────── */}
-      <div className="grid gap-4 rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6 lg:grid-cols-[minmax(260px,1fr)_auto_minmax(220px,auto)] lg:items-center">
-        <div className="min-w-0">
-          <h1 className="truncate text-2xl font-semibold tracking-[-0.035em] sm:text-3xl">
-            Good {getGreeting()}, {displayName}
-          </h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            {unread > 0 ? (
-              <>
-                <span className="font-semibold text-foreground">{unread}</span> unread{' '}
-                {unread === 1 ? 'item' : 'items'} waiting in your inbox.
-              </>
-            ) : total > 0 ? (
-              'All caught up. Here is your overview.'
-            ) : (
-              'Customize a project, install the code, then send one test message.'
-            )}
-          </p>
-          {selectedProject && (
-            <div className="mt-2 inline-flex items-center rounded-md border bg-card p-0.5 text-[11px]" aria-label="Dashboard project scope">
-              <Link
-                href="/dashboard"
-                data-testid="dashboard-current-project-scope"
-                aria-current={!showingAllProjects ? 'page' : undefined}
-                className={cn(
-                  'rounded px-2 py-1 font-medium transition-colors',
-                  !showingAllProjects ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground',
-                )}
-              >
-                {selectedProject.name}
-              </Link>
-              <Link
-                href="/dashboard?scope=all"
-                data-testid="dashboard-all-projects-scope"
-                aria-current={showingAllProjects ? 'page' : undefined}
-                className={cn(
-                  'rounded px-2 py-1 font-medium transition-colors',
-                  showingAllProjects ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground',
-                )}
-              >
-                All projects
-              </Link>
-            </div>
-          )}
-        </div>
-        <div data-tour="dashboard-actions" className="flex flex-wrap items-center gap-2 lg:justify-center">
-          <Link href="/projects/new">
-            <Button size="sm" variant="outline" className="h-8 gap-1.5 px-2.5 text-xs font-medium">
-              <Plus className="h-3.5 w-3.5" />
-              New project
-            </Button>
-          </Link>
-          <Link href={feedbackHref}>
-            <Button size="sm" className="h-8 gap-1.5 text-xs font-medium">
-              <Inbox className="h-3.5 w-3.5" />
-              Inbox
-              {unread > 0 && (
-                <span className="ml-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-white/20 px-1 text-[11px] font-bold">
-                  {unread}
-                </span>
+    <div className="space-y-5">
+      <PageHeader
+        title={`Good ${getGreeting()}, ${displayName}`}
+        description={unread > 0
+          ? `${unread} unread ${unread === 1 ? 'item needs' : 'items need'} review.`
+          : total > 0
+            ? 'Your inbox is clear. Recent product signal is below.'
+            : 'Connect the project and send one test to start the feedback loop.'}
+        meta={selectedProject && (
+          <div className="inline-flex items-center rounded-md border bg-surface-raised p-0.5 text-xs" aria-label="Dashboard project scope">
+            <Link
+              href="/dashboard"
+              data-testid="dashboard-current-project-scope"
+              aria-current={!showingAllProjects ? 'page' : undefined}
+              className={cn(
+                'rounded px-2.5 py-1.5 font-medium transition-colors',
+                !showingAllProjects ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground',
               )}
-            </Button>
-          </Link>
-        </div>
-        {billingSummary && (
-          <div className="min-w-0 border-l border-foreground/10 pl-4 lg:justify-self-end">
-            <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">Plan</p>
-            <p className="mt-0.5 truncate text-xs font-medium">
-              {billingSummary.entitlements.label} · {billingSummary.entitlements.feedbackMonthlyLimit
-                ? `${billingSummary.usage.feedbackThisMonth}/${billingSummary.entitlements.feedbackMonthlyLimit} feedback`
-                : 'Unlimited feedback'}
-            </p>
-            <p className="truncate text-[11px] text-muted-foreground">
-              {billingSummary.entitlements.historyDays
-                ? `Last ${billingSummary.entitlements.historyDays} days visible`
-                : 'Full history visible'}
-            </p>
+            >
+              {selectedProject.name}
+            </Link>
+            <Link
+              href="/dashboard?scope=all"
+              data-testid="dashboard-all-projects-scope"
+              aria-current={showingAllProjects ? 'page' : undefined}
+              className={cn(
+                'rounded px-2.5 py-1.5 font-medium transition-colors',
+                showingAllProjects ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground',
+              )}
+            >
+              All projects
+            </Link>
           </div>
         )}
-      </div>
+        action={
+          <div data-tour="dashboard-actions" className="flex items-center gap-2">
+            <Button asChild size="sm" variant="outline" className="gap-1.5">
+              <Link href="/projects/new"><Plus className="h-3.5 w-3.5" />New project</Link>
+            </Button>
+            <Button asChild size="sm" className="gap-1.5">
+              <Link href={feedbackHref}><Inbox className="h-3.5 w-3.5" />Inbox{unread > 0 && ` (${unread})`}</Link>
+            </Button>
+          </div>
+        }
+      />
+
+      {billingSummary && (
+        <div className="flex flex-wrap items-center justify-between gap-2 border-b pb-3 text-xs text-muted-foreground">
+          <span>{billingSummary.entitlements.label} plan</span>
+          <span>
+            {billingSummary.entitlements.feedbackMonthlyLimit
+              ? `${billingSummary.usage.feedbackThisMonth} of ${billingSummary.entitlements.feedbackMonthlyLimit} monthly feedback used`
+              : 'Unlimited feedback and full history'}
+          </span>
+        </div>
+      )}
 
       {total === 0 && primaryProject ? (
-        <div data-tour="dashboard-capabilities" className="flex flex-col gap-4 rounded-xl border border-primary/25 bg-card p-5 shadow-[var(--shadow-card)] sm:flex-row sm:items-center sm:justify-between">
+        <div data-tour="dashboard-capabilities" className="flex flex-col gap-4 rounded-lg border border-primary/25 bg-card p-5 shadow-[var(--shadow-card)] sm:flex-row sm:items-center sm:justify-between">
           <div className="flex min-w-0 gap-3">
             <Code2 className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
             <div>
@@ -423,92 +342,16 @@ export default async function DashboardPage({
         </div>
       ) : <DashboardRefresher />}
 
-      {/* ─── Onboarding (shown when no projects) ──────────── */}
-      {projects === 0 && (
-        <Card className="relative overflow-hidden border-primary/20 bg-gradient-to-br from-primary/[0.04] via-background to-background">
-          <div className="absolute -right-16 -top-16 h-48 w-48 rounded-full bg-primary/5 blur-3xl" />
-          <CardContent className="relative p-6 sm:p-8">
-            <div className="mb-6">
-              <h2 className="text-xl font-bold tracking-tight">Get started in 2 minutes</h2>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Set up your first project and start collecting feedback from your users.
-              </p>
-            </div>
-            <div className="space-y-3">
-              {[
-                {
-                  step: 1,
-                  title: 'Create your first project',
-                  description: 'Give it a name and optional domain',
-                  href: '/projects/new',
-                  done: false,
-                  cta: 'Create project',
-                },
-                {
-                  step: 2,
-                  title: 'Install the shared embed',
-                  description: 'Add one stable snippet near your application root',
-                  href: null,
-                  done: false,
-                  cta: null,
-                },
-                {
-                  step: 3,
-                  title: 'Verify and manage remotely',
-                  description: 'Confirm one inbox item, then configure products from the dashboard',
-                  href: null,
-                  done: false,
-                  cta: null,
-                },
-              ].map((item) => (
-                <div
-                  key={item.step}
-                  className={cn(
-                    'flex items-center gap-4 rounded-xl border p-4 transition-all',
-                    item.step === 1
-                      ? 'border-primary/30 bg-primary/[0.04] shadow-sm'
-                      : 'border-border/60 opacity-60'
-                  )}
-                >
-                  <div
-                    className={cn(
-                      'flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-bold',
-                      item.step === 1
-                        ? 'bg-primary text-primary-foreground'
-                        : 'bg-muted text-muted-foreground'
-                    )}
-                  >
-                    {item.step}
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <p className="text-sm font-semibold">{item.title}</p>
-                    <p className="text-xs text-muted-foreground">{item.description}</p>
-                  </div>
-                  {item.href && item.cta && (
-                    <Link href={item.href}>
-                      <Button size="sm" className="h-8 gap-1.5 text-xs font-medium">
-                        {item.cta}
-                        <ArrowRight className="h-3 w-3" />
-                      </Button>
-                    </Link>
-                  )}
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-      )}
-
       {/* ─── Stat Cards ───────────────────────────────────── */}
-      <div className="grid grid-cols-2 overflow-hidden rounded-xl border bg-card shadow-[var(--shadow-card)] sm:grid-cols-3 lg:grid-cols-6">
+      <div className="grid overflow-hidden rounded-lg border bg-card shadow-[var(--shadow-card)] sm:grid-cols-3">
         {statCards.map((stat) => (
-          <Link key={stat.id} href={stat.href} className={cn('block border-b border-r border-foreground/10 p-4 transition-colors hover:bg-muted/25 lg:border-b-0', stat.urgent && 'bg-amber-50/50 dark:bg-amber-950/15')}>
+          <Link key={stat.id} href={stat.href} className={cn('block border-b border-border p-4 transition-colors last:border-b-0 hover:bg-surface-raised/55 sm:border-b-0 sm:border-r sm:last:border-r-0', stat.urgent && 'bg-amber-50/55 dark:bg-amber-950/20')}>
                 <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
                   {stat.label}
                 </p>
                 <p
                   className={cn(
-                    'mt-1 text-2xl font-bold leading-none tabular-nums',
+                    'mt-2 text-xl font-semibold leading-none tabular-nums',
                     stat.urgent && 'text-amber-600 dark:text-amber-400'
                   )}
                 >
@@ -521,33 +364,8 @@ export default async function DashboardPage({
 
       {/* ─── Activity + Sidebar ───────────────────────────── */}
       <div className="grid gap-5 lg:grid-cols-[1fr_272px]">
-        {/* Mobile quick actions stay readable without horizontal scrolling. */}
-        <div className="lg:hidden">
-          <CollapsibleDashboardSection
-            storageId="quick-actions-mobile"
-            title="Shortcuts"
-            contentClassName="grid grid-cols-2 gap-2 pb-3 pt-0"
-          >
-            <Link href={feedbackLink({ read: 'unread' })} className="flex items-center gap-2 rounded-md bg-muted/50 px-3 py-2.5 text-xs font-medium hover:bg-accent">
-              <Bell className="h-3.5 w-3.5 text-muted-foreground" />
-              Unread
-              {unread > 0 && <Badge variant="secondary" className="ml-auto h-5 text-[10px]">{unread}</Badge>}
-            </Link>
-            <Link href={feedbackLink({ type: 'bug' })} className="flex items-center gap-2 rounded-md bg-muted/50 px-3 py-2.5 text-xs font-medium hover:bg-accent">
-              <Bug className="h-3.5 w-3.5 text-muted-foreground" /> Bugs
-            </Link>
-            <Link href={feedbackLink({ type: 'idea' })} className="flex items-center gap-2 rounded-md bg-muted/50 px-3 py-2.5 text-xs font-medium hover:bg-accent">
-              <Lightbulb className="h-3.5 w-3.5 text-muted-foreground" /> Ideas
-            </Link>
-            <Link href="/projects/new" className="flex items-center gap-2 rounded-md bg-muted/50 px-3 py-2.5 text-xs font-medium hover:bg-accent">
-              <Plus className="h-3.5 w-3.5 text-muted-foreground" /> New project
-            </Link>
-          </CollapsibleDashboardSection>
-        </div>
-
         {/* Recent Activity Feed */}
-        <CollapsibleDashboardSection
-          storageId="recent-activity"
+        <SectionPanel
           title="Recent activity"
           contentClassName="p-0"
           action={
@@ -568,14 +386,14 @@ export default async function DashboardPage({
                 <Inbox className="h-10 w-10 text-muted-foreground/40" />
                 <p className="mt-4 text-sm font-medium">No feedback yet</p>
                 <p className="mt-1.5 max-w-[240px] text-xs leading-relaxed text-muted-foreground">
-                  Set up a project and feedback will appear here as it arrives.
+                  Your first verified test will appear here.
                 </p>
-                <Link href="/projects/new" className="mt-4">
+                {primaryProject && <Link href={`/projects/${primaryProject.id}/install`} className="mt-4">
                   <Button variant="outline" size="sm" className="h-7 gap-1.5 text-xs">
-                    <Plus className="h-3 w-3" />
-                    Create a project
+                    Continue setup
+                    <ArrowRight className="h-3 w-3" />
                   </Button>
-                </Link>
+                </Link>}
               </div>
             ) : (
               <div>
@@ -650,15 +468,14 @@ export default async function DashboardPage({
                 ))}
               </div>
             )}
-        </CollapsibleDashboardSection>
+        </SectionPanel>
 
         {/* Hide this sidebar on mobile and show shortcuts above instead. */}
         <div className="hidden flex-col gap-4 lg:flex">
           {/* Type Breakdown */}
-          <CollapsibleDashboardSection
-            storageId="by-type"
+          <SectionPanel
             title="Feedback types"
-            contentClassName="space-y-3 pb-4 pt-0"
+            contentClassName="space-y-3 p-4"
           >
               {total === 0 ? (
                 <div className="py-6 text-center">
@@ -701,83 +518,13 @@ export default async function DashboardPage({
                     )
                   })
               )}
-          </CollapsibleDashboardSection>
+          </SectionPanel>
 
-          {/* Quick Actions */}
-          <CollapsibleDashboardSection
-            storageId="quick-actions"
-            title="Shortcuts"
-            contentClassName="space-y-0.5 pb-3 pt-0"
-          >
-              <Link
-                href={feedbackLink({ read: 'unread' })}
-                className="flex items-center justify-between rounded-md px-2 py-2 transition-colors hover:bg-accent"
-              >
-                <span className="flex items-center gap-2 text-[12px]">
-                  <Bell className="h-3.5 w-3.5 text-muted-foreground" />
-                  Review unread
-                </span>
-                {unread > 0 && (
-                  <Badge variant="secondary" className="h-5 text-[10px]">
-                    {unread}
-                  </Badge>
-                )}
-              </Link>
-              <Link
-                href={feedbackLink({ type: 'bug' })}
-                className="flex items-center justify-between rounded-md px-2 py-2 transition-colors hover:bg-accent"
-              >
-                <span className="flex items-center gap-2 text-[12px]">
-                  <Bug className="h-3.5 w-3.5 text-muted-foreground" />
-                  Bug reports
-                </span>
-                {typeCounts.bug > 0 && (
-                  <Badge variant="secondary" className="h-5 text-[10px]">
-                    {typeCounts.bug}
-                  </Badge>
-                )}
-              </Link>
-              <Link
-                href={feedbackLink({ type: 'idea' })}
-                className="flex items-center justify-between rounded-md px-2 py-2 transition-colors hover:bg-accent"
-              >
-                <span className="flex items-center gap-2 text-[12px]">
-                  <Lightbulb className="h-3.5 w-3.5 text-muted-foreground" />
-                  Feature requests
-                </span>
-                {typeCounts.idea > 0 && (
-                  <Badge variant="secondary" className="h-5 text-[10px]">
-                    {typeCounts.idea}
-                  </Badge>
-                )}
-              </Link>
-              {agents > 0 && (
-                <Link
-                  href={feedbackLink({ agent: '1' })}
-                  className="flex items-center justify-between rounded-md px-2 py-2 transition-colors hover:bg-accent"
-                >
-                  <span className="flex items-center gap-2 text-[12px]">
-                    <Bot className="h-3.5 w-3.5 text-muted-foreground" />
-                    Agent submissions
-                  </span>
-                  <Badge variant="secondary" className="h-5 text-[10px]">
-                    {agents}
-                  </Badge>
-                </Link>
-              )}
-              <Link
-                href="/projects/new"
-                className="flex items-center gap-2 rounded-md px-2 py-2 text-[12px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-              >
-                <Plus className="h-3.5 w-3.5" />
-                New project
-              </Link>
-          </CollapsibleDashboardSection>
         </div>
       </div>
 
       {/* ─── 7-Day Trend Chart ────────────────────────────── */}
-      <section className="border-t border-foreground/10 pt-4">
+      {total > 0 && <section className="border-t border-foreground/10 pt-4">
         <header className="flex flex-row items-center justify-between pb-3">
           <div>
             <h2 className="text-sm font-semibold">Feedback volume</h2>
@@ -786,15 +533,6 @@ export default async function DashboardPage({
           <TrendingUp className="h-4 w-4 text-muted-foreground" />
         </header>
         <div>
-          {total === 0 ? (
-            <div className="flex flex-col items-center justify-center py-10 text-center">
-              <TrendingUp className="h-9 w-9 text-muted-foreground/40" />
-              <p className="mt-3 text-sm font-medium">No data yet</p>
-              <p className="mt-1 text-xs text-muted-foreground">
-                Trend will appear once you receive your first feedback.
-              </p>
-            </div>
-          ) : (
             <div className="flex items-end gap-1.5 sm:gap-2" style={{ height: 96 }}>
               {days7.map((day, i) => {
                 const count = sparkCounts[i] || 0
@@ -833,9 +571,8 @@ export default async function DashboardPage({
                 )
               })}
             </div>
-          )}
         </div>
-      </section>
+      </section>}
     </div>
   )
 }

--- a/packages/dashboard/src/app/(dashboard)/feedback/[id]/loading.tsx
+++ b/packages/dashboard/src/app/(dashboard)/feedback/[id]/loading.tsx
@@ -5,7 +5,7 @@ export default function FeedbackDetailLoading() {
     <div className="mx-auto max-w-5xl space-y-6">
       <Skeleton className="h-4 w-28" />
       <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_280px]">
-        <div className="rounded-xl border bg-card p-6">
+        <div className="rounded-lg border bg-card p-6">
           <div className="flex flex-wrap gap-2">
             <Skeleton className="h-6 w-20 rounded-full" />
             <Skeleton className="h-6 w-24 rounded-full" />
@@ -18,8 +18,8 @@ export default function FeedbackDetailLoading() {
           </div>
         </div>
         <div className="space-y-4">
-          <Skeleton className="h-48 rounded-xl" />
-          <Skeleton className="h-40 rounded-xl" />
+          <Skeleton className="h-48 rounded-lg" />
+          <Skeleton className="h-40 rounded-lg" />
         </div>
       </div>
     </div>

--- a/packages/dashboard/src/app/(dashboard)/feedback/[id]/page.tsx
+++ b/packages/dashboard/src/app/(dashboard)/feedback/[id]/page.tsx
@@ -6,6 +6,7 @@ import { getFeedbackReadAtUpdate } from '@/lib/feedback-read-state'
 import { cn, formatDate, getTypeColor, statusConfig } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import Link from 'next/link'
 import {
@@ -29,6 +30,7 @@ import {
 } from 'lucide-react'
 import { FeedbackActions } from './feedback-actions'
 import { FeedbackScreenshot } from './feedback-screenshot'
+import { PageHeader } from '@/components/ui/workspace-shell'
 
 export const metadata = { title: 'Feedback Details' }
 
@@ -105,17 +107,17 @@ export default async function FeedbackDetailPage({
   )
 
   return (
-    <div className="animate-fade-in space-y-6">
-      {/* Breadcrumb */}
-      <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-sm text-muted-foreground">
-        <Link href="/feedback" className="transition-colors hover:text-foreground">
-          Inbox
-        </Link>
-        <span>/</span>
-        <span className="text-foreground font-medium">
-          {fb.type || 'Detail'}
-        </span>
-      </nav>
+    <div className="space-y-6">
+      <PageHeader
+        eyebrow="Inbox"
+        title="Feedback detail"
+        description={fb.projects ? `From ${fb.projects.name} · ${formatDate(fb.created_at)}` : formatDate(fb.created_at)}
+        action={
+          <Button asChild variant="outline" size="sm">
+            <Link href="/feedback">Back to inbox</Link>
+          </Button>
+        }
+      />
 
       <div className="grid gap-6 lg:grid-cols-3">
         {/* Main content */}
@@ -144,7 +146,7 @@ export default async function FeedbackDetailPage({
               </div>
             </CardHeader>
             <CardContent>
-              <p className="max-w-prose whitespace-pre-wrap text-sm leading-relaxed">
+              <p className="max-w-[72ch] whitespace-pre-wrap text-base leading-7 text-foreground">
                 {fb.message}
               </p>
               <div className="mt-4 flex items-center gap-1.5 text-xs text-muted-foreground">

--- a/packages/dashboard/src/app/(dashboard)/feedback/feedback-project-scope.tsx
+++ b/packages/dashboard/src/app/(dashboard)/feedback/feedback-project-scope.tsx
@@ -22,7 +22,7 @@ export function FeedbackProjectScope({
   if (projects.length === 0) return null
 
   return (
-    <div className="rounded-xl border bg-card p-3 shadow-[var(--shadow-card)]">
+    <div className="rounded-lg border bg-card p-3 shadow-[var(--shadow-card)]">
       <div className="mb-2 px-0.5">
         <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">Project view</p>
         <p className="text-[11px] text-muted-foreground">Choose one project or include the whole workspace.</p>

--- a/packages/dashboard/src/app/(dashboard)/feedback/loading.tsx
+++ b/packages/dashboard/src/app/(dashboard)/feedback/loading.tsx
@@ -20,7 +20,7 @@ export default function FeedbackLoading() {
       </div>
 
       {/* List */}
-      <div className="rounded-xl border bg-card overflow-hidden">
+      <div className="rounded-lg border bg-card overflow-hidden">
         <div className="flex items-center gap-3 border-b bg-muted/20 px-4 py-2">
           <Skeleton className="h-3.5 w-3.5 rounded" />
           <Skeleton className="h-3 w-32" />

--- a/packages/dashboard/src/app/(dashboard)/feedback/page.tsx
+++ b/packages/dashboard/src/app/(dashboard)/feedback/page.tsx
@@ -21,6 +21,7 @@ import type { BillingSummary, Feedback, FeedbackPriority, FeedbackStatus, Feedba
 import { CURRENT_PROJECT_COOKIE, getSelectedProject } from '@/lib/project-selection'
 import { FeedbackProjectScope } from './feedback-project-scope'
 import { SavedInboxViews } from './saved-inbox-views'
+import { PageHeader } from '@/components/ui/workspace-shell'
 import {
   Search,
   ChevronLeft,
@@ -369,24 +370,22 @@ function FeedbackInboxInner() {
 
   const hasFilters = status || type || search || agent || publicOnly || priority || projectId || tag || read === 'unread'
   return (
-    <div className="animate-fade-in space-y-5 pb-[calc(6rem+env(safe-area-inset-bottom,0px))]">
+    <div className="space-y-5 pb-[calc(6rem+env(safe-area-inset-bottom,0px))]">
       {/* ─── Header ─────────────────────────────────────── */}
-      <div className="flex items-end justify-between rounded-xl border bg-card p-5 shadow-[var(--shadow-card)]">
-        <div>
-          <p className="text-xs font-semibold text-primary">Your users</p>
-          <h1 className="mt-2 text-2xl font-bold tracking-tight">Feedback</h1>
-          <p className="mt-1 text-sm text-muted-foreground">Read new messages. Decide what to do next.</p>
-          {billingSummary?.entitlements.historyDays && (
-            <p className="mt-1 text-xs text-muted-foreground">
-              Free plan view limited to the most recent {billingSummary.entitlements.historyDays} days.
-            </p>
-          )}
-        </div>
-        <div className="text-right"><p className="text-2xl font-semibold tabular-nums">{loading ? '…' : total}</p><p className="text-xs text-muted-foreground">{hasFilters ? 'shown' : total === 1 ? 'message' : 'messages'}</p></div>
-      </div>
+      <PageHeader
+        eyebrow="Inbox"
+        title="Feedback"
+        description="Review new messages and move the useful signal forward."
+        meta={billingSummary?.entitlements.historyDays && (
+          <p className="text-xs text-muted-foreground">
+            Free plan shows the most recent {billingSummary.entitlements.historyDays} days.
+          </p>
+        )}
+        action={<div className="text-right"><p className="text-xl font-semibold tabular-nums">{loading ? '…' : total}</p><p className="text-xs text-muted-foreground">{hasFilters ? 'shown' : total === 1 ? 'message' : 'messages'}</p></div>}
+      />
 
       {/* ─── Filters ─────────────────────────────────────── */}
-      <div className="flex flex-col gap-3 rounded-xl border bg-card p-4 shadow-[var(--shadow-card)]">
+      <div className="flex flex-col gap-3 rounded-lg border bg-card p-4 shadow-[var(--shadow-card)]">
         <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <form data-tour="inbox-search" onSubmit={handleSearch} className="w-full lg:max-w-md">
             <div className="relative">
@@ -441,7 +440,7 @@ function FeedbackInboxInner() {
             </FilterPill>
           ))}
 
-          <button type="button" onClick={() => setShowMoreFilters((value) => !value)} aria-expanded={showMoreFilters} className={cn('flex min-h-11 flex-shrink-0 items-center gap-1.5 rounded-full px-3 text-[11px] font-medium md:min-h-8', showMoreFilters ? 'bg-foreground text-background' : 'bg-muted text-muted-foreground hover:text-foreground')}><SlidersHorizontal className="h-3.5 w-3.5"/> More</button>
+          <button type="button" onClick={() => setShowMoreFilters((value) => !value)} aria-expanded={showMoreFilters} className={cn('flex min-h-11 flex-shrink-0 items-center gap-1.5 rounded-md border px-3 text-[11px] font-medium md:min-h-8', showMoreFilters ? 'border-primary/30 bg-surface-selected text-foreground' : 'border-transparent bg-surface-raised text-muted-foreground hover:text-foreground')}><SlidersHorizontal className="h-3.5 w-3.5"/> More filters</button>
 
           {hasFilters && (
             <button
@@ -467,7 +466,7 @@ function FeedbackInboxInner() {
         />
 
         {showMoreFilters && (
-          <div className="space-y-3 rounded-xl border bg-[oklch(var(--surface-raised))] p-4">
+          <div className="space-y-3 rounded-md border bg-surface-raised p-4">
             <div className="flex flex-wrap gap-1.5">
               {(['reviewed', 'in_progress', 'closed'] as FeedbackStatus[]).map((s) => <FilterPill key={s} active={status === s} onClick={() => updateParams({ status: status === s ? '' : s })}><span className={cn('h-1.5 w-1.5 rounded-full', statusMeta[s].dot)}/>{statusMeta[s].label}</FilterPill>)}
               {types.map((t) => <FilterPill key={t} active={type === t} onClick={() => updateParams({ type: type === t ? '' : t })}><TypeIcon type={t} className="h-3.5 w-3.5"/><span className="capitalize">{t}</span></FilterPill>)}
@@ -484,7 +483,7 @@ function FeedbackInboxInner() {
       </div>
 
       {/* ─── Main List ────────────────────────────────────── */}
-      <section data-tour="inbox-list" className="overflow-hidden rounded-xl border bg-card shadow-[var(--shadow-card)]">
+      <section data-tour="inbox-list" className="overflow-hidden rounded-lg border bg-card shadow-[var(--shadow-card)]">
         {loading ? (
           <div className="flex items-center justify-center py-20">
             <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
@@ -581,7 +580,7 @@ function FeedbackInboxInner() {
             : 'translate-y-4 opacity-0 pointer-events-none'
         )}
       >
-        <div className="flex items-center gap-1.5 overflow-x-auto rounded-xl border bg-background px-3 py-2 shadow-xl ring-1 ring-black/5 scrollbar-thin dark:ring-white/5 md:rounded-full">
+        <div className="flex items-center gap-1.5 overflow-x-auto rounded-lg border bg-background px-3 py-2 shadow-xl ring-1 ring-black/5 scrollbar-thin dark:ring-white/5 md:rounded-full">
           <span className="shrink-0 pl-1 pr-2 text-xs font-semibold">
             {selected.size} selected
           </span>
@@ -685,11 +684,11 @@ function FilterPill({
       onClick={onClick}
       aria-pressed={active}
       className={cn(
-        'flex items-center gap-1 rounded-full px-3 py-1 text-[11px] font-medium transition-all',
+        'flex items-center gap-1 rounded-md border px-3 py-1 text-[11px] font-medium transition-colors',
         'min-h-11 flex-shrink-0 snap-start md:min-h-8',
         active
-          ? 'bg-foreground text-background shadow-sm'
-          : 'bg-muted text-muted-foreground hover:bg-accent hover:text-foreground'
+          ? 'border-primary/30 bg-surface-selected text-foreground'
+          : 'border-transparent bg-surface-raised text-muted-foreground hover:border-border hover:bg-accent hover:text-foreground'
       )}
     >
       {children}
@@ -721,10 +720,8 @@ function FeedbackRow({
       data-feedback-row-id={fb.id}
       className={cn(
         'group relative flex items-start gap-3 border-b px-4 py-3.5 transition-colors last:border-b-0',
-        isUnread
-          ? 'bg-primary/[0.04] ring-1 ring-inset ring-primary/15 hover:bg-primary/[0.06] dark:bg-primary/[0.07]'
-          : 'hover:bg-accent/30',
-        selected && 'bg-accent/50',
+        isUnread ? 'bg-surface-selected/45 hover:bg-surface-selected/65' : 'hover:bg-surface-raised/55',
+        selected && 'bg-accent/60',
         active && 'ring-2 ring-inset ring-ring/60',
       )}
     >

--- a/packages/dashboard/src/app/(dashboard)/integrations/loading.tsx
+++ b/packages/dashboard/src/app/(dashboard)/integrations/loading.tsx
@@ -8,7 +8,7 @@ export default function IntegrationsLoading() {
         <Skeleton className="h-7 w-64" />
         <Skeleton className="h-4 w-[28rem] max-w-full" />
       </div>
-      <div className="overflow-hidden rounded-xl border bg-card">
+      <div className="overflow-hidden rounded-lg border bg-card">
         {Array.from({ length: 3 }).map((_, index) => (
           <div key={index} className="grid gap-3 border-b px-4 py-4 last:border-b-0 md:grid-cols-[minmax(0,1fr)_auto]">
             <div className="space-y-2">

--- a/packages/dashboard/src/app/(dashboard)/layout.tsx
+++ b/packages/dashboard/src/app/(dashboard)/layout.tsx
@@ -76,7 +76,7 @@ export default async function DashboardLayout({
         })
       : {}
   return (
-    <div className="flex h-dvh flex-col bg-background md:flex-row">
+    <div className="dashboard-shell flex h-dvh flex-col bg-background md:flex-row">
       <Sidebar
         user={{
           email: user.email,
@@ -88,7 +88,7 @@ export default async function DashboardLayout({
         billingAccount={billingAccount}
       />
       <main className="min-h-0 flex-1 overflow-y-auto bg-background pb-[env(safe-area-inset-bottom,0px)]">
-        <div className="mx-auto max-w-[1240px] px-4 py-5 md:px-8 md:py-8">{children}</div>
+        <div className="mx-auto w-full max-w-[1320px] px-4 py-5 sm:px-6 md:px-8 md:py-7">{children}</div>
       </main>
       <ProductTour
         initialOpen={false}

--- a/packages/dashboard/src/app/(dashboard)/loading.tsx
+++ b/packages/dashboard/src/app/(dashboard)/loading.tsx
@@ -25,7 +25,7 @@ export default function DashboardLoading() {
       {/* Stat cards */}
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
         {Array.from({ length: 5 }).map((_, i) => (
-          <div key={i} className="rounded-xl border bg-card p-4">
+          <div key={i} className="rounded-lg border bg-card p-4">
             <Skeleton className="h-3 w-16 mb-3" />
             <Skeleton className="h-8 w-12 mb-2" />
             <Skeleton className="h-2 w-20" />
@@ -46,7 +46,7 @@ export default function DashboardLoading() {
 
       {/* Activity + sidebar */}
       <div className="grid gap-5 lg:grid-cols-[1fr_272px]">
-        <div className="rounded-xl border bg-card">
+        <div className="rounded-lg border bg-card">
           <div className="flex items-center justify-between p-4 pb-3">
             <Skeleton className="h-5 w-32" />
             <Skeleton className="h-7 w-16" />
@@ -64,7 +64,7 @@ export default function DashboardLoading() {
           </div>
         </div>
         <div className="space-y-4">
-          <div className="rounded-xl border bg-card p-4">
+          <div className="rounded-lg border bg-card p-4">
             <Skeleton className="h-5 w-20 mb-4" />
             <div className="space-y-3">
               {Array.from({ length: 4 }).map((_, i) => (

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/api-docs.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/api-docs.tsx
@@ -4,17 +4,12 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { CopyButton } from '@/components/copy-button'
 import type { Project } from '@/lib/types'
+import { CodeSnippet } from '@/components/code-snippet'
+import { PageHeader } from '@/components/ui/workspace-shell'
 
 function CodeBlock({ code, language = 'bash' }: { code: string; language?: string }) {
   return (
-    <div className="relative" aria-label={`${language} code sample`}>
-      <div className="absolute right-2 top-2 z-10">
-        <CopyButton value={code} variant="outline" size="sm" className="bg-background/95" />
-      </div>
-      <pre className="max-h-96 overflow-auto rounded-lg bg-muted p-4 pr-20 text-sm">
-        <code>{code}</code>
-      </pre>
-    </div>
+    <CodeSnippet tabs={[{ label: language.toUpperCase(), code, language }]} maxHeightClassName="max-h-96" />
   )
 }
 
@@ -134,27 +129,22 @@ export function ApiDocs({
 
   return (
     <div className="space-y-6">
-      <Card className="border-primary/30 bg-primary/[0.04]">
-        <CardHeader>
-          <div className="flex flex-wrap items-center gap-2">
-            <Badge variant="secondary">Available on Free</Badge>
-            <Badge variant="outline">REST + MCP</Badge>
-          </div>
-          <CardTitle className="mt-3 text-base">Use API and MCP when code or agents need feedback access</CardTitle>
-          <CardDescription>
-            Free access follows your Free project, monthly feedback, and history limits. Use the key in backend code or trusted agent configuration, not public browser code.
-          </CardDescription>
-        </CardHeader>
-      </Card>
+      <PageHeader
+        eyebrow={project.name}
+        title="API and MCP"
+        description="Use the project key from a backend, script, or trusted agent. Never expose it in public browser code."
+      />
 
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-base">Operational limits and trust boundaries</CardTitle>
-          <CardDescription>
-            Keep API and MCP traffic in trusted runtime contexts. The browser widget uses its generated browser-safe key instead.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="divide-y rounded-b-lg border-t p-0">
+      <details className="group rounded-lg border bg-card shadow-[var(--shadow-card)]">
+        <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-5 py-4">
+          <div>
+            <p className="text-sm font-semibold text-foreground">Limits and trust boundaries</p>
+            <p className="mt-1 text-sm text-muted-foreground">Project scope, plan limits, rate limits, and webhook compatibility.</p>
+          </div>
+          <span className="text-xs font-medium text-primary group-open:hidden">Show</span>
+          <span className="hidden text-xs font-medium text-primary group-open:inline">Hide</span>
+        </summary>
+        <div className="divide-y border-t bg-surface-raised/35">
           {[
             ['Project scope', 'Each API key can access only its attached project.'],
             ['Plan limits', 'Free access follows the shared Free plan quotas and history window; Pro removes the short history limit.'],
@@ -167,8 +157,8 @@ export function ApiDocs({
               <p className="text-sm leading-6 text-muted-foreground">{body}</p>
             </div>
           ))}
-        </CardContent>
-      </Card>
+        </div>
+      </details>
 
       <Card>
         <CardHeader className="pb-3">
@@ -217,7 +207,7 @@ export function ApiDocs({
         </CardContent>
       </Card>
 
-      <details className="group rounded-xl border bg-card">
+      <details className="group rounded-lg border bg-card">
         <summary className="flex cursor-pointer list-none flex-wrap items-start justify-between gap-3 px-6 py-5">
           <div>
             <p className="text-base font-semibold text-foreground">Endpoint reference</p>
@@ -239,7 +229,7 @@ export function ApiDocs({
         </CardContent>
       </details>
 
-      <details className="group rounded-xl border bg-card">
+      <details className="group rounded-lg border bg-card">
         <summary className="flex cursor-pointer list-none flex-wrap items-start justify-between gap-3 px-6 py-5">
           <div>
             <p className="text-base font-semibold text-foreground">MCP server and agent tools</p>

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/customize-tab.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/customize-tab.tsx
@@ -11,9 +11,10 @@ import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
-import { Loader2, MousePointerClick, PanelTop, RotateCcw, Send } from 'lucide-react'
+import { Loader2, MousePointerClick, PanelTop, Send, ShieldCheck } from 'lucide-react'
 import { toast } from '@/hooks/use-toast'
 import { WidgetFormPreview } from './widget-form-preview'
+import { PageHeader } from '@/components/ui/workspace-shell'
 
 interface CustomizeTabProps {
   project: Project
@@ -34,6 +35,8 @@ const TRACKED_WIDGET_FIELDS: Array<[keyof WidgetConfig, string]> = [
   ['enableType', 'Feedback type picker'],
   ['enableScreenshot', 'Screenshot capture'],
   ['requireEmail', 'Require email'],
+  ['requireCaptcha', 'Human verification'],
+  ['captchaProvider', 'Captcha provider'],
 ]
 
 export function CustomizeTab({
@@ -222,58 +225,21 @@ export function CustomizeTab({
 
   return (
     <div className="space-y-7">
-      <header className={`space-y-4 rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6 ${hasUnsavedChanges ? 'border-amber-400/60' : 'border-border/80'}`}>
-          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-            <div className="min-w-0 space-y-2">
-              <div className="flex flex-wrap items-center gap-2">
-                <Badge variant={hasUnsavedChanges ? 'default' : 'secondary'}>
-                  {hasUnsavedChanges ? 'Unsaved draft' : 'Saved'}
-                </Badge>
-                <Badge variant="outline">{draftModeLabel}</Badge>
-              </div>
-              <div>
-                <h1 className="text-2xl font-semibold tracking-[-0.035em]">Make the feedback form feel native</h1>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  {hasUnsavedChanges
-                    ? 'Save to publish these changes to every installed embed.'
-                    : 'This saved version is delivered remotely. Your installed code stays the same.'}
-                </p>
-              </div>
-              {draftRestored && hasUnsavedChanges && (
-                <p className="text-sm text-muted-foreground">
-                  A local draft was restored for this project. Save it to use it outside this browser.
-                </p>
-              )}
-            </div>
-
-            <div className="flex flex-wrap gap-2 md:justify-end">
-              <Button variant="outline" onClick={handleReset} disabled={saving || !hasUnsavedChanges}>
-                <RotateCcw className="mr-2 h-4 w-4" />
-                Discard draft
-              </Button>
-              <Button onClick={handleSave} disabled={saving || !hasUnsavedChanges}>
-                {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                Save changes
-              </Button>
-            </div>
+      <PageHeader
+        eyebrow={project.name}
+        title="Feedback form"
+        description={hasUnsavedChanges
+          ? 'Preview the draft, then save once to publish it to every installed embed.'
+          : 'Edit the saved form without replacing the installed snippet.'}
+        meta={
+          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            <Badge variant={hasUnsavedChanges ? 'default' : 'secondary'}>{hasUnsavedChanges ? 'Unsaved draft' : 'Saved'}</Badge>
+            <span>{draftModeLabel}</span>
+            <span>Saved placement: {savedModeLabel}</span>
+            {draftRestored && hasUnsavedChanges && <span>Local draft restored</span>}
           </div>
-
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-foreground/10 pt-3 text-sm text-muted-foreground">
-            <span>
-              Saved placement: <span className="font-medium text-foreground">{savedModeLabel}</span>
-            </span>
-            <span className="hidden h-1 w-1 rounded-full bg-border sm:block" />
-            <span>
-              {hasUnsavedChanges ? (
-                <>
-                  Draft changes: <span className="font-medium text-foreground">{changedFieldsSummary}</span>
-                </>
-              ) : (
-                'Active remote configuration'
-              )}
-            </span>
-          </div>
-      </header>
+        }
+      />
 
       {!projectKey && (
         <div className="flex flex-col gap-3 rounded-lg border border-primary/30 bg-primary/[0.04] p-3 text-sm md:flex-row md:items-center md:justify-between">
@@ -451,14 +417,17 @@ export function CustomizeTab({
 
             <Separator />
 
-            <div className="space-y-3">
-              <div>
-                <p className="text-sm font-semibold text-foreground">Fields</p>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  Add only the inputs you need for useful feedback.
-                </p>
-              </div>
-              <div className="grid gap-2 sm:grid-cols-2">
+            <details className="group rounded-md border bg-surface-raised/45">
+              <summary className="flex min-h-14 cursor-pointer list-none items-center justify-between gap-3 px-4 py-3">
+                <div>
+                  <p className="text-sm font-semibold text-foreground">Optional fields and protection</p>
+                  <p className="mt-0.5 text-xs text-muted-foreground">Ratings, screenshots, email, and captcha.</p>
+                </div>
+                <span className="text-xs font-medium text-primary group-open:hidden">Show</span>
+                <span className="hidden text-xs font-medium text-primary group-open:inline">Hide</span>
+              </summary>
+              <div className="space-y-5 border-t p-4">
+                <div className="grid gap-2 sm:grid-cols-2">
               {(
                 [
                   ['enableRating', 'Rating stars'],
@@ -480,19 +449,49 @@ export function CustomizeTab({
                   {label}
                 </label>
               ))}
-              </div>
-            </div>
+                </div>
 
-            <div className="flex flex-wrap gap-2 border-t pt-5">
-              <Button onClick={handleSave} disabled={saving || !hasUnsavedChanges}>
-                {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                Save changes
-              </Button>
-              <Button variant="outline" onClick={handleReset} disabled={saving || !hasUnsavedChanges}>
-                <RotateCcw className="mr-2 h-4 w-4" />
-                Discard draft
-              </Button>
-            </div>
+                <div className="border-t pt-4">
+                  <label className="flex min-h-11 items-start gap-3 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={!!config.requireCaptcha}
+                      onChange={(e) => updateConfig('requireCaptcha', e.target.checked)}
+                      className="mt-1 h-4 w-4 rounded border"
+                    />
+                    <span>
+                      <span className="flex items-center gap-2 font-medium text-foreground"><ShieldCheck className="h-4 w-4 text-muted-foreground" />Require human verification</span>
+                      <span className="mt-1 block text-xs leading-5 text-muted-foreground">Keep this off until the form works. Enable it when a public form needs stronger abuse protection.</span>
+                    </span>
+                  </label>
+                  {config.requireCaptcha && (
+                    <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                      <div className="space-y-2">
+                        <Label htmlFor="captcha-provider">Provider</Label>
+                        <select
+                          id="captcha-provider"
+                          className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                          value={config.captchaProvider || 'turnstile'}
+                          onChange={(e) => updateConfig('captchaProvider', e.target.value)}
+                        >
+                          <option value="turnstile">Cloudflare Turnstile</option>
+                          <option value="hcaptcha">hCaptcha</option>
+                        </select>
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="captcha-site-key">Site key</Label>
+                        <Input
+                          id="captcha-site-key"
+                          value={(config.captchaProvider || 'turnstile') === 'hcaptcha' ? config.hcaptchaSiteKey || '' : config.turnstileSiteKey || ''}
+                          onChange={(e) => updateConfig((config.captchaProvider || 'turnstile') === 'hcaptcha' ? 'hcaptchaSiteKey' : 'turnstileSiteKey', e.target.value)}
+                          placeholder="Public site key"
+                        />
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </details>
           </CardContent>
         </Card>
 
@@ -517,7 +516,7 @@ export function CustomizeTab({
       </div>
 
       {hasUnsavedChanges && (
-        <div className="sticky bottom-4 z-20 border border-amber-300/80 bg-amber-50 p-3 shadow-lg dark:bg-amber-950">
+        <div className="sticky bottom-4 z-20 rounded-lg border border-amber-300/80 bg-amber-50 p-3 shadow-lg dark:bg-amber-950">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <p className="text-sm font-semibold text-foreground">Publish remote changes</p>

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/install-tab.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/install-tab.tsx
@@ -15,10 +15,9 @@ import type { Project } from '@/lib/types'
 import { publicEnv } from '@/lib/public-env'
 import { Button } from '@/components/ui/button'
 import { CodeSnippet } from '@/components/code-snippet'
-import { CopyButton } from '@/components/copy-button'
 import { Badge } from '@/components/ui/badge'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Bot, CheckCircle2, Code2, Loader2, RefreshCw, XCircle } from 'lucide-react'
+import { PageHeader, SectionPanel } from '@/components/ui/workspace-shell'
+import { ArrowRight, Bot, CheckCircle2, KeyRound, Loader2, RefreshCw, XCircle } from 'lucide-react'
 
 interface InstallTabProps {
   project: Project
@@ -51,6 +50,7 @@ export function InstallTab({
   const [setupPacketError, setSetupPacketError] = React.useState<string | null>(null)
   const [setupTokens, setSetupTokens] = React.useState<SetupTokenStatus[]>([])
   const [activePlatform, setActivePlatform] = React.useState<InstallPlatform>('website')
+  const [hasCopiedSnippet, setHasCopiedSnippet] = React.useState(false)
   const appOrigin = publicEnv.NEXT_PUBLIC_APP_ORIGIN
   const savedConfig = React.useMemo(
     () => project.settings?.widget_config || {},
@@ -207,20 +207,6 @@ ${JSON.stringify(setupPacket, null, 2)}`
   const activeSetupTokens = setupTokens.filter((token) => {
     return !token.revoked_at && new Date(token.expires_at).getTime() > Date.now()
   })
-  const installSteps = [
-    {
-      title: 'Choose platform',
-      body: 'Pick the environment where this widget will run.',
-    },
-    {
-      title: 'Copy code',
-      body: 'Add the stable embed once near your app root.',
-    },
-    {
-      title: 'Verify one message',
-      body: 'Submit a test item and confirm it reaches the inbox.',
-    },
-  ]
   const nextSnippet = projectKey ? `"use client"
 
 import Script from "next/script"
@@ -319,192 +305,164 @@ export function FeedbacksWidgetScript() {
     },
   ]
   const selectedTarget = installTargets.find((target) => target.id === activePlatform) || installTargets[0]
+  const primaryTargets = installTargets.filter((target) => ['website', 'react', 'next', 'vue'].includes(target.id))
+  const secondaryTargets = installTargets.filter((target) => !['website', 'react', 'next', 'vue'].includes(target.id))
 
   return (
-    <div className="space-y-8" data-tour="install-workspace">
-      <section className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_360px]">
-        <Card>
-          <CardHeader>
-          <div className="flex flex-wrap items-center gap-2 text-xs font-medium text-primary"><Code2 className="h-4 w-4" /> One shared connection</div>
-          <CardTitle className="mt-2 text-2xl tracking-[-0.035em]">Install once. Keep the code unchanged.</CardTitle>
-          <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">
-            This stable embed powers the feedback form and the product updates you show to users. Saved dashboard changes arrive remotely on the next page load.
-          </p>
-          </CardHeader>
-          <CardContent className="grid gap-3 sm:grid-cols-3">
-              {installSteps.map((step, index) => (
-                <div key={step.title} className="flex gap-3 rounded-lg border bg-[oklch(var(--surface-raised))] p-4">
-                  <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-foreground text-xs font-semibold text-background">
-                    {index + 1}
-                  </span>
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium text-foreground">{step.title}</p>
-                    <p className="mt-0.5 text-sm leading-5 text-muted-foreground">{step.body}</p>
-                  </div>
-                </div>
+    <div className="space-y-6" data-tour="install-workspace">
+      <PageHeader
+        eyebrow={project.name}
+        title="Install feedback"
+        description="Choose your stack, copy the snippet once, then verify a real test."
+      />
+
+      <SectionPanel
+        title="Choose your stack"
+        description={selectedTarget.body}
+        dataTour="install-snippet"
+        contentClassName="space-y-4"
+      >
+        <div data-tour="install-platforms" className="flex flex-wrap gap-1 rounded-md border bg-surface-raised p-1" role="group" aria-label="Install platform">
+          {primaryTargets.map((target) => (
+            <button
+              key={target.id}
+              type="button"
+              aria-pressed={activePlatform === target.id}
+              onClick={() => setActivePlatform(target.id)}
+              className={`min-h-10 rounded px-3 text-sm font-medium transition-colors ${
+                activePlatform === target.id
+                  ? 'bg-card text-foreground shadow-sm ring-1 ring-border'
+                  : 'text-muted-foreground hover:bg-card/60 hover:text-foreground'
+              }`}
+            >
+              {target.label}
+              {target.id === 'website' && <span className="ml-1.5 text-[10px] font-semibold uppercase tracking-wide text-primary">Recommended</span>}
+            </button>
+          ))}
+          <details className="group relative">
+            <summary className={`flex min-h-10 cursor-pointer list-none items-center rounded px-3 text-sm font-medium transition-colors ${
+              secondaryTargets.some((target) => target.id === activePlatform)
+                ? 'bg-card text-foreground shadow-sm ring-1 ring-border'
+                : 'text-muted-foreground hover:bg-card/60 hover:text-foreground'
+            }`}>
+              Other
+            </summary>
+            <div className="absolute left-0 top-11 z-20 min-w-52 overflow-hidden rounded-md border bg-popover p-1 shadow-[var(--shadow-float)]">
+              {secondaryTargets.map((target) => (
+                <button
+                  key={target.id}
+                  type="button"
+                  aria-pressed={activePlatform === target.id}
+                  onClick={() => setActivePlatform(target.id)}
+                  className={`flex min-h-10 w-full items-center rounded px-3 text-left text-sm ${
+                    activePlatform === target.id ? 'bg-surface-selected text-foreground' : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+                  }`}
+                >
+                  {target.label}
+                </button>
               ))}
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex-row items-center justify-between space-y-0">
-                <div className="flex flex-wrap items-center justify-between gap-2">
-                <CardTitle className="text-base">Connection details</CardTitle>
-                </div>
-                <Badge variant="outline">{modeLabel}</Badge>
-          </CardHeader>
-          <CardContent>
-              <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-1">
-                <div className="min-w-0">
-                  <p className="text-xs font-medium text-muted-foreground">Project key</p>
-                  {projectKey ? (
-                    <p className="mt-1 break-all font-mono text-xs text-foreground">
-                      {projectKey}
-                    </p>
-                  ) : (
-                    <div className="mt-1">
-                      <p className="text-sm leading-5 text-muted-foreground">
-                        Key hidden{apiKeyLastFour ? `, ending in ${apiKeyLastFour}` : ''}. Generate a fresh key to copy a new snippet.
-                      </p>
-                      <Button size="sm" variant="outline" className="mt-3" onClick={() => void onRotateApiKey()} disabled={rotatingApiKey}>
-                        {rotatingApiKey && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                        Generate fresh key
-                      </Button>
-                    </div>
-                  )}
-                </div>
-                <div>
-                  <p className="text-xs font-medium text-muted-foreground">Current feedback form</p>
-                  <p className="mt-1 text-sm font-medium text-foreground">{modeLabel}</p>
-                  <p className="mt-1 text-sm leading-5 text-muted-foreground">{verifyInstruction}</p>
-                </div>
-              </div>
-          </CardContent>
-        </Card>
-      </section>
-
-      <Card data-tour="install-snippet">
-        <CardHeader data-tour="install-snippet-header" className="gap-4">
-          <div className="flex flex-wrap items-end justify-between gap-4">
-          <div>
-            <CardTitle className="text-lg">Choose where you are installing</CardTitle>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Select your environment and add this once near the application root.
-            </p>
-          </div>
-          </div>
-          <div data-tour="install-platforms" className="flex flex-wrap gap-1 rounded-lg bg-[oklch(var(--surface-raised))] p-1" role="group" aria-label="Install platform">
-            {installTargets.map((target) => (
-              <button
-                key={target.id}
-                type="button"
-                aria-pressed={activePlatform === target.id}
-                onClick={() => setActivePlatform(target.id)}
-                className={`min-h-9 rounded-md px-3 text-sm font-medium transition-colors ${
-                  activePlatform === target.id
-                    ? 'bg-card text-foreground shadow-sm'
-                    : 'text-muted-foreground hover:bg-card/60 hover:text-foreground'
-                }`}
-              >
-                {target.label}
-              </button>
-            ))}
-          </div>
-        </CardHeader>
-
-        <CardContent className="space-y-5">
-          <div className="flex flex-wrap items-start justify-between gap-3 rounded-lg border bg-[oklch(var(--surface-raised))] p-4">
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <div>
-                <p className="text-sm font-semibold text-foreground">{selectedTarget.title}</p>
-                <p className="mt-1 text-sm leading-6 text-muted-foreground">{selectedTarget.body}</p>
-              </div>
-              {selectedTarget.code && (
-                <CopyButton
-                  value={selectedTarget.code}
-                  label="Copy code"
-                  copiedLabel="Copied"
-                  size="sm"
-                  onCopied={() => {
-                    void fetch(`/api/projects/${project.id}/activation`, {
-                      method: 'POST',
-                      headers: { 'Content-Type': 'application/json' },
-                      body: JSON.stringify({ event: 'install_code_copied' }),
-                    })
-                  }}
-                />
-              )}
-              {selectedTarget.id === 'mobile' && (
-                <Link href={`/projects/${project.id}?tab=api`}>
-                  <Button variant="outline" size="sm">Open API docs</Button>
-                </Link>
-              )}
             </div>
-          </div>
+          </details>
+        </div>
 
-          {projectKey ? (
-            selectedTarget.code ? (
-              <div data-tour="install-code">
-                <CodeSnippet
-                  tabs={[
-                    {
-                      label: selectedTarget.label,
-                      code: selectedTarget.code,
-                      language: selectedTarget.language,
-                    },
-                  ]}
-                />
-              </div>
-            ) : (
-              <div className="rounded-lg border border-dashed bg-muted/10 p-4 text-sm leading-6 text-muted-foreground">
-                Native mobile apps do not use a browser script tag. Use the API from your backend, or inject the Website snippet only inside WebView content.
-              </div>
-            )
+        {projectKey ? (
+          selectedTarget.code ? (
+            <div data-tour="install-code">
+              <CodeSnippet
+                tabs={[{
+                  label: selectedTarget.label,
+                  code: selectedTarget.code,
+                  language: selectedTarget.language,
+                }]}
+                onCopied={() => {
+                  setHasCopiedSnippet(true)
+                  void fetch(`/api/projects/${project.id}/activation`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ event: 'install_code_copied' }),
+                  })
+                }}
+              />
+            </div>
           ) : (
-            <div className="rounded-lg border border-dashed bg-muted/10 p-4 text-sm text-muted-foreground">
-              Generate a fresh key to reveal a new install snippet. Existing deployed clients keep working with the old key because only the raw database copy was removed.
+            <div className="rounded-md border border-dashed bg-surface-raised/60 p-4 text-sm leading-6 text-muted-foreground">
+              Native apps use the REST API. The browser snippet only works in web content or a WebView.
+              <Link href={`/projects/${project.id}?tab=api`} className="ml-1 font-medium text-primary hover:underline">Open API docs</Link>
             </div>
-          )}
-
-          <div className="divide-y overflow-hidden rounded-lg border bg-[oklch(var(--surface-raised))]">
-            <div className="grid gap-1 px-4 py-3 md:grid-cols-[180px_minmax(0,1fr)]">
-              <p className="text-sm font-medium text-foreground">Where this goes</p>
-              <p className="text-sm leading-6 text-muted-foreground">{selectedTarget.placement}</p>
-            </div>
-            <div className="grid gap-1 px-4 py-3 md:grid-cols-[180px_minmax(0,1fr)]">
-              <p className="text-sm font-medium text-foreground">What appears</p>
-              <p data-testid="install-verify-instruction" className="text-sm leading-6 text-muted-foreground">
-                {verifyInstruction}
-              </p>
-            </div>
-            <div className="grid gap-1 px-4 py-3 md:grid-cols-[180px_minmax(0,1fr)]">
-              <p className="text-sm font-medium text-foreground">Check it worked</p>
-              <p className="text-sm leading-6 text-muted-foreground">
-                Use your real site first. Send one test, then open the inbox and look for it.
-              </p>
-            </div>
+          )
+        ) : (
+          <div className="rounded-md border border-primary/30 bg-primary/[0.045] p-4">
+            <p className="text-sm font-medium text-foreground">Generate a fresh key to reveal the snippet.</p>
+            <p className="mt-1 text-sm text-muted-foreground">Existing deployed clients keep working with the previous key.</p>
+            <Button size="sm" variant="outline" className="mt-3" onClick={() => void onRotateApiKey()} disabled={rotatingApiKey}>
+              {rotatingApiKey && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Generate fresh key
+            </Button>
           </div>
+        )}
 
-          <div className="flex items-start gap-3 rounded-lg border border-primary/20 bg-primary/[0.055] px-4 py-3 text-sm text-muted-foreground">
+        <div className="divide-y rounded-md border bg-surface-raised/55">
+          <div className="grid gap-1 px-4 py-3 md:grid-cols-[140px_minmax(0,1fr)]">
+            <p className="text-sm font-medium text-foreground">Paste it here</p>
+            <p className="text-sm leading-6 text-muted-foreground">{selectedTarget.placement}</p>
+          </div>
+          <div className="grid gap-1 px-4 py-3 md:grid-cols-[140px_minmax(0,1fr)]">
+            <p className="text-sm font-medium text-foreground">You should see</p>
+            <p data-testid="install-verify-instruction" className="text-sm leading-6 text-muted-foreground">{verifyInstruction}</p>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-4 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex min-w-0 gap-2.5 text-sm text-muted-foreground">
             <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
-            <p>After installation, change the button, fields, wording, placement, captcha, and user-facing product updates from the dashboard. <span className="font-medium text-foreground">You will not need a new snippet.</span></p>
+            <p><span className="font-medium text-foreground">The snippet stays the same.</span> Form and product-update changes publish remotely.</p>
           </div>
-        </CardContent>
-      </Card>
+          <Button asChild className="min-h-11 shrink-0 gap-2">
+            <Link href={`/projects/${project.id}/verify`}>
+              {hasCopiedSnippet ? 'Verify installation' : 'Continue to verification'}
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          </Button>
+        </div>
+      </SectionPanel>
 
-      <details className="group rounded-xl border bg-card shadow-[var(--shadow-card)]">
+      <details className="group rounded-lg border bg-card shadow-[var(--shadow-card)]">
+        <summary className="flex min-h-14 cursor-pointer list-none items-center justify-between gap-3 px-5 py-3">
+          <span className="flex items-center gap-2.5 text-sm font-medium text-foreground">
+            <KeyRound className="h-4 w-4 text-muted-foreground" />
+            Connection details
+          </span>
+          <span className="text-xs text-muted-foreground">{modeLabel}</span>
+        </summary>
+        <div className="grid gap-5 border-t bg-surface-raised/35 p-5 sm:grid-cols-2">
+          <div className="min-w-0">
+            <p className="text-xs font-medium text-muted-foreground">Project key</p>
+            {projectKey ? (
+              <p className="mt-1 break-all font-mono text-xs text-foreground">{projectKey}</p>
+            ) : (
+              <p className="mt-1 text-sm text-muted-foreground">Hidden{apiKeyLastFour ? `, ending in ${apiKeyLastFour}` : ''}.</p>
+            )}
+          </div>
+          <div>
+            <p className="text-xs font-medium text-muted-foreground">Current form</p>
+            <p className="mt-1 text-sm font-medium text-foreground">{modeLabel}</p>
+            <p className="mt-1 text-sm leading-5 text-muted-foreground">{verifyInstruction}</p>
+          </div>
+        </div>
+      </details>
+
+      <details className="group rounded-lg border bg-card shadow-[var(--shadow-card)]">
         <summary className="flex cursor-pointer list-none flex-wrap items-start justify-between gap-3 px-6 py-5">
           <div>
             <div className="flex flex-wrap items-center gap-2">
               <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 text-primary">
                 <Bot className="h-4 w-4" />
               </div>
-              <Badge variant="secondary">Agent setup</Badge>
-              <Badge variant="outline">Copyable prompt</Badge>
+              <Badge variant="secondary">Optional</Badge>
             </div>
-            <p className="mt-3 text-lg font-semibold text-foreground">Give this to your AI builder</p>
+            <p className="mt-3 text-base font-semibold text-foreground">Install with an AI coding agent</p>
             <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
-              Optional setup packet and prompt for Cursor, Claude Code, Codex, Windsurf, or another repo-aware builder.
+              Create a short-lived setup packet or copy a repo-aware prompt.
             </p>
           </div>
           <span className="text-sm font-medium text-primary">
@@ -637,12 +595,12 @@ export function FeedbacksWidgetScript() {
         </div>
       </details>
 
-      <details className="group rounded-xl border bg-card">
+      <details className="group rounded-lg border bg-card">
         <summary className="flex cursor-pointer list-none flex-wrap items-start justify-between gap-3 px-6 py-5">
           <div>
-            <p className="text-lg font-semibold text-foreground">After the widget is live: deployment hardening</p>
+            <p className="text-base font-semibold text-foreground">Security and deployment hardening</p>
             <p className="mt-1 text-sm text-muted-foreground">
-              Keep CSP, SRI, and stronger human-verification as a second pass after the snippet is already working.
+              Add CSP, SRI, or stronger human verification after the first test works.
             </p>
           </div>
           <span className="text-sm font-medium text-primary">Show security guidance</span>
@@ -671,7 +629,7 @@ export function FeedbacksWidgetScript() {
           />
 
           <div className="rounded-lg border border-dashed bg-muted/10 p-4 text-sm text-muted-foreground">
-            Captcha keys stay secondary to install. Verify the widget first, then enable human-verification if your site is public-facing or you expect abuse risk.
+            Verify the widget first. Add captcha only when the public form needs stronger abuse protection.
           </div>
         </div>
       </details>

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/integrations-tab.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/integrations-tab.tsx
@@ -27,8 +27,8 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { toast } from '@/hooks/use-toast'
+import { PageHeader } from '@/components/ui/workspace-shell'
 import {
-  BellRing,
   Github,
   Loader2,
   Mail,
@@ -548,34 +548,19 @@ export function IntegrationsTab({ project, initialBillingSummary }: Integrations
 
   return (
     <div className="space-y-4" data-tour="integration-workspace">
-      <Card className="overflow-hidden rounded-xl shadow-[var(--shadow-card)]">
-        <CardHeader className="border-b bg-muted/25">
-          <div className="flex flex-wrap items-center gap-2">
-            <Badge variant="secondary">Workflow routing</Badge>
-            <Badge variant="outline">Operational logs</Badge>
-            <Badge variant="outline">Rules and health</Badge>
-            {billingSummary?.entitlements.label === 'Free' && (
-              <Badge variant="outline">Limited on Free</Badge>
-            )}
-          </div>
-          <CardTitle className="mt-3 text-lg">Route important feedback where your team already works</CardTitle>
-          <CardDescription>
-            Slack, Discord, GitHub, and generic webhooks are available here. Free includes one active endpoint; Pro removes that cap.
-          </CardDescription>
-        </CardHeader>
-      </Card>
+      <PageHeader
+        eyebrow={project.name}
+        title="Integrations"
+        description="Send important feedback to Slack, Discord, GitHub, or your own webhook."
+      />
 
       {!featureLocked && billingSummary && (
-        <Card className="overflow-hidden rounded-xl bg-muted/15 shadow-[var(--shadow-card)]">
-          <CardContent className="flex flex-col gap-3 p-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex flex-col gap-3 border-b pb-4 md:flex-row md:items-center md:justify-between">
             <div>
-              <p className="text-sm font-semibold text-foreground">
+              <p className="text-sm font-medium text-foreground">
                 {endpointLimit === null
                   ? 'Unlimited active endpoints on Pro'
                   : `${activeEndpointCount} of ${endpointLimit} active endpoint${endpointLimit === 1 ? '' : 's'} used on Free`}
-              </p>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Disable an endpoint to free the slot, or upgrade when you need multiple destinations.
               </p>
             </div>
             {billingSummary.entitlements.label === 'Free' && (
@@ -583,8 +568,7 @@ export function IntegrationsTab({ project, initialBillingSummary }: Integrations
                 <Button variant="outline" size="sm">View Pro limits</Button>
               </Link>
             )}
-          </CardContent>
-        </Card>
+        </div>
       )}
 
       {featureLocked && (
@@ -615,12 +599,13 @@ export function IntegrationsTab({ project, initialBillingSummary }: Integrations
         const Icon = section.icon
 
         return (
-          <Card key={section.kind} data-webhook-kind={section.kind} data-tour="integration-endpoint" className="overflow-hidden rounded-xl shadow-[var(--shadow-card)]">
-            <CardHeader className="flex flex-col gap-3 border-b bg-muted/25 md:flex-row md:items-start md:justify-between">
+          <details key={section.kind} data-webhook-kind={section.kind} data-tour="integration-endpoint" className="group overflow-hidden rounded-lg border bg-card shadow-[var(--shadow-card)]">
+            <summary className="flex cursor-pointer list-none flex-col gap-3 bg-surface-raised/55 px-5 py-4 md:flex-row md:items-center md:justify-between">
               <div>
                 <div className="flex items-center gap-2">
                   <Icon className="h-4 w-4 text-primary" />
                   <CardTitle className="text-base">{section.title}</CardTitle>
+                  <span className="text-xs text-muted-foreground">{endpoints.length > 0 ? `${endpoints.length} configured` : 'Not connected'}</span>
                 </div>
                 <CardDescription className="mt-1">{section.description}</CardDescription>
               </div>
@@ -628,16 +613,20 @@ export function IntegrationsTab({ project, initialBillingSummary }: Integrations
               <Button
                 variant="outline"
                 size="sm"
-                onClick={() => addEndpoint(section.kind)}
+                onClick={(event) => {
+                  event.preventDefault()
+                  event.currentTarget.closest('details')?.setAttribute('open', '')
+                  addEndpoint(section.kind)
+                }}
                 disabled={endpointLimitReached}
                 title={endpointLimitReached ? 'Free includes one active endpoint. Disable another endpoint or upgrade.' : undefined}
               >
                 <Plus className="mr-2 h-4 w-4" />
                 Add endpoint
               </Button>
-            </CardHeader>
+            </summary>
 
-            <CardContent className="space-y-4 pt-6">
+            <div className="space-y-4 border-t p-5">
               {endpoints.length === 0 ? (
                 <div className="border-y border-dashed bg-muted/10 p-4 text-sm text-muted-foreground">
                   No {section.title.toLowerCase()} endpoint yet. Add one when you are ready to send feedback there.
@@ -794,39 +783,25 @@ export function IntegrationsTab({ project, initialBillingSummary }: Integrations
                   )
                 })
               )}
-            </CardContent>
-          </Card>
+            </div>
+          </details>
         )
       })}
 
-      <Card className="overflow-hidden rounded-xl border-dashed shadow-[var(--shadow-card)]">
-        <CardHeader className="border-b bg-muted/25">
-          <div className="flex items-center gap-2">
-            <Mail className="h-4 w-4 text-muted-foreground" />
-            <CardTitle className="text-base">Email Notifications</CardTitle>
-            <Badge variant="secondary">Live in Settings</Badge>
-          </div>
-          <CardDescription>
-            Email alerts for new feedback and failed integrations are managed in account settings.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="bg-muted/10 pt-6">
-          <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-muted-foreground">
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-dashed bg-surface-raised/35 p-4 text-sm text-muted-foreground">
             <div className="flex items-center gap-2">
-              <BellRing className="h-4 w-4" />
-              Use email for personal alerts. Use Slack, Discord, GitHub, or a webhook for team workflows.
+              <Mail className="h-4 w-4" />
+              Personal email alerts are managed in account settings.
             </div>
             <Link href="/settings">
               <Button variant="outline" size="sm">Manage email alerts</Button>
             </Link>
-          </div>
-        </CardContent>
-      </Card>
+      </div>
 
       {!featureLocked && (
         <>
-          <Card className="overflow-hidden rounded-xl shadow-[var(--shadow-card)]">
-            <CardHeader className="flex flex-col gap-3 border-b bg-muted/25 md:flex-row md:items-start md:justify-between">
+          <Card className="overflow-hidden rounded-lg shadow-[var(--shadow-card)]">
+            <CardHeader className="flex flex-col gap-3 border-b bg-surface-raised/55 md:flex-row md:items-start md:justify-between">
               <div>
                 <CardTitle className="text-base">Recent delivery history</CardTitle>
                 <CardDescription>

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/loading.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/loading.tsx
@@ -21,10 +21,10 @@ export default function ProjectLoading() {
         </div>
       </div>
 
-      <div className="rounded-xl border-2 border-foreground/15 bg-card p-3 dark:border-primary/25">
+      <div className="rounded-lg border-2 border-foreground/15 bg-card p-3 dark:border-primary/25">
         <div className="grid gap-3 md:grid-cols-4">
           {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="rounded-xl border border-border/80 bg-background p-4 shadow-[var(--shadow-card)] dark:border-primary/25">
+            <div key={i} className="rounded-lg border border-border/80 bg-background p-4 shadow-[var(--shadow-card)] dark:border-primary/25">
               <div className="flex gap-3">
                 <Skeleton className="h-7 w-7 rounded-full" />
                 <div className="space-y-2">
@@ -37,7 +37,7 @@ export default function ProjectLoading() {
         </div>
       </div>
 
-      <div className="rounded-xl border bg-card p-6">
+      <div className="rounded-lg border bg-card p-6">
         <Skeleton className="h-5 w-32" />
         <Skeleton className="mt-3 h-4 w-64" />
         <Skeleton className="mt-6 h-36 w-full rounded-lg" />

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/project-flow-nav.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/project-flow-nav.tsx
@@ -1,36 +1,6 @@
-'use client'
-
-import * as React from 'react'
-import Link from 'next/link'
-import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import { ArrowRight, Check, Loader2 } from 'lucide-react'
+import { CompactSteps } from '@/components/ui/workspace-shell'
 
 export type SetupStep = 'install' | 'verify' | 'inbox'
-
-function usePendingProjectLink() {
-  const pathname = usePathname()
-  const searchParams = useSearchParams()
-  const router = useRouter()
-  const [pendingHref, setPendingHref] = React.useState<string | null>(null)
-
-  React.useEffect(() => {
-    setPendingHref(null)
-  }, [pathname, searchParams])
-
-  const beginNavigation = React.useCallback(
-    (href: string) => {
-      const currentHref = searchParams.size > 0 ? `${pathname}?${searchParams.toString()}` : pathname
-      if (href === currentHref) return
-      setPendingHref(href)
-      router.prefetch(href)
-    },
-    [pathname, router, searchParams],
-  )
-
-  const prefetch = React.useCallback((href: string) => router.prefetch(href), [router])
-
-  return { pendingHref, beginNavigation, prefetch }
-}
 
 export function SetupProgress({
   projectId,
@@ -39,120 +9,31 @@ export function SetupProgress({
   projectId: string
   activeStep: SetupStep
 }) {
-  const { pendingHref, beginNavigation, prefetch } = usePendingProjectLink()
-  const steps: Array<{ id: SetupStep; label: string; body: string; href: string }> = [
-    {
-      id: 'install',
-      label: 'Install once',
-      body: 'Add the shared embed.',
-      href: `/projects/${projectId}/install`,
-    },
-    {
-      id: 'verify',
-      label: 'Verify',
-      body: 'Send one test message.',
-      href: `/projects/${projectId}/verify`,
-    },
-    {
-      id: 'inbox',
-      label: 'Inbox',
-      body: 'Confirm it arrived.',
-      href: `/feedback?projectId=${projectId}`,
-    },
+  const steps: Array<{ id: SetupStep; label: string; href: string }> = [
+    { id: 'install', label: 'Install', href: `/projects/${projectId}/install` },
+    { id: 'verify', label: 'Verify', href: `/projects/${projectId}/verify` },
+    { id: 'inbox', label: 'Inbox', href: `/feedback?projectId=${projectId}` },
   ]
   const activeIndex = Math.max(steps.findIndex((step) => step.id === activeStep), 0)
-  const nextActionByStep: Record<SetupStep, { title: string; body: string; href: string; label: string }> = {
-    install: {
-      title: 'Install the embed once',
-      body: 'Paste one stable snippet into your app shell. Future form and user-update changes arrive remotely without replacement code.',
-      href: `/projects/${projectId}/verify`,
-      label: 'Open verification',
-    },
-    verify: {
-      title: 'Next: confirm the test reached the inbox',
-      body: 'After submitting one test message, check the project inbox for URL and browser context.',
-      href: `/feedback?projectId=${projectId}`,
-      label: 'Open project inbox',
-    },
-    inbox: {
-      title: 'Connected: manage products remotely',
-      body: 'The shared embed works. Change the feedback form or publish updates to users without editing your site again.',
-      href: `/projects/${projectId}`,
-      label: 'Open project home',
-    },
-  }
-  const nextAction = nextActionByStep[activeStep]
 
   return (
-    <nav aria-label="Setup steps" data-tour="setup-progress" className="rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
-      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
-        <div className="min-w-0">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-primary">
-            Setup progress
-          </p>
-          <h2 className="mt-2 text-base font-semibold text-foreground">{nextAction.title}</h2>
-          <p className="mt-1 max-w-2xl text-sm leading-6 text-muted-foreground">{nextAction.body}</p>
-        </div>
-        <Link
-          href={nextAction.href}
-          prefetch={false}
-          onClick={() => beginNavigation(nextAction.href)}
-          onMouseEnter={() => prefetch(nextAction.href)}
-          onFocus={() => prefetch(nextAction.href)}
-          className="inline-flex min-h-10 items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground transition-[background-color,transform] hover:bg-primary/90 active:scale-[0.98]"
-        >
-          {pendingHref === nextAction.href ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <ArrowRight className="h-4 w-4" />
-          )}
-          {nextAction.label}
-        </Link>
+    <nav
+      aria-label="Setup steps"
+      data-tour="setup-progress"
+      className="flex min-h-12 flex-col gap-3 border-b pb-4 sm:flex-row sm:items-center sm:justify-between"
+    >
+      <div>
+        <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+          First connection
+        </p>
+        <p className="mt-0.5 text-sm font-medium text-foreground">
+          Step {activeIndex + 1} of {steps.length}
+        </p>
       </div>
-
-      <ol className="mt-5 grid grid-cols-3 overflow-hidden rounded-lg border border-foreground/10 bg-[oklch(var(--surface-raised))]">
-        {steps.map((step, index) => {
-          const current = activeStep === step.id
-          const completed = index < activeIndex
-          return (
-            <li key={step.id} className="border-l border-foreground/10 first:border-l-0">
-              <Link
-                href={step.href}
-                prefetch={false}
-                onClick={() => beginNavigation(step.href)}
-                onMouseEnter={() => prefetch(step.href)}
-                onFocus={() => prefetch(step.href)}
-                className={`flex min-h-16 flex-col items-center justify-center gap-1 px-1.5 py-2 text-center transition-colors hover:bg-accent/35 md:flex-row md:justify-start md:gap-3 md:px-4 md:py-3 md:text-left ${
-                  current ? 'bg-primary/[0.055]' : ''
-                }`}
-                aria-current={current ? 'step' : undefined}
-              >
-                <span
-                  className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-xs font-semibold ${
-                    completed
-                      ? 'border-primary bg-primary text-primary-foreground'
-                      : current
-                        ? 'border-primary text-primary'
-                        : 'border-border bg-background text-muted-foreground'
-                  }`}
-                >
-                  {pendingHref === step.href ? (
-                    <Loader2 className="h-3 w-3 animate-spin" />
-                  ) : completed ? (
-                    <Check className="h-3 w-3" />
-                  ) : (
-                    index + 1
-                  )}
-                </span>
-                <span className="min-w-0">
-                  <span className="block text-sm font-medium text-foreground">{step.label}</span>
-                  <span className="mt-0.5 hidden text-xs leading-4 text-muted-foreground lg:block">{step.body}</span>
-                </span>
-              </Link>
-            </li>
-          )
-        })}
-      </ol>
+      <CompactSteps
+        steps={steps.map(({ label, href }) => ({ label, href }))}
+        activeIndex={activeIndex}
+      />
     </nav>
   )
 }

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/project-home.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/project-home.tsx
@@ -2,67 +2,76 @@ import Link from 'next/link'
 import { ArrowRight, Check, Code2, FormInput, Megaphone } from 'lucide-react'
 import type { Project } from '@/lib/types'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { PageHeader, SectionPanel, StatusDot } from '@/components/ui/workspace-shell'
 
 export function ProjectHome({ project }: { project: Project }) {
   const feedbackEnabled = project.settings?.widget_config?.feedbackEnabled !== false
 
   return (
-    <div className="animate-fade-in space-y-5">
-      <Card>
-      <CardHeader className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
-        <div>
-          <p className="text-sm font-medium text-primary">{project.name}</p>
-          <h1 className="mt-2 text-3xl font-semibold tracking-[-0.04em]">Your product feedback loop</h1>
-          <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-            Collect useful feedback from users, then show them what improved. Both experiences use the same installed connection.
-          </p>
+    <div className="space-y-6">
+      <PageHeader
+        eyebrow={project.name}
+        title="Project overview"
+        description="Collect feedback and show users what changed through one installed connection."
+        action={
+          <Button asChild>
+            <Link href={`/projects/${project.id}/install`}>
+              Install or verify
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Link>
+          </Button>
+        }
+      />
+
+      <SectionPanel title="User communication" description="Choose the product surface you want to work on.">
+        <div className="-m-5 divide-y">
+          <ProductLane
+            icon={<FormInput className="h-4 w-4" />}
+            direction="Users to your team"
+            title="Feedback form"
+            description="Control the in-product form and collect technical context with each message."
+            status={feedbackEnabled ? 'Enabled' : 'Disabled'}
+            href={`/projects/${project.id}/feedback-form`}
+            action="Customize form"
+          />
+          <ProductLane
+            icon={<Megaphone className="h-4 w-4" />}
+            direction="Your team to users"
+            title="Product updates"
+            description="Publish concise release notes inside the product."
+            href={`/projects/${project.id}/release-notes`}
+            action="Manage updates"
+          />
         </div>
-        <Button asChild>
-          <Link href={`/projects/${project.id}/install`}>Install or verify connection <ArrowRight className="ml-2 h-4 w-4" /></Link>
-        </Button>
-      </CardHeader>
-      </Card>
+      </SectionPanel>
 
-      <div className="grid gap-5 lg:grid-cols-2">
-        <ProductLane
-          icon={<FormInput className="h-5 w-5" />}
-          direction="Users → your team"
-          title="Collect feedback from users"
-          description="Shape the in-product form, choose the fields, and receive every message with useful technical context."
-          status={feedbackEnabled ? 'Enabled' : 'Disabled'}
-          href={`/projects/${project.id}/feedback-form`}
-          action="Customize feedback form"
-        />
-        <ProductLane
-          icon={<Megaphone className="h-5 w-5" />}
-          direction="Your team → users"
-          title="Show product updates to users"
-          description="Create a polished “What’s new” popup that appears inside your product when there is something worth announcing."
-          href={`/projects/${project.id}/release-notes`}
-          action="Manage updates for users"
-        />
-      </div>
-
-      <Card>
-      <CardContent className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
-        <div className="flex gap-4">
-          <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-foreground text-background"><Code2 className="h-4 w-4" /></span>
+      <div className="flex flex-col gap-4 rounded-lg border bg-surface-raised/55 p-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex gap-3">
+          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-foreground text-background"><Code2 className="h-4 w-4" /></span>
           <div>
-            <h2 className="text-sm font-semibold">One connection, installed once</h2>
-            <p className="mt-1 max-w-2xl text-sm leading-6 text-muted-foreground">The code stays stable. Save form changes or publish user-facing updates here, and the installed embed receives them automatically.</p>
+            <h2 className="text-sm font-semibold">One stable connection</h2>
+            <p className="mt-1 text-sm text-muted-foreground">Save changes here. The installed snippet does not change.</p>
           </div>
         </div>
-        <ol className="flex flex-wrap gap-x-5 gap-y-2 text-xs text-muted-foreground">
-          {['Copy embed', 'Verify one test', 'Manage remotely'].map((label) => <li key={label} className="inline-flex items-center gap-1.5"><Check className="h-3.5 w-3.5 text-primary" />{label}</li>)}
+        <ol className="flex flex-wrap gap-x-4 gap-y-2 text-xs text-muted-foreground">
+          {['Copy embed', 'Verify test', 'Manage remotely'].map((label) => (
+            <li key={label} className="inline-flex items-center gap-1.5"><Check className="h-3.5 w-3.5 text-primary" />{label}</li>
+          ))}
         </ol>
-      </CardContent>
-      </Card>
+      </div>
     </div>
   )
 }
 
-function ProductLane({ icon, direction, title, description, status, href, action, className = '' }: {
+function ProductLane({
+  icon,
+  direction,
+  title,
+  description,
+  status,
+  href,
+  action,
+}: {
   icon: React.ReactNode
   direction: string
   title: string
@@ -70,22 +79,21 @@ function ProductLane({ icon, direction, title, description, status, href, action
   status?: string
   href: string
   action: string
-  className?: string
 }) {
   return (
-    <Card className={`group ${className}`}>
-      <CardContent>
-      <div className="flex items-center justify-between gap-4">
-        <span className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">{icon}</span>
-        {status && <span className="inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground"><span className="h-1.5 w-1.5 rounded-full bg-primary" />{status}</span>}
+    <Link href={href} className="group grid gap-4 px-5 py-5 transition-colors hover:bg-surface-raised/55 sm:grid-cols-[32px_minmax(0,1fr)_auto] sm:items-center">
+      <span className="flex h-8 w-8 items-center justify-center rounded-md bg-primary/10 text-primary">{icon}</span>
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <h2 className="text-sm font-semibold">{title}</h2>
+          {status && <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground"><StatusDot tone={status === 'Enabled' ? 'success' : 'neutral'} />{status}</span>}
+        </div>
+        <p className="mt-1 text-xs font-medium text-muted-foreground">{direction}</p>
+        <p className="mt-1 max-w-2xl text-sm leading-6 text-muted-foreground">{description}</p>
       </div>
-      <p className="mt-8 text-xs font-medium text-muted-foreground">{direction}</p>
-      <h2 className="mt-2 text-xl font-semibold tracking-tight">{title}</h2>
-      <p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">{description}</p>
-      <Link href={href} className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-foreground transition-colors hover:text-primary">
+      <span className="inline-flex items-center gap-2 text-sm font-medium text-foreground">
         {action}<ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
-      </Link>
-      </CardContent>
-    </Card>
+      </span>
+    </Link>
   )
 }

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/project-tabs.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/project-tabs.tsx
@@ -21,6 +21,7 @@ import { IntegrationsTab } from './integrations-tab'
 import { SetupProgress } from './project-flow-nav'
 import { ProductUpdatesTab } from '@/components/product-updates/ProductUpdatesTab'
 import { ProjectHome } from './project-home'
+import { PageHeader } from '@/components/ui/workspace-shell'
 
 interface ProjectTabsProps {
   project: Project
@@ -39,7 +40,7 @@ export function ProjectTabs({ project, billingSummary, initialTab, updatesView, 
   return (
     <Suspense
       fallback={
-        <div className="rounded-xl border bg-card p-6 text-sm text-muted-foreground">
+        <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground">
           Loading project workspace...
         </div>
       }
@@ -229,9 +230,10 @@ function SettingsTab({ project }: { project: Project }) {
 
   return (
     <div className="space-y-6">
+      <PageHeader eyebrow={project.name} title="Project settings" description="Manage identity, allowed origins, and project lifecycle." />
       <Card>
         <CardHeader>
-          <CardTitle className="text-lg">Project Settings</CardTitle>
+          <CardTitle className="text-lg">Project details</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="space-y-2">
@@ -286,7 +288,7 @@ function SettingsTab({ project }: { project: Project }) {
 
       <Card className="border-destructive/50">
         <CardHeader>
-          <CardTitle className="text-lg text-destructive">Danger Zone</CardTitle>
+          <CardTitle className="text-lg text-destructive">Delete project</CardTitle>
           <CardDescription>
             Permanently delete this project and all its feedback.
           </CardDescription>

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/project-verify-client.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/project-verify-client.tsx
@@ -14,6 +14,7 @@ import { Badge } from '@/components/ui/badge'
 import { CheckCircle2, ExternalLink, RefreshCw } from 'lucide-react'
 import { WidgetPreviewSurface } from './widget-preview-surface'
 import { SetupProgress } from './project-flow-nav'
+import { PageHeader } from '@/components/ui/workspace-shell'
 
 interface ProjectVerifyClientProps {
   appOrigin: string
@@ -84,7 +85,7 @@ export function ProjectVerifyClient({
       <SetupProgress projectId={projectId} activeStep="verify" />
 
       {verifiedFeedbackId && (
-        <div className="flex flex-col gap-4 rounded-xl border border-primary/35 bg-card p-5 shadow-[var(--shadow-card)] sm:flex-row sm:items-center sm:justify-between" role="status">
+        <div className="flex flex-col gap-4 rounded-lg border border-primary/35 bg-card p-5 shadow-[var(--shadow-card)] sm:flex-row sm:items-center sm:justify-between" role="status">
           <div className="flex min-w-0 gap-3">
             <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
             <div>
@@ -103,31 +104,21 @@ export function ProjectVerifyClient({
         </div>
       )}
 
-      <header data-tour="verify-guide" className="flex flex-wrap items-end justify-between gap-4 rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
-        <div>
-          <h1 className="text-2xl font-semibold tracking-[-0.035em]">Send one test. Know the connection works.</h1>
-          <p className="mt-1 max-w-3xl text-sm leading-6 text-muted-foreground">
-            This page is a safe test page. It proves your saved form can send feedback. It does not check the code on your own website.
-          </p>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <Link href={`/feedback?projectId=${projectId}`}>
-            <Button variant="outline">Open project inbox</Button>
-          </Link>
-          <Link href={`/projects/${projectId}/feedback-form`}>
-            <Button variant="outline">Manage feedback form</Button>
-          </Link>
-        </div>
-      </header>
+      <div data-tour="verify-guide">
+        <PageHeader
+          eyebrow={projectName}
+          title="Verify one test"
+          description="Send a known message here, then confirm it reaches the project inbox. This hosted page tests the saved form and inbox path."
+        />
+      </div>
 
       <div className="grid gap-5 lg:grid-cols-[300px_minmax(0,1fr)]">
-        <aside className="rounded-xl border bg-card p-5 shadow-[var(--shadow-card)]">
+        <aside className="rounded-lg border bg-card p-5 shadow-[var(--shadow-card)]">
             <div className="flex items-center gap-2">
               <Badge variant="secondary">Saved config</Badge>
               <Badge variant="outline">{modeLabel} mode</Badge>
             </div>
-            <h2 className="mt-5 text-lg font-semibold">Three quick checks</h2>
-            <p className="mt-1 text-sm text-muted-foreground">This hosted page tests your saved form and inbox path.</p>
+            <h2 className="mt-5 text-base font-semibold">Three quick checks</h2>
           <ol className="mt-5 divide-y overflow-hidden rounded-lg border bg-[oklch(var(--surface-raised))] px-4 text-sm text-muted-foreground">
             <li className="grid grid-cols-[24px_1fr] gap-2 py-3">
               <span className="font-medium text-foreground">1</span><span>Find the form here. {verifyInstruction}</span>
@@ -147,7 +138,7 @@ export function ProjectVerifyClient({
             </div>
         </aside>
 
-        <section className="min-w-0 overflow-hidden rounded-xl border bg-card shadow-[var(--shadow-card)]">
+        <section className="min-w-0 overflow-hidden rounded-lg border bg-card shadow-[var(--shadow-card)]">
             <div className="bg-muted/25 p-5 sm:p-7">
               <div className="max-w-xl space-y-3">
                 <p className="text-xs font-medium text-primary">Live saved configuration</p>

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/verify/loading.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/verify/loading.tsx
@@ -11,10 +11,10 @@ export default function ProjectVerifyLoading() {
         </div>
       </div>
 
-      <div className="rounded-xl border-2 border-foreground/15 bg-card p-3 dark:border-primary/25">
+      <div className="rounded-lg border-2 border-foreground/15 bg-card p-3 dark:border-primary/25">
         <div className="grid gap-3 md:grid-cols-4">
           {Array.from({ length: 4 }).map((_, index) => (
-            <div key={index} className="rounded-xl border-2 border-foreground/15 bg-background p-4">
+            <div key={index} className="rounded-lg border-2 border-foreground/15 bg-background p-4">
               <div className="flex gap-3">
                 <Skeleton className="h-7 w-7 rounded-full" />
                 <div className="space-y-2">
@@ -39,8 +39,8 @@ export default function ProjectVerifyLoading() {
       </div>
 
       <div className="grid gap-6 lg:grid-cols-[320px_minmax(0,1fr)]">
-        <Skeleton className="h-[32rem] rounded-xl" />
-        <Skeleton className="h-[36rem] rounded-xl" />
+        <Skeleton className="h-[32rem] rounded-lg" />
+        <Skeleton className="h-[36rem] rounded-lg" />
       </div>
     </div>
   )

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/widget-form-preview.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/widget-form-preview.tsx
@@ -23,7 +23,7 @@ function PreviewForm({ config, compact = false }: { config: SavedWidgetConfig; c
   return (
     <div
       className={cn(
-        'rounded-xl border bg-white text-zinc-950 shadow-sm',
+        'rounded-lg border bg-white text-zinc-950 shadow-sm',
         compact ? 'p-4' : 'p-5',
       )}
       style={{ borderColor: `${primary}26` }}
@@ -135,7 +135,7 @@ export function WidgetFormPreview({ config, className }: WidgetFormPreviewProps)
   )
 
   return (
-    <div className={cn('rounded-xl border bg-zinc-50 p-4', className)}>
+    <div className={cn('rounded-lg border bg-zinc-50 p-4', className)}>
       {mode === 'inline' ? (
         <PreviewForm config={config} />
       ) : (
@@ -161,7 +161,7 @@ export function WidgetFormPreview({ config, className }: WidgetFormPreviewProps)
           {isFormOpen ? (
             <PreviewForm config={config} compact />
           ) : (
-            <div className="rounded-xl border border-dashed bg-white p-6 text-sm text-zinc-500">
+            <div className="rounded-lg border border-dashed bg-white p-6 text-sm text-zinc-500">
               The form is closed. Use the preview button to open it.
             </div>
           )}

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/widget-preview-surface.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/widget-preview-surface.tsx
@@ -220,7 +220,7 @@ export function WidgetPreviewSurface({
     <div
       ref={hostRef}
       className={cn(
-        'relative min-h-[280px] rounded-xl border bg-background p-6',
+        'relative min-h-[280px] rounded-lg border bg-background p-6',
         className,
       )}
     />

--- a/packages/dashboard/src/app/(dashboard)/projects/loading.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/loading.tsx
@@ -11,7 +11,7 @@ export default function ProjectsLoading() {
         <Skeleton className="h-10 w-32 rounded-md" />
       </div>
 
-      <div className="overflow-hidden rounded-xl border bg-card">
+      <div className="overflow-hidden rounded-lg border bg-card">
         {Array.from({ length: 5 }).map((_, index) => (
           <div
             key={index}

--- a/packages/dashboard/src/app/(dashboard)/projects/new/loading.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/new/loading.tsx
@@ -5,7 +5,7 @@ export default function NewProjectLoading() {
     <div className="mx-auto max-w-4xl space-y-6">
       <Skeleton className="h-4 w-28" />
       <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_320px]">
-        <div className="rounded-xl border bg-card p-6">
+        <div className="rounded-lg border bg-card p-6">
           <Skeleton className="h-6 w-48" />
           <Skeleton className="mt-3 h-4 w-72 max-w-full" />
           <div className="mt-6 space-y-4">
@@ -15,7 +15,7 @@ export default function NewProjectLoading() {
             <Skeleton className="h-11 w-full rounded-md" />
           </div>
         </div>
-        <div className="rounded-xl border bg-card p-6">
+        <div className="rounded-lg border bg-card p-6">
           <Skeleton className="h-5 w-36" />
           <Skeleton className="mt-2 h-4 w-44" />
           <div className="mt-5 space-y-3">

--- a/packages/dashboard/src/app/(dashboard)/projects/new/page.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/new/page.tsx
@@ -79,11 +79,13 @@ export default function NewProjectPage() {
         const modulePayload = await modulesResponse.json().catch(() => null)
         throw new Error(modulePayload?.error || 'Project created, but the product choice could not be saved.')
       }
-      router.push(goal === 'feedback'
+      const destination = goal === 'feedback'
         ? `/projects/${payload.id}/install?created=1`
         : goal === 'updates'
           ? `/projects/${payload.id}/release-notes`
-          : `/projects/${payload.id}`)
+          : `/projects/${payload.id}`
+      router.push(destination)
+      router.refresh()
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : 'Failed to create project')
     } finally {
@@ -92,7 +94,7 @@ export default function NewProjectPage() {
   }
 
   return (
-    <div className="mx-auto max-w-xl animate-fade-in">
+    <div className="mx-auto max-w-xl">
       <Link
         href="/projects"
         className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
@@ -102,9 +104,9 @@ export default function NewProjectPage() {
 
       <Card className="mt-6">
       <CardHeader>
-        <p className="text-xs font-semibold text-primary">New project</p>
+        <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-primary">New project</p>
         <h1 className="mt-3 text-3xl font-semibold tracking-[-0.035em]">Name your app or website</h1>
-        <p className="mt-3 max-w-md text-sm leading-6 text-muted-foreground">That is all we need to start. You will make the feedback form on the next screen.</p>
+        <p className="mt-2 max-w-md text-sm leading-6 text-muted-foreground">One name is enough. The recommended install snippet comes next.</p>
       </CardHeader>
 
       <CardContent>
@@ -128,7 +130,7 @@ export default function NewProjectPage() {
 
             <details className="overflow-hidden rounded-lg border bg-[oklch(var(--surface-raised))] px-4">
               <summary className="cursor-pointer py-3 text-sm font-medium text-muted-foreground hover:text-foreground">
-                Start with something else <span className="font-normal">· {productChoices.find((choice) => choice.value === goal)?.label}</span>
+                Choose a different first goal <span className="font-normal">· {productChoices.find((choice) => choice.value === goal)?.label}</span>
               </summary>
               <fieldset className="space-y-2 border-t py-4">
                 <legend className="sr-only">First tool</legend>
@@ -145,7 +147,7 @@ export default function NewProjectPage() {
 
             <details className="overflow-hidden rounded-lg border bg-[oklch(var(--surface-raised))] px-4">
               <summary className="cursor-pointer py-3 text-sm font-medium text-muted-foreground hover:text-foreground">
-                Add an icon or domain <span className="font-normal">· optional</span>
+                Add project details <span className="font-normal">· optional</span>
               </summary>
               <div className="space-y-5 border-t py-4">
                 <fieldset className="space-y-2">
@@ -212,10 +214,10 @@ export default function NewProjectPage() {
             )}
             <Button data-tour="project-create-submit" type="submit" size="lg" className="h-12 w-full gap-2" disabled={loading || !name.trim()}>
               {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {goal === 'updates' ? 'Create project and write a user message' : goal === 'both' ? 'Create project' : 'Create project and make the form'}
+              {goal === 'updates' ? 'Create project and write an update' : goal === 'both' ? 'Create project' : 'Create project and get the snippet'}
               {!loading && <ArrowRight className="h-4 w-4" />}
             </Button>
-            <p className="text-center text-xs leading-5 text-muted-foreground">Next: make the form, add one code block, then send a test.</p>
+            <p className="text-center text-xs leading-5 text-muted-foreground">Next: copy the snippet and verify one test.</p>
       </form>
       </CardContent>
       </Card>

--- a/packages/dashboard/src/app/(dashboard)/projects/page.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/page.tsx
@@ -9,6 +9,7 @@ import Link from 'next/link'
 import { ArrowRight, Code2, FolderOpen, Inbox, Key, Plus } from 'lucide-react'
 import { cookies } from 'next/headers'
 import { CURRENT_PROJECT_COOKIE, getSelectedProject } from '@/lib/project-selection'
+import { PageHeader } from '@/components/ui/workspace-shell'
 
 export const metadata = { title: 'Projects' }
 
@@ -40,24 +41,18 @@ export default async function ProjectsPage() {
 
   return (
     <div data-tour="project-surface" className="space-y-6">
-      <div className="flex items-center justify-between rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
-        <div>
-          <h1 className="text-2xl font-bold">Projects</h1>
-          {billingSummary && (
-            <p className="mt-1 text-sm text-muted-foreground">
-              {billingSummary.entitlements.label} plan · {billingSummary.usage.projectCount}
-              {billingSummary.entitlements.projectLimit
-                ? ` of ${billingSummary.entitlements.projectLimit} projects used`
-                : ' projects'}
-            </p>
-          )}
-        </div>
-        <Link href="/projects/new" data-tour="new-project">
-          <Button>
-            <Plus className="mr-2 h-4 w-4" /> New Project
+      <PageHeader
+        eyebrow="Workspace"
+        title="Projects"
+        description={billingSummary
+          ? `${billingSummary.entitlements.label} plan · ${billingSummary.usage.projectCount}${billingSummary.entitlements.projectLimit ? ` of ${billingSummary.entitlements.projectLimit} projects used` : ' projects'}`
+          : 'Manage each product connection.'}
+        action={
+          <Button asChild>
+            <Link href="/projects/new" data-tour="new-project"><Plus className="mr-2 h-4 w-4" />New project</Link>
           </Button>
-        </Link>
-      </div>
+        }
+      />
 
       {billingSummary?.entitlements.projectLimit &&
         billingSummary.usage.projectCount >= billingSummary.entitlements.projectLimit && (
@@ -100,11 +95,11 @@ export default async function ProjectsPage() {
           </CardContent>
         </Card>
       ) : (
-        <div className="overflow-hidden rounded-xl border bg-card shadow-[var(--shadow-card)]">
+        <div className="overflow-hidden rounded-lg border bg-card shadow-[var(--shadow-card)]">
           {(projects as Project[]).map((project) => (
             <Link
               key={project.id}
-              href={`/projects/${project.id}?tab=customize`}
+              href={`/projects/${project.id}`}
               className="group grid gap-3 border-b px-4 py-4 transition-colors last:border-b-0 hover:bg-accent/40 md:grid-cols-[minmax(0,1fr)_auto] md:items-center"
             >
               <div className="min-w-0">

--- a/packages/dashboard/src/app/(dashboard)/settings/loading.tsx
+++ b/packages/dashboard/src/app/(dashboard)/settings/loading.tsx
@@ -5,7 +5,7 @@ export default function SettingsLoading() {
     <div className="mx-auto max-w-2xl space-y-6">
       <Skeleton className="h-7 w-28" />
       {Array.from({ length: 4 }).map((_, index) => (
-        <div key={index} className="rounded-xl border bg-card p-6">
+        <div key={index} className="rounded-lg border bg-card p-6">
           <Skeleton className="h-5 w-32" />
           <div className="mt-5 space-y-4">
             <Skeleton className="h-4 w-24" />

--- a/packages/dashboard/src/app/(dashboard)/settings/page.tsx
+++ b/packages/dashboard/src/app/(dashboard)/settings/page.tsx
@@ -6,8 +6,9 @@ import { useTheme } from 'next-themes'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
+import { PageHeader } from '@/components/ui/workspace-shell'
 import { AlertTriangle, Loader2, Mail } from 'lucide-react'
 import { toast } from '@/hooks/use-toast'
 import Link from 'next/link'
@@ -158,127 +159,120 @@ export default function SettingsPage() {
 
   return (
     <div className="mx-auto max-w-2xl space-y-8">
-      <header className="rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
-        <p className="text-xs font-semibold text-primary">Your account</p>
-        <h1 className="mt-2 text-2xl font-semibold tracking-[-0.03em]">Settings</h1>
-        <p className="mt-2 text-sm text-muted-foreground">Manage your profile, alerts, theme, and account.</p>
-      </header>
+      <PageHeader eyebrow="Account" title="Settings" description="Manage your profile, alerts, appearance, and account." />
 
-      {/* Profile */}
-      <Card className="overflow-hidden rounded-xl shadow-[var(--shadow-card)]">
-        <CardHeader className="border-b bg-muted/25">
-          <CardTitle className="text-lg">Profile</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4 pt-6">
-          <div className="space-y-2">
-            <Label htmlFor="settings-email">Email</Label>
-            <Input id="settings-email" value={email} disabled />
+      <div className="divide-y overflow-hidden rounded-lg border bg-card shadow-sm">
+        <section className="grid gap-6 p-5 sm:p-6 md:grid-cols-[150px_minmax(0,1fr)]">
+          <div>
+            <h2 className="font-semibold">Profile</h2>
+            <p className="mt-1 text-sm text-muted-foreground">How your account appears.</p>
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="settings-name">Display name</Label>
-            <Input
-              id="settings-name"
-              value={displayName}
-              onChange={(e) => setDisplayName(e.target.value)}
-              placeholder="Your name"
-            />
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="settings-email">Email</Label>
+              <Input id="settings-email" value={email} disabled />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="settings-name">Display name</Label>
+              <Input
+                id="settings-name"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                placeholder="Your name"
+              />
+            </div>
+            <Button onClick={handleSaveProfile} disabled={saving}>
+              {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Save profile
+            </Button>
           </div>
-          <Button onClick={handleSaveProfile} disabled={saving}>
-            {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            Save profile
-          </Button>
-        </CardContent>
-      </Card>
+        </section>
 
-      {/* Notifications */}
-      <Card className="overflow-hidden rounded-xl shadow-[var(--shadow-card)]">
-        <CardHeader className="border-b bg-muted/25">
-          <CardTitle className="text-lg">Notifications</CardTitle>
-          <CardDescription>
-            Choose which account alerts reach your email.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-3 pt-6">
-          <div className="divide-y border-y bg-muted/10">
-            <label className="flex min-h-14 items-start gap-3 px-4 py-3 text-sm">
-              <input
-                type="checkbox"
-                className="mt-0.5 h-4 w-4 rounded border accent-primary"
-                checked={emailNotifications}
-                onChange={(event) => setEmailNotifications(event.target.checked)}
-              />
-              <span>
-                <span className="block font-medium text-foreground">Email me when new feedback arrives</span>
-                <span className="text-muted-foreground">
-                  Immediate owner alerts for newly submitted feedback. Off by default.
-                </span>
-              </span>
-            </label>
-            <label className="flex min-h-14 items-start gap-3 px-4 py-3 text-sm">
-              <input
-                type="checkbox"
-                className="mt-0.5 h-4 w-4 rounded border accent-primary"
-                checked={dailyDigest}
-                onChange={(event) => setDailyDigest(event.target.checked)}
-              />
-              <span>
-                <span className="block font-medium text-foreground">Send a daily feedback digest</span>
-                <span className="text-muted-foreground">
-                  A once-per-day summary of new feedback across your projects.
-                </span>
-              </span>
-            </label>
-            <label className="flex min-h-14 items-start gap-3 px-4 py-3 text-sm">
-              <input
-                type="checkbox"
-                className="mt-0.5 h-4 w-4 rounded border accent-primary"
-                checked={webhookFailureEmails}
-                onChange={(event) => setWebhookFailureEmails(event.target.checked)}
-                disabled={!emailNotifications}
-              />
-              <span>
-                <span className="block font-medium text-foreground">Email me when an integration is auto-disabled</span>
-                <span className="text-muted-foreground">
-                  Sends an alert if repeated webhook failures disable an endpoint.
-                </span>
-              </span>
-            </label>
-            <label className="flex min-h-14 items-start gap-3 px-4 py-3 text-sm">
-              <input
-                type="checkbox"
-                className="mt-0.5 h-4 w-4 rounded border accent-primary"
-                checked={billingFailureEmails}
-                onChange={(event) => setBillingFailureEmails(event.target.checked)}
-              />
-              <span>
-                <span className="block font-medium text-foreground">Email me when billing needs attention</span>
-                <span className="text-muted-foreground">
-                  Sends a direct alert when Dodo reports a failed recurring payment.
-                </span>
-              </span>
-            </label>
+        <section className="grid gap-6 p-5 sm:p-6 md:grid-cols-[150px_minmax(0,1fr)]">
+          <div>
+            <h2 className="font-semibold">Notifications</h2>
+            <p className="mt-1 text-sm text-muted-foreground">Choose which account alerts reach your email.</p>
           </div>
-          <div className="flex flex-wrap gap-2">
-            <Link href="/projects">
-              <Button variant="outline" size="sm">Choose a project</Button>
-            </Link>
-            <Link href="/billing">
-              <Button variant="ghost" size="sm">View billing</Button>
-            </Link>
+          <div className="space-y-3">
+            <div className="divide-y border-y bg-surface-raised/60">
+              <label className="flex min-h-14 items-start gap-3 px-4 py-3 text-sm">
+                <input
+                  type="checkbox"
+                  className="mt-0.5 h-4 w-4 rounded border accent-primary"
+                  checked={emailNotifications}
+                  onChange={(event) => setEmailNotifications(event.target.checked)}
+                />
+                <span>
+                  <span className="block font-medium text-foreground">Email me when new feedback arrives</span>
+                  <span className="text-muted-foreground">
+                    Immediate owner alerts for newly submitted feedback. Off by default.
+                  </span>
+                </span>
+              </label>
+              <label className="flex min-h-14 items-start gap-3 px-4 py-3 text-sm">
+                <input
+                  type="checkbox"
+                  className="mt-0.5 h-4 w-4 rounded border accent-primary"
+                  checked={dailyDigest}
+                  onChange={(event) => setDailyDigest(event.target.checked)}
+                />
+                <span>
+                  <span className="block font-medium text-foreground">Send a daily feedback digest</span>
+                  <span className="text-muted-foreground">
+                    A once-per-day summary of new feedback across your projects.
+                  </span>
+                </span>
+              </label>
+              <label className="flex min-h-14 items-start gap-3 px-4 py-3 text-sm">
+                <input
+                  type="checkbox"
+                  className="mt-0.5 h-4 w-4 rounded border accent-primary"
+                  checked={webhookFailureEmails}
+                  onChange={(event) => setWebhookFailureEmails(event.target.checked)}
+                  disabled={!emailNotifications}
+                />
+                <span>
+                  <span className="block font-medium text-foreground">Email me when an integration is auto-disabled</span>
+                  <span className="text-muted-foreground">
+                    Sends an alert if repeated webhook failures disable an endpoint.
+                  </span>
+                </span>
+              </label>
+              <label className="flex min-h-14 items-start gap-3 px-4 py-3 text-sm">
+                <input
+                  type="checkbox"
+                  className="mt-0.5 h-4 w-4 rounded border accent-primary"
+                  checked={billingFailureEmails}
+                  onChange={(event) => setBillingFailureEmails(event.target.checked)}
+                />
+                <span>
+                  <span className="block font-medium text-foreground">Email me when billing needs attention</span>
+                  <span className="text-muted-foreground">
+                    Sends a direct alert when Dodo reports a failed recurring payment.
+                  </span>
+                </span>
+              </label>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Link href="/projects">
+                <Button variant="outline" size="sm">Choose a project</Button>
+              </Link>
+              <Link href="/billing">
+                <Button variant="ghost" size="sm">View billing</Button>
+              </Link>
+            </div>
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Mail className="h-4 w-4" />
+              Slack, Discord, GitHub, and webhooks are set up inside each project.
+            </div>
           </div>
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Mail className="h-4 w-4" />
-            Slack, Discord, GitHub, and webhooks are set up inside each project.
-          </div>
-        </CardContent>
-      </Card>
+        </section>
 
-      {/* Theme */}
-      <Card className="overflow-hidden rounded-xl shadow-[var(--shadow-card)]">
-        <CardHeader className="border-b bg-muted/25">
-          <CardTitle className="text-lg">Appearance</CardTitle>
-        </CardHeader>
-        <CardContent className="pt-6">
+        <section className="grid gap-6 p-5 sm:p-6 md:grid-cols-[150px_minmax(0,1fr)]">
+          <div>
+            <h2 className="font-semibold">Appearance</h2>
+            <p className="mt-1 text-sm text-muted-foreground">Use light, dark, or your system preference.</p>
+          </div>
           <div className="flex gap-2">
             {(['light', 'dark', 'system'] as const).map((t) => (
               <Button
@@ -291,18 +285,15 @@ export default function SettingsPage() {
               </Button>
             ))}
           </div>
-        </CardContent>
-      </Card>
+        </section>
+      </div>
 
-      {/* Account */}
-      <Card className="overflow-hidden rounded-xl border-destructive/35 shadow-[var(--shadow-card)]">
-        <CardHeader className="border-b border-destructive/25 bg-destructive/[0.045]">
-          <CardTitle className="text-lg">Account</CardTitle>
-          <CardDescription>
-            Delete your account and all associated data.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4 pt-6">
+      <section className="overflow-hidden rounded-lg border border-destructive/35 bg-card shadow-sm">
+        <div className="border-b border-destructive/25 bg-destructive/[0.045] px-5 py-4 sm:px-6">
+          <h2 className="font-semibold">Delete account</h2>
+          <p className="mt-1 text-sm text-muted-foreground">Permanently remove your account and all associated data.</p>
+        </div>
+        <div className="space-y-4 p-5 sm:p-6">
           <div className="border-y border-destructive/30 bg-destructive/5 px-4 py-4 text-sm">
             <div className="flex items-start gap-3">
               <AlertTriangle className="mt-0.5 h-4 w-4 text-destructive" />
@@ -331,8 +322,8 @@ export default function SettingsPage() {
             {deleting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
             Delete account
           </Button>
-        </CardContent>
-      </Card>
+        </div>
+      </section>
     </div>
   )
 }

--- a/packages/dashboard/src/app/(dashboard)/tutorials/tutorial-center.tsx
+++ b/packages/dashboard/src/app/(dashboard)/tutorials/tutorial-center.tsx
@@ -56,7 +56,7 @@ export function TutorialCenter({
 
   return (
     <div className="mx-auto max-w-5xl space-y-6">
-      <div className="max-w-2xl rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
+      <div className="max-w-2xl rounded-lg border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
         <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-primary">Tutorials</p>
         <h1 className="mt-2 text-2xl font-bold">Learn one job at a time</h1>
         <p className="mt-2 text-sm leading-6 text-muted-foreground">
@@ -64,7 +64,7 @@ export function TutorialCenter({
         </p>
       </div>
 
-      <div className="flex flex-col gap-3 rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-3 rounded-lg border bg-card p-5 shadow-[var(--shadow-card)] sm:flex-row sm:items-center sm:justify-between">
         <div>
           <p className="text-sm font-semibold">Your progress</p>
           <p className="mt-1 text-sm text-muted-foreground">{completed} of {GUIDED_TUTORIALS.length} tutorials completed</p>
@@ -85,7 +85,7 @@ export function TutorialCenter({
           const href = tutorialHref(tutorial.id, tutorial.steps[0].href, defaultProjectId)
 
           return (
-            <article key={tutorial.id} className="flex min-h-48 flex-col rounded-xl border bg-card p-5 shadow-[var(--shadow-card)]">
+            <article key={tutorial.id} className="flex min-h-48 flex-col rounded-lg border bg-card p-5 shadow-[var(--shadow-card)]">
               <div className="flex items-start justify-between gap-3">
                 <span className="flex h-9 w-9 items-center justify-center rounded-md border bg-background text-primary">
                   <Icon className="h-4 w-4" />

--- a/packages/dashboard/src/app/globals.css
+++ b/packages/dashboard/src/app/globals.css
@@ -4,67 +4,67 @@
 
 @layer base {
   :root {
-    /* Warm, precise neutrals with one controlled product-green accent. */
-    --background: 0.985 0.006 105;
-    --foreground: 0.205 0.012 105;
-    /* Tonal elevation: raised surfaces get gently deeper in light mode. */
-    --surface-sidebar: 0.97 0.008 105;
-    --surface-raised: 0.985 0.008 105;
-    --surface-overlay: 0.995 0.006 105;
-    --surface-selected: 0.925 0.028 120;
-    --card: 0.995 0.004 105;
-    --card-foreground: 0.205 0.012 105;
-    --popover: 0.95 0.012 105;
-    --popover-foreground: 0.205 0.012 105;
-    --primary: 0.49 0.145 127;
-    --primary-foreground: 0.985 0.01 110;
-    --secondary: 0.952 0.011 105;
-    --secondary-foreground: 0.29 0.018 105;
-    --muted: 0.955 0.009 105;
-    --muted-foreground: 0.49 0.016 105;
-    --accent: 0.935 0.021 112;
-    --accent-foreground: 0.27 0.022 110;
+    /* Canvas, work surfaces, and controls each have a distinct neutral role. */
+    --background: 0.968 0.007 105;
+    --foreground: 0.205 0.014 108;
+    --surface-sidebar: 0.988 0.005 105;
+    --surface-raised: 0.944 0.009 105;
+    --surface-overlay: 0.995 0.004 105;
+    --surface-selected: 0.925 0.038 126;
+    --surface-code: 0.205 0.012 112;
+    --card: 0.992 0.004 105;
+    --card-foreground: 0.205 0.014 108;
+    --popover: 0.998 0.003 105;
+    --popover-foreground: 0.205 0.014 108;
+    --primary: 0.475 0.135 132;
+    --primary-foreground: 0.985 0.008 110;
+    --secondary: 0.925 0.011 105;
+    --secondary-foreground: 0.28 0.018 108;
+    --muted: 0.934 0.01 105;
+    --muted-foreground: 0.455 0.018 108;
+    --accent: 0.918 0.022 122;
+    --accent-foreground: 0.255 0.025 116;
     --destructive: 0.58 0.218 27;
     --destructive-foreground: 0.985 0.005 27;
-    --border: 0.89 0.012 105;
-    --input: 0.87 0.014 105;
-    --ring: 0.49 0.145 127;
-    --radius: 0.55rem;
+    --border: 0.855 0.013 105;
+    --input: 0.82 0.015 105;
+    --ring: 0.475 0.135 132;
+    --radius: 0.45rem;
 
     /* Brand tokens */
-    --brand: 0.49 0.145 127;
-    --brand-subtle: 0.95 0.035 120;
+    --brand: 0.475 0.135 132;
+    --brand-subtle: 0.93 0.04 126;
   }
 
   .dark {
-    --background: 0.135 0.009 105;
-    --foreground: 0.94 0.009 105;
-    /* Tonal elevation reverses in dark mode: higher surfaces become lighter. */
-    --surface-sidebar: 0.165 0.01 105;
-    --surface-raised: 0.225 0.011 105;
-    --surface-overlay: 0.255 0.012 105;
-    --surface-selected: 0.275 0.035 120;
-    --card: 0.195 0.01 105;
-    --card-foreground: 0.94 0.009 105;
-    --popover: 0.22 0.011 105;
-    --popover-foreground: 0.94 0.009 105;
-    --primary: 0.78 0.19 126;
-    --primary-foreground: 0.18 0.032 120;
-    --secondary: 0.235 0.012 105;
+    --background: 0.115 0.009 108;
+    --foreground: 0.935 0.009 105;
+    --surface-sidebar: 0.15 0.011 108;
+    --surface-raised: 0.235 0.013 108;
+    --surface-overlay: 0.275 0.014 108;
+    --surface-selected: 0.255 0.042 130;
+    --surface-code: 0.085 0.01 112;
+    --card: 0.185 0.012 108;
+    --card-foreground: 0.935 0.009 105;
+    --popover: 0.245 0.014 108;
+    --popover-foreground: 0.935 0.009 105;
+    --primary: 0.735 0.155 132;
+    --primary-foreground: 0.145 0.028 126;
+    --secondary: 0.255 0.014 108;
     --secondary-foreground: 0.9 0.009 105;
-    --muted: 0.225 0.011 105;
-    --muted-foreground: 0.69 0.014 105;
-    --accent: 0.265 0.017 110;
+    --muted: 0.225 0.013 108;
+    --muted-foreground: 0.72 0.015 105;
+    --accent: 0.285 0.025 120;
     --accent-foreground: 0.94 0.009 105;
     --destructive: 0.55 0.19 27;
     --destructive-foreground: 0.97 0.008 27;
-    --border: 0.31 0.012 105;
-    --input: 0.34 0.014 105;
-    --ring: 0.78 0.19 126;
+    --border: 0.335 0.014 108;
+    --input: 0.39 0.016 108;
+    --ring: 0.735 0.155 132;
 
     /* Brand tokens dark */
-    --brand: 0.78 0.19 126;
-    --brand-subtle: 0.23 0.035 120;
+    --brand: 0.735 0.155 132;
+    --brand-subtle: 0.245 0.04 128;
   }
 }
 
@@ -113,12 +113,12 @@
   --ease-out-quart: cubic-bezier(0.25, 1, 0.5, 1);
   --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
   --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
-  --shadow-card: 0 1px 2px rgb(15 18 13 / 0.04), 0 8px 28px rgb(15 18 13 / 0.035);
+  --shadow-card: 0 1px 2px rgb(15 18 13 / 0.035), 0 6px 18px rgb(15 18 13 / 0.025);
   --shadow-float: 0 20px 60px rgb(8 12 7 / 0.16);
 }
 
 .dark {
-  --shadow-card: 0 0 0 1px rgb(255 255 255 / 0.025), 0 14px 36px rgb(0 0 0 / 0.2);
+  --shadow-card: 0 1px 2px rgb(0 0 0 / 0.18), 0 10px 24px rgb(0 0 0 / 0.14);
   --shadow-float: 0 24px 72px rgb(0 0 0 / 0.4);
 }
 
@@ -172,31 +172,6 @@
 /* ─── Utilities ───────────────────────────────────────────────────────────── */
 
 @layer utilities {
-  /* Scrollbar */
-  .scrollbar-thin {
-    scrollbar-width: thin;
-    scrollbar-color: oklch(var(--border)) transparent;
-  }
-
-  .scrollbar-thin::-webkit-scrollbar {
-    width: 5px;
-    height: 5px;
-  }
-
-  .scrollbar-thin::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  .scrollbar-thin::-webkit-scrollbar-thumb {
-    background-color: oklch(var(--border));
-    border-radius: 9999px;
-    transition: background-color 150ms;
-  }
-
-  .scrollbar-thin::-webkit-scrollbar-thumb:hover {
-    background-color: oklch(var(--muted-foreground) / 0.4);
-  }
-
   @media (max-width: 767px) {
     .scroll-fade-x {
       -webkit-mask-image: linear-gradient(to right, #000 0, #000 calc(100% - 32px), transparent 100%);
@@ -266,6 +241,12 @@
     animation: logo-load-pop 1.1s var(--ease-out-expo) infinite;
     transform-origin: center;
   }
+}
+
+.dashboard-shell .animate-fade-in,
+.dashboard-shell .animate-slide-up,
+.dashboard-shell .animate-slide-in {
+  animation: none;
 }
 
 .landing-hero {

--- a/packages/dashboard/src/app/layout.tsx
+++ b/packages/dashboard/src/app/layout.tsx
@@ -37,7 +37,7 @@ export default async function RootLayout({
       <body className={inter.className}>
         <ThemeProvider
           attribute="class"
-          defaultTheme="dark"
+          defaultTheme="light"
           enableSystem
           disableTransitionOnChange
           nonce={nonce}

--- a/packages/dashboard/src/components/board-settings/BoardAdvancedSection.tsx
+++ b/packages/dashboard/src/components/board-settings/BoardAdvancedSection.tsx
@@ -37,7 +37,7 @@ export function BoardAdvancedSection({
 }: BoardAdvancedSectionProps) {
   return (
     <div className="space-y-6">
-      <details className="overflow-hidden rounded-xl border bg-card shadow-[var(--shadow-card)]">
+      <details className="overflow-hidden rounded-lg border bg-card shadow-[var(--shadow-card)]">
         <summary className="cursor-pointer border-b bg-muted/25 px-5 py-4 text-base font-semibold">Custom CSS <span className="text-sm font-normal text-muted-foreground">· optional</span></summary>
         <div className="space-y-3 p-5 sm:p-6">
           <textarea

--- a/packages/dashboard/src/components/board-settings/BoardSettingsTabs.tsx
+++ b/packages/dashboard/src/components/board-settings/BoardSettingsTabs.tsx
@@ -16,6 +16,7 @@ import { BoardIdentitySection } from './BoardIdentitySection'
 import { BoardContentSection } from './BoardContentSection'
 import { BoardVisibilitySection } from './BoardVisibilitySection'
 import { BoardAdvancedSection } from './BoardAdvancedSection'
+import { PageHeader } from '@/components/ui/workspace-shell'
 
 interface BoardSettingsState {
   id?: string
@@ -326,11 +327,12 @@ export function BoardSettingsTabs({ project }: BoardSettingsTabsProps) {
 
   return (
     <div className="space-y-5">
-      <section className="overflow-hidden rounded-xl border bg-card shadow-[var(--shadow-card)]">
-        <div className="p-5 sm:p-6">
-          <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
-            <div className="min-w-0">
-              <div className="flex flex-wrap items-center gap-2">
+      <PageHeader
+        eyebrow={project.name}
+        title="Public feedback page"
+        description="Give users one place to share ideas, vote, and see your replies."
+        meta={
+          <div className="flex flex-wrap items-center gap-2">
                 <Badge variant={canOpenBoard ? 'secondary' : 'outline'}>
                   {canOpenBoard ? 'Live public page' : settings.enabled ? 'Private draft' : 'Not published'}
                 </Badge>
@@ -342,12 +344,10 @@ export function BoardSettingsTabs({ project }: BoardSettingsTabsProps) {
                       : 'Private'}
                 </Badge>
                 {isListed && <Badge variant="outline">Listed in directory</Badge>}
-              </div>
-              <h2 className="mt-3 text-xl font-semibold">Public feedback page</h2>
-              <p className="mt-1 max-w-2xl text-sm leading-6 text-muted-foreground">Give users one place to share ideas, vote, and see your replies.</p>
-            </div>
-
-            <div className="flex flex-wrap gap-2">
+          </div>
+        }
+        action={
+          <div className="flex flex-wrap gap-2">
               {!canOpenBoard && (
                 <Button onClick={() => void handleEnableAndSave()} disabled={saving}>
                   {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Rocket className="mr-2 h-4 w-4" />}
@@ -368,18 +368,17 @@ export function BoardSettingsTabs({ project }: BoardSettingsTabsProps) {
                   Open page
                 </Button>
               )}
-            </div>
           </div>
-        </div>
-          <div className="flex flex-col gap-3 border-t bg-muted/20 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-6">
+        }
+      />
+      <div className="flex flex-col gap-3 rounded-lg border bg-surface-raised/55 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
             <p className="min-w-0 truncate font-mono text-xs text-muted-foreground">{boardUrl}</p>
             <div className="flex flex-wrap gap-x-5 gap-y-2 text-xs text-muted-foreground">
               <span><strong className="font-semibold text-foreground">{stats.followerCount}</strong> followers</span>
               <span><strong className="font-semibold text-foreground">{stats.watchCount}</strong> watched posts</span>
               <span><strong className="font-semibold text-foreground">{stats.openReportCount}</strong> reports to check</span>
             </div>
-          </div>
-      </section>
+      </div>
 
       {/* Tab bar */}
       <div className="flex gap-2 overflow-x-auto rounded-lg border bg-[oklch(var(--surface-raised))] p-1.5 scrollbar-thin">

--- a/packages/dashboard/src/components/code-snippet.tsx
+++ b/packages/dashboard/src/components/code-snippet.tsx
@@ -15,45 +15,54 @@ interface CodeSnippetProps {
   className?: string
   wrap?: boolean
   maxHeightClassName?: string
+  onCopied?: () => void
 }
 
-export function CodeSnippet({ tabs, className, wrap = false, maxHeightClassName }: CodeSnippetProps) {
+export function CodeSnippet({ tabs, className, wrap = false, maxHeightClassName, onCopied }: CodeSnippetProps) {
   const [activeTab, setActiveTab] = React.useState(0)
 
   return (
-    <div className={cn('overflow-hidden rounded-lg border bg-muted', className)}>
-      {tabs.length > 1 && (
-        <div className="flex border-b bg-muted/50">
+    <div className={cn('overflow-hidden rounded-lg border border-zinc-700/80 bg-surface-code text-zinc-100 shadow-sm', className)}>
+      <div className="flex min-h-11 items-center justify-between gap-3 border-b border-zinc-700/80 bg-zinc-900/45 px-2">
+        <div className="flex min-w-0 items-center">
+          {tabs.length > 1 ? (
+            <div className="flex min-w-0">
           {tabs.map((tab, i) => (
             <button
               key={tab.label}
               onClick={() => setActiveTab(i)}
               className={cn(
-                'px-4 py-2 text-sm font-medium transition-colors',
+                    'min-h-10 border-b-2 px-3 text-xs font-medium transition-colors',
                 i === activeTab
-                  ? 'border-b-2 border-primary text-foreground'
-                  : 'text-muted-foreground hover:text-foreground'
+                      ? 'border-primary text-zinc-50'
+                      : 'border-transparent text-zinc-400 hover:text-zinc-100'
               )}
             >
               {tab.label}
             </button>
           ))}
+            </div>
+          ) : (
+            <span className="truncate px-2 font-mono text-[11px] uppercase tracking-[0.12em] text-zinc-400">
+              {tabs[activeTab].label}
+            </span>
+          )}
         </div>
-      )}
-      <div className="relative">
         <CopyButton
           value={tabs[activeTab].code}
-          label="Copy"
+            label="Copy code"
           copiedLabel="Copied"
-          variant="outline"
           size="sm"
-          className="absolute right-2 top-2 z-10 h-8 border-zinc-600 bg-zinc-800 px-2 text-xs text-zinc-100 shadow-md hover:bg-zinc-700 hover:text-zinc-50"
+          onCopied={onCopied}
+            className="h-8 shrink-0 border border-zinc-600 bg-zinc-800 px-2.5 text-xs text-zinc-100 shadow-none hover:bg-zinc-700 hover:text-zinc-50"
         />
+      </div>
+      <div>
         <pre
           tabIndex={0}
           aria-label={`${tabs[activeTab].label} code`}
           className={cn(
-            'p-4 pr-24 text-sm',
+            'p-4 text-[13px] leading-6 text-zinc-100',
             wrap ? 'overflow-x-hidden overflow-y-auto whitespace-pre-wrap break-words' : 'overflow-x-auto',
             maxHeightClassName
           )}

--- a/packages/dashboard/src/components/landing-connections-story.tsx
+++ b/packages/dashboard/src/components/landing-connections-story.tsx
@@ -33,20 +33,20 @@ export function LandingConnectionsStory() {
           </div>
 
           <div className="py-6">
-            <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-zinc-500">Send it where work happens</p>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-zinc-400">Send it where work happens</p>
             <div className="mt-4 divide-y divide-white/[0.08] border-y border-white/10">
               {destinations.map(({ label, detail, Icon, tone }, index) => (
                 <div key={label} className="flex items-center gap-3 py-3.5">
                   <Icon className={`h-4 w-4 shrink-0 ${tone}`} />
                   <span className="text-xs font-semibold">{label}</span>
-                  <span className="ml-auto text-[11px] text-zinc-500">{detail}</span>
+                  <span className="ml-auto text-[11px] text-zinc-400">{detail}</span>
                   {index < 2 && <Check className="h-3.5 w-3.5 text-lime-300" />}
                 </div>
               ))}
             </div>
           </div>
 
-          <p className="text-[11px] leading-5 text-zinc-500">Choose what gets sent. Check delivery history and replay a failed send from the dashboard.</p>
+          <p className="text-[11px] leading-5 text-zinc-400">Choose what gets sent. Check delivery history and replay a failed send from the dashboard.</p>
         </div>
 
         <div className="grid sm:grid-rows-2">
@@ -74,7 +74,7 @@ export function LandingConnectionsStory() {
             </div>
             <div className="mt-5 divide-y divide-white/[0.08] border-y border-white/10">
               <div className="flex items-center gap-3 py-3 text-xs"><span className="font-mono text-lime-300">24</span><span className="font-medium">Add saved report views</span><span className="ml-auto text-[10px] text-sky-300">Planned</span></div>
-              <div className="flex items-center gap-3 py-3 text-xs"><span className="font-mono text-zinc-500">11</span><span className="font-medium">Faster CSV exports</span><span className="ml-auto text-[10px] text-lime-300">Shipped</span></div>
+              <div className="flex items-center gap-3 py-3 text-xs"><span className="font-mono text-zinc-400">11</span><span className="font-medium">Faster CSV exports</span><span className="ml-auto text-[10px] text-lime-300">Shipped</span></div>
             </div>
           </div>
         </div>

--- a/packages/dashboard/src/components/product-updates/ProductUpdatesTab.tsx
+++ b/packages/dashboard/src/components/product-updates/ProductUpdatesTab.tsx
@@ -19,6 +19,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { toast } from "@/hooks/use-toast";
 import { UpdatesOnboarding } from "./UpdatesOnboarding";
+import { PageHeader } from "@/components/ui/workspace-shell";
 
 type Update = {
   id: string;
@@ -529,7 +530,7 @@ export function ProductUpdatesTab({
 
   return (
     <div className="space-y-6">
-      <section className="flex flex-wrap items-start justify-between gap-4 rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
+      <section className="flex flex-wrap items-start justify-between gap-4 rounded-lg border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
         <div className="max-w-2xl">
           <p className="text-xs font-semibold text-primary">
             Update shown to your users
@@ -552,7 +553,7 @@ export function ProductUpdatesTab({
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_360px]">
         <div className="space-y-6">
-          <section className="rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
+          <section className="rounded-lg border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
             <div className="mb-4 flex items-center justify-between">
               <div>
                 <h3 className="font-semibold">
@@ -723,7 +724,7 @@ export function ProductUpdatesTab({
         </div>
 
         <aside className="space-y-6 xl:sticky xl:top-6 xl:self-start">
-          <section className="rounded-xl border bg-card p-5 shadow-[var(--shadow-card)]">
+          <section className="rounded-lg border bg-card p-5 shadow-[var(--shadow-card)]">
             <div className="flex items-center justify-between">
               <h3 className="font-semibold">Preview</h3>
               <div className="flex gap-1">
@@ -773,7 +774,7 @@ export function ProductUpdatesTab({
             </Button>
           </section>
           {selected && (
-            <section className="rounded-xl border bg-card p-5 shadow-[var(--shadow-card)]">
+            <section className="rounded-lg border bg-card p-5 shadow-[var(--shadow-card)]">
               <h3 className="font-semibold">Approximate metrics</h3>
               <p className="mt-1 text-xs text-muted-foreground">
                 Last {entitlements?.analyticsDays || 7} days, aggregate only.
@@ -829,7 +830,7 @@ function UpdatesOverview({
   if (!updates.length) {
     return (
       <div className="mx-auto max-w-3xl space-y-5">
-        <section className="rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
+        <section className="rounded-lg border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
           <p className="text-xs font-semibold text-primary">
             Updates for your users
           </p>
@@ -841,7 +842,7 @@ function UpdatesOverview({
             is already connected, so publishing here requires no code change.
           </p>
         </section>
-        <section className="rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
+        <section className="rounded-lg border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
           <h3 className="text-lg font-semibold">
             Create the first product update
           </h3>
@@ -860,19 +861,12 @@ function UpdatesOverview({
 
   return (
     <div className="space-y-5">
-      <section className="flex flex-wrap items-start justify-between gap-4 rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
-        <div>
-          <p className="text-xs font-semibold text-primary">
-            Inside your product
-          </p>
-          <h2 className="mt-2 text-2xl font-semibold tracking-[-0.035em]">
-            Updates for your users
-          </h2>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Publish clear “What’s new” messages through the connected embed.
-          </p>
-        </div>
-        <div className="flex gap-2">
+      <PageHeader
+        eyebrow="Inside your product"
+        title="Updates for your users"
+        description="Publish concise “What’s new” messages through the connected embed."
+        action={
+          <div className="flex gap-2">
           <Button variant="outline" onClick={onSettings}>
             <Settings2 className="mr-2 h-4 w-4" />
             Settings
@@ -881,9 +875,10 @@ function UpdatesOverview({
             <Plus className="mr-2 h-4 w-4" />
             New product update
           </Button>
-        </div>
-      </section>
-      <div className="divide-y overflow-hidden rounded-xl border bg-card shadow-[var(--shadow-card)]">
+          </div>
+        }
+      />
+      <div className="divide-y overflow-hidden rounded-lg border bg-card shadow-[var(--shadow-card)]">
         {updates.map((update) => (
           <div
             key={update.id}
@@ -965,7 +960,7 @@ function UpdatesSettings({
   const hasCustomDelay = ![0, 3, 5].includes(delaySeconds);
   return (
     <div className="mx-auto max-w-3xl space-y-6">
-      <section className="flex flex-wrap items-start justify-between gap-4 rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
+      <section className="flex flex-wrap items-start justify-between gap-4 rounded-lg border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
         <div>
           <p className="text-xs font-semibold text-primary">
             Updates for your users
@@ -981,7 +976,7 @@ function UpdatesSettings({
           Back to updates
         </Button>
       </section>
-      <div className="space-y-5 rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
+      <div className="space-y-5 rounded-lg border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
         <Check
           label="Show product updates to users"
           value={draft.enabled}

--- a/packages/dashboard/src/components/product-updates/UpdatesOnboarding.tsx
+++ b/packages/dashboard/src/components/product-updates/UpdatesOnboarding.tsx
@@ -160,7 +160,7 @@ export function UpdatesOnboarding({
 
   return (
     <div className="mx-auto max-w-4xl space-y-5">
-      <section className="rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
+      <section className="rounded-lg border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
         <p className="text-xs font-semibold text-primary">
           Updates for your users
         </p>
@@ -174,7 +174,7 @@ export function UpdatesOnboarding({
         </p>
       </section>
 
-      <section className="space-y-5 rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
+      <section className="space-y-5 rounded-lg border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
         <Step title="Choose what the shared embed should do" />
         <div className="grid gap-3 sm:grid-cols-3">
           <ChoiceButton
@@ -206,7 +206,7 @@ export function UpdatesOnboarding({
       </section>
 
       {modules.updates && (
-        <section className="space-y-5 rounded-xl border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
+        <section className="space-y-5 rounded-lg border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
           <Step title="Install the shared embed" />
           <div className="flex flex-wrap gap-2">
             {(["AI assistant", "Script tag", "React", "Vue"] as Method[]).map(

--- a/packages/dashboard/src/components/sidebar.tsx
+++ b/packages/dashboard/src/components/sidebar.tsx
@@ -224,7 +224,7 @@ export function Sidebar({ user, projects, currentProjectId, boardSlugs = {}, bil
   const sidebarContent = (
     <>
       {/* Logo row */}
-      <div className="flex h-14 shrink-0 items-center justify-between border-b px-3">
+      <div className="flex h-14 shrink-0 items-center justify-between border-b border-border/80 px-3">
         <div
           className={cn(
             'overflow-hidden transition-[width,opacity] duration-200',
@@ -263,17 +263,17 @@ export function Sidebar({ user, projects, currentProjectId, boardSlugs = {}, bil
 
       {/* Project switcher */}
       {visibleProjects.length > 0 && !collapsed && (
-        <div data-tour="project-switcher" className="shrink-0 border-b p-2.5" ref={dropdownRef}>
+        <div data-tour="project-switcher" className="shrink-0 border-b border-border/80 p-2.5" ref={dropdownRef}>
           <button
             onClick={() => setProjectOpen(!projectOpen)}
             aria-expanded={projectOpen}
             aria-label="Switch project"
             className={cn(
               'group flex min-h-12 w-full items-center justify-between rounded-lg border px-2.5 py-2 text-left text-[13px]',
-              'border-border/80 bg-surface-raised shadow-sm shadow-black/[0.025]',
-              'transition-[background-color,border-color,box-shadow,transform] duration-150 hover:border-border hover:bg-surface-overlay',
+              'border-border bg-card shadow-sm shadow-black/[0.025]',
+              'transition-[background-color,border-color,box-shadow,transform] duration-150 hover:border-primary/25 hover:bg-surface-overlay',
               'active:scale-[0.99]',
-              projectOpen && 'border-primary/25 bg-surface-overlay shadow-md shadow-black/[0.06]'
+              projectOpen && 'border-primary/35 bg-surface-overlay shadow-md shadow-black/[0.06]'
             )}
           >
             <span className="flex min-w-0 items-center gap-2">
@@ -365,7 +365,7 @@ export function Sidebar({ user, projects, currentProjectId, boardSlugs = {}, bil
       )}
 
       {visibleProjects.length === 0 && !collapsed && (
-        <div className="shrink-0 border-b p-2.5">
+        <div className="shrink-0 border-b border-border/80 p-2.5">
           <Link
             href="/projects/new"
             prefetch={false}
@@ -634,7 +634,7 @@ export function Sidebar({ user, projects, currentProjectId, boardSlugs = {}, bil
       {/* ── Desktop sidebar (static flex child, full height from parent) ─ */}
       <aside
         className={cn(
-          'hidden md:flex md:flex-col md:border-r md:bg-surface-sidebar',
+          'hidden md:flex md:flex-col md:border-r md:border-border/80 md:bg-surface-sidebar',
           'transition-[width] duration-300 [transition-timing-function:cubic-bezier(0.25,1,0.5,1)]',
           collapsed ? 'md:w-[60px]' : 'md:w-[232px]'
         )}

--- a/packages/dashboard/src/components/theme-toggle.tsx
+++ b/packages/dashboard/src/components/theme-toggle.tsx
@@ -78,8 +78,8 @@ export function ThemeToggle({ collapsed = false }: ThemeToggleProps) {
       type="button"
       role="switch"
       aria-checked={isDark}
-      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
-      title={collapsed ? (isDark ? 'Light mode' : 'Dark mode') : undefined}
+      aria-label={isDark ? 'Use light appearance' : 'Use dark appearance'}
+      title={collapsed ? (isDark ? 'Use light appearance' : 'Use dark appearance') : undefined}
       onClick={toggleTheme}
       className={cn(
         'group flex w-full items-center rounded-lg text-[13px] font-medium',
@@ -94,28 +94,10 @@ export function ThemeToggle({ collapsed = false }: ThemeToggleProps) {
         ) : (
           <Sun className="h-[17px] w-[17px] shrink-0" />
         )}
-        {!collapsed && <span>{isDark ? 'Dark mode' : 'Light mode'}</span>}
+        {!collapsed && <span>Appearance</span>}
       </span>
 
-      {!collapsed && (
-        <span
-          aria-hidden="true"
-          className={cn(
-            'relative h-5 w-9 shrink-0 rounded-full border transition-colors duration-200',
-            isDark
-              ? 'border-primary/30 bg-primary/20'
-              : 'border-border bg-muted',
-          )}
-        >
-          <span
-            className={cn(
-              'absolute top-1/2 flex h-4 w-4 -translate-y-1/2 items-center justify-center rounded-full',
-              'bg-background shadow-sm ring-1 ring-border transition-transform duration-200 [transition-timing-function:var(--ease-out-quart)]',
-              isDark ? 'translate-x-[18px]' : 'translate-x-[2px]',
-            )}
-          />
-        </span>
-      )}
+      {!collapsed && <span className="text-[11px] font-medium text-muted-foreground">{isDark ? 'Dark' : 'Light'}</span>}
     </button>
   )
 }

--- a/packages/dashboard/src/components/ui/card.tsx
+++ b/packages/dashboard/src/components/ui/card.tsx
@@ -6,7 +6,7 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
     <div
       ref={ref}
       className={cn(
-        "overflow-hidden rounded-xl border border-border/80 bg-card text-card-foreground shadow-[var(--shadow-card)]",
+        "overflow-hidden rounded-lg border border-border bg-card text-card-foreground shadow-[var(--shadow-card)]",
         className,
       )}
       {...props}
@@ -17,14 +17,14 @@ Card.displayName = "Card"
 
 const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex flex-col space-y-1.5 border-b bg-muted/25 p-5 sm:p-6", className)} {...props} />
+    <div ref={ref} className={cn("flex flex-col space-y-1.5 border-b bg-surface-raised/55 p-5", className)} {...props} />
   )
 )
 CardHeader.displayName = "CardHeader"
 
 const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
   ({ className, ...props }, ref) => (
-    <h3 ref={ref} className={cn("text-2xl font-semibold leading-none tracking-tight", className)} {...props} />
+    <h3 ref={ref} className={cn("text-lg font-semibold leading-tight tracking-[-0.018em]", className)} {...props} />
   )
 )
 CardTitle.displayName = "CardTitle"
@@ -38,14 +38,14 @@ CardDescription.displayName = "CardDescription"
 
 const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("p-5 sm:p-6", className)} {...props} />
+    <div ref={ref} className={cn("p-5", className)} {...props} />
   )
 )
 CardContent.displayName = "CardContent"
 
 const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex items-center border-t bg-muted/15 p-5 sm:p-6", className)} {...props} />
+    <div ref={ref} className={cn("flex items-center border-t bg-surface-raised/35 p-5", className)} {...props} />
   )
 )
 CardFooter.displayName = "CardFooter"

--- a/packages/dashboard/src/components/ui/workspace-section.tsx
+++ b/packages/dashboard/src/components/ui/workspace-section.tsx
@@ -23,14 +23,14 @@ export function WorkspaceSection({
   return (
     <section
       className={cn(
-        'overflow-hidden rounded-xl border bg-card text-card-foreground shadow-[var(--shadow-card)]',
+        'overflow-hidden rounded-lg border bg-card text-card-foreground shadow-[var(--shadow-card)]',
         tone === 'danger' && 'border-destructive/35',
         className,
       )}
     >
       <header
         className={cn(
-          'flex flex-col gap-3 border-b bg-muted/25 px-5 py-4 sm:flex-row sm:items-start sm:justify-between',
+          'flex flex-col gap-3 border-b bg-surface-raised/55 px-5 py-4 sm:flex-row sm:items-start sm:justify-between',
           tone === 'danger' && 'border-destructive/25 bg-destructive/[0.045]',
         )}
       >

--- a/packages/dashboard/src/components/ui/workspace-shell.tsx
+++ b/packages/dashboard/src/components/ui/workspace-shell.tsx
@@ -1,0 +1,144 @@
+import type { ReactNode } from 'react'
+import Link from 'next/link'
+import { Check } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export function PageHeader({
+  eyebrow,
+  title,
+  description,
+  action,
+  meta,
+  className,
+}: {
+  eyebrow?: string
+  title: string
+  description?: string
+  action?: ReactNode
+  meta?: ReactNode
+  className?: string
+}) {
+  return (
+    <header className={cn('flex flex-col gap-4 border-b pb-5 sm:flex-row sm:items-end sm:justify-between', className)}>
+      <div className="min-w-0">
+        {eyebrow && (
+          <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-primary">
+            {eyebrow}
+          </p>
+        )}
+        <h1 className="text-2xl font-semibold tracking-[-0.035em] text-foreground sm:text-[1.75rem]">
+          {title}
+        </h1>
+        {description && (
+          <p className="mt-2 max-w-[68ch] text-sm leading-6 text-muted-foreground">
+            {description}
+          </p>
+        )}
+        {meta && <div className="mt-3">{meta}</div>}
+      </div>
+      {action && <div className="shrink-0">{action}</div>}
+    </header>
+  )
+}
+
+export function SectionPanel({
+  title,
+  description,
+  action,
+  children,
+  className,
+  contentClassName,
+  dataTour,
+}: {
+  title?: string
+  description?: string
+  action?: ReactNode
+  children: ReactNode
+  className?: string
+  contentClassName?: string
+  dataTour?: string
+}) {
+  return (
+    <section data-tour={dataTour} className={cn('overflow-hidden rounded-lg border bg-card shadow-[var(--shadow-card)]', className)}>
+      {(title || description || action) && (
+        <header className="flex flex-col gap-3 border-b bg-surface-raised/55 px-5 py-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0">
+            {title && <h2 className="text-sm font-semibold text-foreground">{title}</h2>}
+            {description && <p className="mt-1 max-w-[68ch] text-sm leading-5 text-muted-foreground">{description}</p>}
+          </div>
+          {action && <div className="shrink-0">{action}</div>}
+        </header>
+      )}
+      <div className={cn('p-5', contentClassName)}>{children}</div>
+    </section>
+  )
+}
+
+export function StatusDot({
+  tone = 'neutral',
+  className,
+}: {
+  tone?: 'neutral' | 'success' | 'warning' | 'danger' | 'info'
+  className?: string
+}) {
+  const tones = {
+    neutral: 'bg-muted-foreground/55',
+    success: 'bg-emerald-500',
+    warning: 'bg-amber-500',
+    danger: 'bg-destructive',
+    info: 'bg-sky-500',
+  }
+
+  return <span aria-hidden="true" className={cn('h-1.5 w-1.5 shrink-0 rounded-full', tones[tone], className)} />
+}
+
+export function CompactSteps({
+  steps,
+  activeIndex,
+  className,
+}: {
+  steps: Array<{ label: string; href?: string }>
+  activeIndex: number
+  className?: string
+}) {
+  return (
+    <ol className={cn('flex min-w-0 items-center gap-1 text-xs', className)} aria-label="Setup progress">
+      {steps.map((step, index) => {
+        const complete = index < activeIndex
+        const current = index === activeIndex
+        const content = (
+          <>
+            <span
+              className={cn(
+                'flex h-5 w-5 shrink-0 items-center justify-center rounded-full border text-[10px] font-semibold',
+                complete && 'border-primary bg-primary text-primary-foreground',
+                current && 'border-primary bg-primary/10 text-primary',
+                !complete && !current && 'border-border bg-surface-raised text-muted-foreground',
+              )}
+            >
+              {complete ? <Check className="h-3 w-3" /> : index + 1}
+            </span>
+            <span className={cn('truncate font-medium', current ? 'text-foreground' : 'text-muted-foreground')}>
+              {step.label}
+            </span>
+          </>
+        )
+
+        return (
+          <li key={step.label} className="flex min-w-0 items-center gap-1">
+            {index > 0 && <span aria-hidden="true" className="mx-1 h-px w-4 bg-border sm:w-8" />}
+            {step.href ? (
+              <Link href={step.href} aria-current={current ? 'step' : undefined} className="flex min-w-0 items-center gap-1.5">
+                {content}
+              </Link>
+            ) : (
+              <span aria-current={current ? 'step' : undefined} className="flex min-w-0 items-center gap-1.5">
+                {content}
+              </span>
+            )}
+          </li>
+        )
+      })}
+    </ol>
+  )
+}

--- a/packages/dashboard/tailwind.config.cjs
+++ b/packages/dashboard/tailwind.config.cjs
@@ -24,6 +24,7 @@ module.exports = {
           raised: 'oklch(var(--surface-raised) / <alpha-value>)',
           overlay: 'oklch(var(--surface-overlay) / <alpha-value>)',
           selected: 'oklch(var(--surface-selected) / <alpha-value>)',
+          code: 'oklch(var(--surface-code) / <alpha-value>)',
         },
         primary: {
           DEFAULT: 'oklch(var(--primary) / <alpha-value>)',

--- a/packages/dashboard/tests/e2e/customize.spec.ts
+++ b/packages/dashboard/tests/e2e/customize.spec.ts
@@ -14,7 +14,7 @@ test('publishes saved feedback-form changes remotely without changing install co
   await expect(page.locator('[data-project-tabs-ready="true"]')).toBeVisible()
 
   await expect(
-    page.getByText(/saved version is delivered remotely/i),
+    page.getByText(/without replacing the installed snippet/i),
   ).toBeVisible()
   await expect(page.getByRole('heading', { name: 'Live form preview' })).toBeVisible()
   await expect(page.getByText(/Placement, color, copy, and optional fields update/i)).toBeVisible()
@@ -25,9 +25,9 @@ test('publishes saved feedback-form changes remotely without changing install co
   await page.getByLabel('Button text').fill('Ideas')
   await expect(page.getByLabel('Button text')).toHaveValue('Ideas')
   await expect(
-    page.getByText(/Save to publish these changes/i),
+    page.getByText(/Preview the draft, then save once/i),
   ).toBeVisible()
-  await expect(page.getByText(/Draft changes: Button text/i)).toBeVisible()
+  await expect(page.getByText(/Unsaved changes: Button text/i)).toBeVisible()
   await expect(page.getByText(/Previewing unsaved changes/i)).toBeVisible()
   await expect(page.getByText(/Publish remote changes/i)).toBeVisible()
   await expect
@@ -44,7 +44,7 @@ test('publishes saved feedback-form changes remotely without changing install co
   await expect(page.locator('[data-project-tabs-ready="true"]')).toBeVisible()
   await expect(page.getByLabel('Button text')).toHaveValue('Ideas')
   await expect(
-    page.getByText(/Save to publish these changes/i),
+    page.getByText(/Preview the draft, then save once/i),
   ).toBeVisible()
   await expect(page.getByText(/Previewing unsaved changes/i)).toBeVisible()
 
@@ -56,7 +56,7 @@ test('publishes saved feedback-form changes remotely without changing install co
   await page.getByRole('button', { name: 'Save changes' }).first().click()
   await saveResponse
   await expect(
-    page.getByText(/saved version is delivered remotely/i),
+    page.getByText(/without replacing the installed snippet/i),
   ).toBeVisible()
 
   const bootstrapResponse = await page.request.get(`/api/widget/bootstrap?projectKey=${encodeURIComponent(project.apiKey)}&runtimeVersion=e2e`)

--- a/packages/dashboard/tests/e2e/install.spec.ts
+++ b/packages/dashboard/tests/e2e/install.spec.ts
@@ -10,20 +10,21 @@ test('creates a project and lands on a stable one-time embed installation', asyn
 
   await page.goto('/projects/new')
   await page.getByLabel('App or website name').fill(`Playwright Install ${Date.now().toString(36)}`)
-  await page.getByRole('button', { name: 'Create project and make the form' }).click()
+  await page.getByRole('button', { name: 'Create project and get the snippet' }).click()
 
   await expect(page).toHaveURL(/\/projects\/[^/]+\/install\?created=1/, { timeout: 30_000 })
   await expect(page.getByRole('navigation', { name: 'Setup steps' })).toBeVisible()
-  await expect(page.getByRole('heading', { name: 'Install once. Keep the code unchanged.' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Install feedback' })).toBeVisible()
   await expect(page.getByRole('button', { name: 'Copy code' })).toBeVisible()
-  await expect(page.getByText('Choose platform')).toBeVisible()
-  await expect(page.getByText('Verify one message')).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Choose your stack' })).toBeVisible()
+  await expect(page.getByText('Step 1 of 3')).toBeVisible()
+  await page.getByText('Other', { exact: true }).click()
   await expect(page.getByRole('button', { name: 'WordPress' })).toBeVisible()
   await page.getByRole('button', { name: 'HTML block' }).click()
   await expect(page.getByText(/Prefer global custom code/i)).toBeVisible()
 
   await page.goto(page.url().replace(/\/install(?:\?.*)?$/, '/feedback-form'))
-  await expect(page.getByRole('heading', { name: 'Make the feedback form feel native' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Feedback form' })).toBeVisible()
   await expect(page.getByRole('heading', { name: 'Live form preview' })).toBeVisible()
 })
 
@@ -33,15 +34,16 @@ test('copy-paste install guidance stays visible for an existing project', async 
 
   await page.goto(projectInstallPath(project.id), { waitUntil: 'domcontentloaded' })
 
-  await expect(page.getByRole('heading', { name: 'Install once. Keep the code unchanged.' })).toBeVisible()
-  await expect(page.getByRole('heading', { name: 'Choose where you are installing' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Install feedback' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Choose your stack' })).toBeVisible()
   await expect(
     page.getByText(/Paste before the closing body tag/i),
   ).toBeVisible({ timeout: 30_000 })
   await expect(
     page.getByTestId('install-verify-instruction'),
   ).toBeVisible({ timeout: 30_000 })
-  await expect(page.getByRole('link', { name: 'Open verification' })).toBeVisible()
+  await expect(page.getByRole('link', { name: /verification/i })).toBeVisible()
+  await page.getByText('Other', { exact: true }).click()
   await page.getByRole('button', { name: 'Mobile app' }).click()
   await expect(page.getByText(/browser script does not run inside native/i)).toBeVisible()
   await expect(page.getByRole('link', { name: 'Open API docs' })).toBeVisible()

--- a/packages/dashboard/tests/e2e/verify.spec.ts
+++ b/packages/dashboard/tests/e2e/verify.spec.ts
@@ -13,7 +13,7 @@ test('renders the live widget and accepts a test submission', async ({ page }) =
   const widgetRuntimeResponse = await page.request.fetch('/widget/latest.js')
 
   await expect(page.getByRole('navigation', { name: 'Setup steps' })).toBeVisible()
-  await expect(page.getByRole('heading', { name: 'Send one test. Know the connection works.' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Verify one test' })).toBeVisible()
   await expect(page.getByRole('heading', { name: 'Three quick checks' })).toBeVisible()
   await expect(page.getByRole('heading', { name: 'Send one test message.' })).toBeVisible()
   expect(widgetRuntimeResponse.ok()).toBeTruthy()

--- a/packages/dashboard/tests/unit/product-experience.test.ts
+++ b/packages/dashboard/tests/unit/product-experience.test.ts
@@ -54,9 +54,9 @@ test('first-run and public feedback screens keep optional work out of the main p
   const publicForm = read('../../src/components/boards/BoardSubmitForm.tsx')
 
   assert.match(newProject, /Name your app or website/)
-  assert.match(newProject, /Start with something else/)
+  assert.match(newProject, /Choose a different first goal/)
   assert.doesNotMatch(newProject, /What happens next/)
-  assert.match(inbox, /Read new messages\. Decide what to do next\./)
+  assert.match(inbox, /Review new messages and move the useful signal forward\./)
   assert.match(inbox, /showMoreFilters/)
   assert.match(publicForm, /What do you need\?/)
   assert.match(publicForm, /className="sr-only"/)
@@ -80,7 +80,7 @@ test('navigation gives product updates user context instead of an ambiguous rele
   const updatesOnboarding = read('../../src/components/product-updates/UpdatesOnboarding.tsx')
 
   assert.match(sidebar, /Updates for users/)
-  assert.match(projectHome, /Show product updates to users/)
+  assert.match(projectHome, /Product updates/)
   assert.match(updatesOnboarding, /useState<Choice>\(["']updates["']\)/)
   assert.doesNotMatch(updatesOnboarding, /localStorage/)
   assert.doesNotMatch(sidebar, /label: 'Release notes'/)
@@ -92,11 +92,11 @@ test('dense dashboard forms use clear tonal sections instead of one flat canvas'
   const boardVisibility = read('../../src/components/board-settings/BoardVisibilitySection.tsx')
   const inbox = read('../../src/app/(dashboard)/feedback/page.tsx')
 
-  assert.match(section, /rounded-xl border bg-card/)
-  assert.match(section, /border-b bg-muted\/25/)
+  assert.match(section, /rounded-lg border bg-card/)
+  assert.match(section, /border-b bg-surface-raised\/55/)
   assert.match(boardIdentity, /WorkspaceSection/)
   assert.match(boardVisibility, /WorkspaceSection/)
-  assert.match(inbox, /rounded-xl border bg-card/)
+  assert.match(inbox, /rounded-lg border bg-card/)
 })
 
 test('sidebar exposes a stable Home destination and groups project work by user intent', () => {
@@ -126,10 +126,10 @@ test('theme tokens use perceptual OKLCH colors in both themes', () => {
   const css = read('../../src/app/globals.css')
   const tailwind = read('../../tailwind.config.cjs')
 
-  assert.match(css, /--background: 0\.985/)
-  assert.match(css, /\.dark[\s\S]*--background: 0\.135/)
-  assert.match(css, /\.dark[\s\S]*--surface-raised: 0\.225/)
-  assert.match(css, /\.dark[\s\S]*--card: 0\.195/)
+  assert.match(css, /--background: 0\.968/)
+  assert.match(css, /\.dark[\s\S]*--background: 0\.115/)
+  assert.match(css, /\.dark[\s\S]*--surface-raised: 0\.235/)
+  assert.match(css, /\.dark[\s\S]*--card: 0\.185/)
   assert.match(css, /\[class~="shadow-\[var\(--shadow-card\)\]"\]/)
   assert.match(css, /--surface-sidebar:/)
   assert.match(css, /--surface-selected:/)
@@ -138,22 +138,24 @@ test('theme tokens use perceptual OKLCH colors in both themes', () => {
   assert.doesNotMatch(tailwind, /hsl\(var\(--primary\)/)
 })
 
-test('authenticated workspaces use elevated cards instead of flat divider-only canvases', () => {
+test('authenticated workspaces use page headers, section panels, and progressive disclosure', () => {
   const card = read('../../src/components/ui/card.tsx')
   const install = read('../../src/app/(dashboard)/projects/[id]/install-tab.tsx')
   const projectHome = read('../../src/app/(dashboard)/projects/[id]/project-home.tsx')
   const customize = read('../../src/app/(dashboard)/projects/[id]/customize-tab.tsx')
   const verify = read('../../src/app/(dashboard)/projects/[id]/project-verify-client.tsx')
 
-  assert.match(card, /rounded-xl border border-border\/80 bg-card/)
-  assert.match(card, /border-b bg-muted\/25/)
+  assert.match(card, /rounded-lg border border-border bg-card/)
+  assert.match(card, /border-b bg-surface-raised\/55/)
   assert.match(card, /shadow-\[var\(--shadow-card\)\]/)
-  assert.match(install, /<Card data-tour="install-snippet">/)
+  assert.match(install, /title="Choose your stack"/)
+  assert.match(install, /dataTour="install-snippet"/)
   assert.match(install, /surface-raised/)
-  assert.doesNotMatch(install, /grid gap-8 border-b/)
-  assert.match(projectHome, /<Card>/)
-  assert.match(customize, /rounded-xl border bg-card/)
-  assert.match(verify, /rounded-xl border bg-card/)
+  assert.match(install, /Connection details/)
+  assert.match(projectHome, /<PageHeader/)
+  assert.match(projectHome, /<SectionPanel/)
+  assert.match(customize, /Optional fields and protection/)
+  assert.match(verify, /<PageHeader/)
 })
 
 test('public docs use the stable canonical embed and remote customization language', () => {


### PR DESCRIPTION
## What changed

- rebuilt the first-run project, install, verify, and inbox journey around one clear next action
- introduced a light-first workspace hierarchy with materially distinct dark-mode surfaces
- reduced repeated cards, pills, duplicate guidance, and advanced setup noise across the dashboard
- applied shared page headers, section panels, compact progress, loading, empty, and destructive-state patterns
- redesigned home, inbox, feedback detail, customization, integrations, API, boards, updates, projects, settings, and billing
- fixed stale project navigation after creation
- added the completed UX audit and implementation contract

## Why

The previous dashboard gave setup instructions, platform options, technical details, and repeated progress explanations equal visual weight. This made the first successful feedback submission harder than it needed to be and made ongoing dashboard pages feel dense and intimidating.

## User impact

New users now reach a copyable recommended snippet above the fold, verify one test, and reach the inbox without reading advanced material. Returning users get a calmer, more consistent information hierarchy throughout the product.

## Validation

- TypeScript passed
- ESLint passed
- 111 unit tests passed
- selected authenticated browser journeys passed
- accessibility and mobile overflow checks passed
- light and dark visual smoke checks passed
- production build passed
- staged diff whitespace check passed