### PR TITLE
Add growth SEO foundation

### DIFF
--- a/packages/dashboard/src/app/layout.tsx
+++ b/packages/dashboard/src/app/layout.tsx
@@ -9,11 +9,24 @@ import { Toaster } from '@/components/toaster'
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
+  metadataBase: new URL('https://feedbacks.dev'),
   title: {
     default: 'feedbacks.dev | Feedback forms and product updates',
     template: '%s | feedbacks.dev',
   },
   description: 'Collect in-product feedback and show product updates to users with one lightweight embed. Install once, verify, and manage remotely.',
+  applicationName: 'feedbacks.dev',
+  keywords: [
+    'user feedback widget',
+    'in-app feedback',
+    'product feedback',
+    'feature request board',
+    'product updates',
+    'feedback API',
+  ],
+  authors: [{ name: 'feedbacks.dev', url: 'https://feedbacks.dev' }],
+  creator: 'feedbacks.dev',
+  publisher: 'feedbacks.dev',
   icons: {
     icon: [
       { url: '/new_logo_feedbacks.dev.svg', type: 'image/svg+xml' },

--- a/packages/dashboard/src/app/opengraph-image.tsx
+++ b/packages/dashboard/src/app/opengraph-image.tsx
@@ -1,0 +1,78 @@
+import { ImageResponse } from 'next/og'
+
+export const alt = 'feedbacks.dev — collect feedback and show users what shipped'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default function OpenGraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          alignItems: 'center',
+          background: '#f5f7f0',
+          color: '#171914',
+          display: 'flex',
+          height: '100%',
+          justifyContent: 'center',
+          padding: '68px',
+          width: '100%',
+        }}
+      >
+        <div
+          style={{
+            background: '#ffffff',
+            border: '2px solid #d9ded0',
+            borderRadius: '28px',
+            boxShadow: '0 32px 90px rgba(24, 28, 20, 0.12)',
+            display: 'flex',
+            flexDirection: 'column',
+            height: '100%',
+            justifyContent: 'space-between',
+            padding: '58px 64px',
+            width: '100%',
+          }}
+        >
+          <div style={{ alignItems: 'center', display: 'flex', fontSize: 32, fontWeight: 700 }}>
+            <div
+              style={{
+                alignItems: 'center',
+                background: '#171914',
+                borderRadius: '10px',
+                color: '#9bd60b',
+                display: 'flex',
+                height: 42,
+                justifyContent: 'center',
+                marginRight: 16,
+                width: 42,
+              }}
+            >
+              f
+            </div>
+            feedbacks<span style={{ color: '#70a000' }}>.dev</span>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <div style={{ color: '#70a000', display: 'flex', fontSize: 22, fontWeight: 700, letterSpacing: 2 }}>
+              FEEDBACK AND UPDATES INSIDE YOUR APP
+            </div>
+            <div style={{ display: 'flex', fontSize: 68, fontWeight: 750, letterSpacing: -3, lineHeight: 1.05, marginTop: 20 }}>
+              Find what users need.
+            </div>
+            <div style={{ display: 'flex', fontSize: 68, fontWeight: 750, letterSpacing: -3, lineHeight: 1.05 }}>
+              Show what you fixed.
+            </div>
+            <div style={{ color: '#606659', display: 'flex', fontSize: 27, lineHeight: 1.4, marginTop: 26 }}>
+              One lightweight embed. A useful inbox. Product updates users can see.
+            </div>
+          </div>
+
+          <div style={{ color: '#606659', display: 'flex', fontSize: 22 }}>
+            Install in minutes · Start free · Manage remotely
+          </div>
+        </div>
+      </div>
+    ),
+    size,
+  )
+}

--- a/packages/dashboard/src/app/page.tsx
+++ b/packages/dashboard/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import type { Metadata } from 'next'
 import { Button } from '@/components/ui/button'
 import { BrandWordmark } from '@/components/brand-wordmark'
 import { PLAN_MATRIX, generateInstallSnippets } from '@feedbacks/shared'
