### PR TITLE
Repair redesigned journey E2E coverage

### DIFF
--- a/packages/dashboard/tests/e2e/api-docs.spec.ts
+++ b/packages/dashboard/tests/e2e/api-docs.spec.ts
@@ -9,10 +9,11 @@ test('API docs are visible on Free and start with quick submit guidance', async 
   await signInWithTestSession(page)
   const project = await createProjectViaApi(page, { name: `Playwright API ${Date.now().toString(36)}` })
 
-  await page.goto(`/projects/${project.id}?tab=api`, { waitUntil: 'domcontentloaded' })
+  await page.goto(`/projects/${project.id}/api`, { waitUntil: 'domcontentloaded' })
   await expect(page.locator('[data-project-tabs-ready="true"]')).toBeVisible()
+  await expect(page).toHaveURL(`/projects/${project.id}/api`)
 
-  await expect(page.getByText('Available on Free')).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'API and MCP' })).toBeVisible()
   await expect(page.getByRole('heading', { name: 'Connection details' })).toBeVisible()
   await expect(page.getByRole('heading', { name: 'Quick start: submit feedback' })).toBeVisible()
   await expect(page.getByText(/Do not expose this key in public browser code/i)).toBeVisible()

--- a/packages/dashboard/tests/e2e/product-updates.spec.ts
+++ b/packages/dashboard/tests/e2e/product-updates.spec.ts
@@ -32,7 +32,7 @@ test('new Updates-only user verifies the embed, tests a draft, and publishes', a
 
   await page.goto('/projects/new?goal=updates')
   await page.getByLabel('App or website name').fill(`Playwright Updates ${Date.now().toString(36)}`)
-  await page.getByRole('button', { name: 'Create project and write a user message' }).click()
+  await page.getByRole('button', { name: 'Create project and write an update' }).click()
   await expect(page).toHaveURL(/\/projects\/([^/]+)\/release-notes$/, { timeout: 30_000 })
 
   const projectId = page.url().match(/\/projects\/([^/]+)\/release-notes$/)?.[1]

--- a/packages/dashboard/tests/e2e/webhooks.spec.ts
+++ b/packages/dashboard/tests/e2e/webhooks.spec.ts
@@ -188,6 +188,8 @@ test('integrations UI shows saved endpoints', async ({ page }) => {
 
   // The slack section should show the saved endpoint with a "Send test" button
   const slackSection = page.locator('[data-webhook-kind="slack"]')
+  await expect(slackSection.getByText('1 configured')).toBeVisible()
+  await slackSection.locator('summary').click()
   await expect(slackSection.getByRole('button', { name: 'Send test' })).toBeVisible()
 })
 

--- a/packages/dashboard/tests/e2e/webhooks.spec.ts
+++ b/packages/dashboard/tests/e2e/webhooks.spec.ts
@@ -180,10 +180,11 @@ test('integrations UI shows saved endpoints', async ({ page }) => {
     },
   })
 
-  // Navigate to integrations tab and verify UI shows the endpoint
-  await page.goto(`/projects/${project.id}?tab=integrations`)
+  // Navigate to the stable integrations route and verify UI shows the endpoint
+  await page.goto(`/projects/${project.id}/integrations`)
   await expect(page.locator('[data-project-tabs-ready="true"]')).toBeVisible()
-  await expect(page.getByRole('heading', { name: 'Route important feedback where your team already works' })).toBeVisible()
+  await expect(page).toHaveURL(`/projects/${project.id}/integrations`)
+  await expect(page.getByRole('heading', { name: 'Integrations' })).toBeVisible()
 
   // The slack section should show the saved endpoint with a "Send test" button
   const slackSection = page.locator('[data-webhook-kind="slack"]')
@@ -202,9 +203,10 @@ test('free plan can use one active integration endpoint', async ({ page }) => {
     await setBillingPlan(userId, 'free')
     const deliveriesPath = `/api/projects/${project.id}/webhooks/deliveries`
 
-    await page.goto(`/projects/${project.id}?tab=integrations`)
+    await page.goto(`/projects/${project.id}/integrations`)
     await expect(page.locator('[data-project-tabs-ready="true"]')).toBeVisible()
-    await expect(page.getByRole('heading', { name: 'Route important feedback where your team already works' })).toBeVisible()
+    await expect(page).toHaveURL(`/projects/${project.id}/integrations`)
+    await expect(page.getByRole('heading', { name: 'Integrations' })).toBeVisible()
     await expect(page.getByText(/0 of 1 active endpoint used on Free/i)).toBeVisible()
     await expect(page.locator('[data-webhook-kind="slack"]')).toBeVisible()
     await page.locator('[data-webhook-kind="slack"]').getByRole('button', { name: 'Add endpoint' }).click()


### PR DESCRIPTION
## Why
The dashboard redesign moved API and integrations to stable routes and clarified first-run copy. Four end-to-end assertions still targeted the retired query-tab URLs or old labels, causing the long post-merge Playwright gate to fail even though the redesigned screens loaded.

## What changed
- exercise /projects/:id/api and /projects/:id/integrations directly
- assert the current API and MCP and Integrations page headings
- use the current Updates-first project creation action
- keep the substantive API, webhook, Free-plan, draft-test, and publish assertions intact

## Validation
- dashboard type-check
- dashboard lint
- 112 unit tests
- local required E2E is unavailable because E2E_AUTH_BYPASS_SECRET is CI-only; the PR's configured GitHub E2E job is the acceptance gate