@@ -32,9 +33,63 @@ const installSnippet = generateInstallSnippets({
 const freePlan = PLAN_MATRIX.free
 const proPlan = PLAN_MATRIX.pro
 
+export const metadata: Metadata = {
+  alternates: { canonical: '/' },
+  openGraph: {
+    type: 'website',
+    url: 'https://feedbacks.dev',
+    siteName: 'feedbacks.dev',
+    title: 'feedbacks.dev | Feedback forms and product updates',
+    description: 'Collect useful in-product feedback, triage it quickly, and show users what shipped with one lightweight embed.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'feedbacks.dev | Feedback forms and product updates',
+    description: 'Collect useful in-product feedback, triage it quickly, and show users what shipped with one lightweight embed.',
+  },
+}
+
+const softwareApplicationJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'feedbacks.dev',
+  applicationCategory: 'DeveloperApplication',
+  operatingSystem: 'Web',
+  url: 'https://feedbacks.dev',
+  description: 'Collect in-product feedback and publish product updates with one lightweight embed.',
+  offers: [
+    {
+      '@type': 'Offer',
+      name: 'Free',
+      price: freePlan.monthlyPrice,
+      priceCurrency: 'USD',
+    },
+    {
+      '@type': 'Offer',
+      name: 'Pro',
+      price: proPlan.monthlyPrice,
+      priceCurrency: 'USD',
+    },
+  ],
+  featureList: [
+    'In-product feedback form',
+    'Feedback inbox and triage',
+    'Product updates',
+    'Public feedback boards',
+    'Slack, Discord, GitHub, and webhook integrations',
+    'REST API and MCP server',
+  ],
+}
+
 export default function LandingPage() {
   return (
     <div className="min-h-screen bg-background text-foreground">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(softwareApplicationJsonLd).replace(/</g, '\\u003c'),
+        }}
+      />
       <AuthenticatedRedirect appOrigin={appOrigin} />
       <LandingScrollHeader>
         <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-5 sm:px-6">

--- a/packages/dashboard/src/app/robots.ts
+++ b/packages/dashboard/src/app/robots.ts
@@ -1,0 +1,24 @@
+import type { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/docs/', '/boards', '/p/'],
+      disallow: [
+        '/api/',
+        '/auth',
+        '/billing',
+        '/dashboard',
+        '/feedback',
+        '/integrations',
+        '/projects',
+        '/settings',
+        '/tutorials',
+        '/updates',
+      ],
+    },
+    sitemap: 'https://feedbacks.dev/sitemap.xml',
+    host: 'https://feedbacks.dev',
+  }
+}

--- a/packages/dashboard/src/app/sitemap.ts
+++ b/packages/dashboard/src/app/sitemap.ts
@@ -1,0 +1,36 @@
+import type { MetadataRoute } from 'next'
+import { DOCS_PAGES } from '@/lib/docs-content'
+
+const ORIGIN = 'https://feedbacks.dev'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const docs = DOCS_PAGES.map((page) => ({
+    url: page.slug === 'overview' ? `${ORIGIN}/docs` : `${ORIGIN}/docs/${page.slug}`,
+    changeFrequency: 'monthly' as const,
+    priority: page.slug === 'quickstart' ? 0.85 : 0.7,
+  }))
+
+  return [
+    {
+      url: ORIGIN,
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${ORIGIN}/boards`,
+      changeFrequency: 'daily',
+      priority: 0.75,
+    },
+    ...docs,
+    {
+      url: `${ORIGIN}/privacy`,
+      changeFrequency: 'yearly',
+      priority: 0.2,
+    },
+    {
+      url: `${ORIGIN}/terms`,
+      changeFrequency: 'yearly',
+      priority: 0.2,
+    },
+  ]
+}

--- a/packages/dashboard/tests/unit/product-experience.test.ts
+++ b/packages/dashboard/tests/unit/product-experience.test.ts
@@ -48,6 +48,26 @@ test('landing page explains both sides of the feedback loop and keeps the instal
   assert.doesNotMatch(source, /userbase|Collecting user feedbacks/)
 })
 
+test('marketing routes expose a crawlable acquisition foundation without indexing private workspaces', () => {
+  const layout = read('../../src/app/layout.tsx')
+  const landing = read('../../src/app/page.tsx')
+  const robots = read('../../src/app/robots.ts')
+  const sitemap = read('../../src/app/sitemap.ts')
+  const openGraph = read('../../src/app/opengraph-image.tsx')
+
+  assert.match(layout, /metadataBase: new URL\('https:\/\/feedbacks\.dev'\)/)
+  assert.match(landing, /SoftwareApplication/)
+  assert.match(landing, /summary_large_image/)
+  assert.match(landing, /alternates: \{ canonical: '\/' \}/)
+  assert.match(robots, /sitemap: 'https:\/\/feedbacks\.dev\/sitemap\.xml'/)
+  assert.match(robots, /'\/dashboard'/)
+  assert.match(robots, /'\/api\/'/)
+  assert.match(sitemap, /DOCS_PAGES/)
+  assert.match(sitemap, /`\$\{ORIGIN\}\/boards`/)
+  assert.match(openGraph, /ImageResponse/)
+  assert.match(openGraph, /Find what users need\./)
+})
+
 test('first-run and public feedback screens keep optional work out of the main path', () => {
   const newProject = read('../../src/app/(dashboard)/projects/new/page.tsx')
   const inbox = read('../../src/app/(dashboard)/feedback/page.tsx')


### PR DESCRIPTION
## What changed

- added canonical landing metadata, product keywords, Open Graph, and Twitter card metadata
- added a generated 1200×630 social preview image
- added `robots.txt` that exposes public acquisition surfaces while excluding private workspace and API routes
- added a sitemap covering the marketing page, public-board directory, legal pages, and every documentation route
- added SoftwareApplication structured data with Free and Pro offers and the product capability set

## Why

The activation report shows only one real project created in the last seven days. The production site had no sitemap, robots policy, canonical metadata, social card, or software structured data, making discoverability the highest-leverage code-owned growth gap after the onboarding redesign.

## Validation

- TypeScript passed
- ESLint passed
- 112 unit tests passed
- Next.js production build passed
- `/robots.txt`, `/sitemap.xml`, and `/opengraph-image` generated as static routes
- diff whitespace check passed