### PR TITLE
Add comprehensive Windows 98 appearance

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -24,13 +24,22 @@ A developer is adding feedback collection during a normal build session, switchi
 
 ## Visual System
 
-- Theme: light-first by default. Both themes use visibly distinct canvas, sidebar, panel, raised, selected, popover, and code roles.
+- Theme: light-first by default. Light, dark, and the optional Windows 98 appearance use visibly distinct canvas, sidebar, panel, raised, selected, popover, and code roles.
 - Dark hierarchy: keep the canvas, sidebar, inset rails, and code areas deep. Use lighter cards for primary work, a soft neutral for supporting rows and footers, and the brightest neutral only for headers, menus, and overlays. Do not alternate shades decoratively; assign them by function.
 - Typography: system sans or the existing app font stack. Fixed sizes, no viewport-scaled product text.
 - Accent: controlled green/primary accent for primary actions, active state, success, and focus. Do not use accent as decoration.
 - Structure: crisp 1px borders, neutral panels, compact spacing, and clear section separation. Prefer page headers, rows, tables, and disclosures over card stacks.
 - Radius: keep panels and controls modest. Avoid oversized rounded containers and repeated pill shapes.
 - Icons: use the existing icon system for actions and status. Prefer icon plus label for unfamiliar actions.
+
+## Windows 98 Appearance
+
+- Windows 98 is an optional product appearance, never the default.
+- Base the palette on Windows Classic system roles: teal desktop, button-face gray, near-white window fields, navy active captions, and separate highlight, light, shadow, and dark-shadow edges.
+- Raised controls use highlight/light on the top and left with shadow/dark-shadow on the bottom and right. Pressed controls and fields reverse that edge order.
+- Apply the appearance across marketing, authentication, dashboard, documentation, legal pages, public directories, public boards, overlays, loading states, tables, code panes, and responsive navigation.
+- Preserve native product semantics, keyboard focus, reduced-motion behavior, and mobile usability. Nostalgia must not hide actions or reduce legibility.
+- Keep customer widget previews and the installed widget isolated from the app appearance. Their project-controlled styles remain authoritative.
 
 ## Component Rules
 

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/widget-form-preview.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/widget-form-preview.tsx
@@ -135,7 +135,7 @@ export function WidgetFormPreview({ config, className }: WidgetFormPreviewProps)
   )
 
   return (
-    <div className={cn('rounded-lg border bg-zinc-50 p-4', className)}>
+    <div className={cn('widget-theme-preview rounded-lg border bg-zinc-50 p-4', className)}>
       {mode === 'inline' ? (
         <PreviewForm config={config} />
       ) : (

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/widget-preview-surface.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/widget-preview-surface.tsx
@@ -220,7 +220,7 @@ export function WidgetPreviewSurface({
     <div
       ref={hostRef}
       className={cn(
-        'relative min-h-[280px] rounded-lg border bg-background p-6',
+        'widget-theme-preview relative min-h-[280px] rounded-lg border bg-background p-6',
         className,
       )}
     />

--- a/packages/dashboard/src/app/(dashboard)/settings/page.tsx
+++ b/packages/dashboard/src/app/(dashboard)/settings/page.tsx
@@ -310,17 +310,24 @@ export default function SettingsPage() {
         <section className="grid gap-6 p-5 sm:p-6 md:grid-cols-[150px_minmax(0,1fr)]">
           <div>
             <h2 className="font-semibold">Appearance</h2>
-            <p className="mt-1 text-sm text-muted-foreground">Use light, dark, or your system preference.</p>
+            <p className="mt-1 text-sm text-muted-foreground">Choose the calm light UI, focused dark UI, Windows 98, or your device preference.</p>
           </div>
-          <div className="flex gap-2">
-            {(['light', 'dark', 'system'] as const).map((t) => (
+          <div className="flex flex-wrap gap-2" role="radiogroup" aria-label="Appearance">
+            {([
+              ['light', 'Light'],
+              ['dark', 'Dark'],
+              ['windows98', 'Windows 98'],
+              ['system', 'Device'],
+            ] as const).map(([value, label]) => (
               <Button
-                key={t}
-                variant={theme === t ? 'default' : 'outline'}
+                key={value}
+                role="radio"
+                aria-checked={theme === value}
+                variant={theme === value ? 'default' : 'outline'}
                 size="sm"
-                onClick={() => setTheme(t)}
+                onClick={() => setTheme(value)}
               >
-                {t.charAt(0).toUpperCase() + t.slice(1)}
+                {label}
               </Button>
             ))}
           </div>

--- a/packages/dashboard/src/app/auth/page.tsx
+++ b/packages/dashboard/src/app/auth/page.tsx
@@ -80,7 +80,7 @@ function AuthPageInner() {
   }
 
   return (
-    <main className="relative min-h-screen overflow-hidden bg-background">
+    <main className="auth-shell relative min-h-screen overflow-hidden bg-background">
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_18%_16%,oklch(var(--primary)/0.1),transparent_34%)]" />
       <div className="relative mx-auto grid min-h-screen max-w-7xl lg:grid-cols-[1fr_0.85fr]">
         <section className="hidden border-r px-10 py-9 lg:flex lg:flex-col xl:px-16">

--- a/packages/dashboard/src/app/boards/page.tsx
+++ b/packages/dashboard/src/app/boards/page.tsx
@@ -22,7 +22,7 @@ export default async function BoardsPage({
   const authHref = `${publicEnv.NEXT_PUBLIC_APP_ORIGIN}/auth`
 
   return (
-    <div className="min-h-screen bg-[linear-gradient(180deg,_oklch(var(--background))_0%,_oklch(var(--muted))_100%)]">
+    <div className="board-directory-shell min-h-screen bg-[linear-gradient(180deg,_oklch(var(--background))_0%,_oklch(var(--muted))_100%)]">
       <header className="border-b bg-background/85 backdrop-blur">
         <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4 sm:px-6">
           <Link href="/" className="font-bold transition-opacity active:opacity-70">

--- a/packages/dashboard/src/app/docs/[[...slug]]/page.tsx
+++ b/packages/dashboard/src/app/docs/[[...slug]]/page.tsx
@@ -95,8 +95,8 @@ export default async function DocsPage({ params }: { params: Promise<{ slug?: st
   const dashboardHref = `${publicEnv.NEXT_PUBLIC_APP_ORIGIN}/dashboard`
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <header className="sticky top-0 z-40 border-b bg-background/95 backdrop-blur">
+    <div className="docs-shell min-h-screen bg-background text-foreground">
+      <header className="docs-titlebar sticky top-0 z-40 border-b bg-background/95 backdrop-blur">
         <div className="mx-auto flex h-16 max-w-[1480px] items-center gap-4 px-4 sm:px-6">
           <Link href="/" className="shrink-0"><BrandWordmark className="text-lg" priority /></Link>
           <span className="hidden h-5 w-px bg-border sm:block" />
@@ -123,7 +123,7 @@ export default async function DocsPage({ params }: { params: Promise<{ slug?: st
         <div className="grid lg:grid-cols-[230px_minmax(0,1fr)] xl:grid-cols-[230px_minmax(0,820px)_220px] xl:gap-12">
           <aside className="hidden border-r pr-5 lg:block"><div className="sticky top-20 max-h-[calc(100vh-6rem)] overflow-y-auto py-8"><DocsNavigation activeSlug={page.slug} /></div></aside>
 
-          <main className="min-w-0 py-8 lg:px-8 xl:px-0 xl:py-12">
+          <main className="docs-content min-w-0 py-8 lg:px-8 xl:px-0 xl:py-12">
             <p className="text-xs font-semibold uppercase tracking-[0.16em] text-primary">{page.category}</p>
             <h1 className="mt-3 text-3xl font-bold tracking-tight sm:text-4xl">{page.title}</h1>
             <p className="mt-4 max-w-[68ch] text-base leading-7 text-muted-foreground">{page.description}</p>

--- a/packages/dashboard/src/app/globals.css
+++ b/packages/dashboard/src/app/globals.css
@@ -70,6 +70,61 @@
     --brand: 0.735 0.155 132;
     --brand-subtle: 0.245 0.04 128;
   }
+
+  .windows98 {
+    color-scheme: light;
+    /* Windows Classic system-color roles, adapted to the app's OKLCH token contract. */
+    --background: 0.8078 0 90;
+    --foreground: 0.115 0.003 264;
+    --surface-sidebar: 0.8078 0 90;
+    --surface-raised: 0.9037 0 90;
+    --surface-soft: 0.8078 0 90;
+    --surface-inset: 0.5999 0 90;
+    --surface-overlay: 0.9922 0.039 107.09;
+    --surface-selected: 0.2711 0.1879 264.05;
+    --surface-code: 0.135 0.008 145;
+    --card: 0.8078 0 90;
+    --card-foreground: 0.115 0.003 264;
+    --popover: 0.8078 0 90;
+    --popover-foreground: 0.115 0.003 264;
+    --primary: 0.2711 0.1879 264.05;
+    --primary-foreground: 0.985 0.004 90;
+    --secondary: 0.8078 0 90;
+    --secondary-foreground: 0.115 0.003 264;
+    --muted: 0.756 0 90;
+    --muted-foreground: 0.3715 0 90;
+    --accent: 0.2711 0.1879 264.05;
+    --accent-foreground: 0.985 0.004 90;
+    --destructive: 0.44 0.17 28;
+    --destructive-foreground: 0.985 0.004 90;
+    --border: 0.3715 0 90;
+    --input: 0.3715 0 90;
+    --ring: 0.115 0.003 264;
+    --radius: 0rem;
+    --brand: 0.2711 0.1879 264.05;
+    --brand-subtle: 0.8078 0 90;
+
+    --win98-desktop: oklch(0.5431 0.0927 194.77);
+    --win98-face: oklch(0.8078 0 90);
+    --win98-window: oklch(0.985 0.004 90);
+    --win98-highlight: oklch(0.985 0.004 90);
+    --win98-light: oklch(0.9037 0 90);
+    --win98-shadow: oklch(0.5999 0 90);
+    --win98-dark-shadow: oklch(0.3715 0 90);
+    --win98-text: oklch(0.115 0.003 264);
+    --win98-title: oklch(0.2711 0.1879 264.05);
+    --win98-title-end: oklch(0.452 0.3132 264.05);
+    --win98-raised:
+      inset -1px -1px var(--win98-dark-shadow),
+      inset 1px 1px var(--win98-highlight),
+      inset -2px -2px var(--win98-shadow),
+      inset 2px 2px var(--win98-light);
+    --win98-sunken:
+      inset -1px -1px var(--win98-highlight),
+      inset 1px 1px var(--win98-dark-shadow),
+      inset -2px -2px var(--win98-light),
+      inset 2px 2px var(--win98-shadow);
+  }
 }
 
 @layer base {
@@ -124,6 +179,13 @@
 .dark {
   --shadow-card: 0 1px 2px rgb(0 0 0 / 0.18), 0 10px 24px rgb(0 0 0 / 0.14);
   --shadow-float: 0 24px 72px rgb(0 0 0 / 0.4);
+}
+
+.windows98 {
+  --shadow-card: var(--win98-raised);
+  --shadow-float:
+    2px 2px 0 rgb(5 5 8 / 0.72),
+    var(--win98-raised);
 }
 
 /* ─── Keyframes ───────────────────────────────────────────────────────────── */
@@ -324,6 +386,464 @@
 
 .dark .landing-header-scrolled {
   box-shadow: 0 1px 0 rgb(255 255 255 / 0.06) inset, 0 12px 34px rgb(0 0 0 / 0.22);
+}
+
+/* ─── Windows 98 appearance ──────────────────────────────────────────────── */
+
+.windows98 body {
+  font-family: "MS Sans Serif", Tahoma, "Segoe UI", sans-serif;
+  font-feature-settings: normal;
+  letter-spacing: 0;
+  text-rendering: optimizeSpeed;
+  -webkit-font-smoothing: auto;
+}
+
+html.windows98 {
+  scroll-behavior: auto;
+}
+
+.windows98 ::selection {
+  background: var(--win98-title);
+  color: var(--win98-highlight);
+}
+
+.windows98 *:focus-visible {
+  outline: 1px dotted var(--win98-text) !important;
+  outline-offset: -4px !important;
+  box-shadow: none;
+  --tw-ring-shadow: 0 0 transparent !important;
+  --tw-ring-offset-shadow: 0 0 transparent !important;
+}
+
+.windows98 [class*="rounded-"]:not(.widget-theme-preview *),
+.windows98 [class~="rounded"]:not(.widget-theme-preview *) {
+  border-radius: 0 !important;
+}
+
+.windows98 .dashboard-shell,
+.windows98 .marketing-shell,
+.windows98 .board-directory-shell,
+.windows98 .public-board-shell,
+.windows98 .auth-shell {
+  background-color: var(--win98-desktop) !important;
+  background-image:
+    linear-gradient(45deg, rgb(5 5 8 / 0.025) 25%, transparent 25%),
+    linear-gradient(-45deg, rgb(5 5 8 / 0.025) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, rgb(250 250 248 / 0.025) 75%),
+    linear-gradient(-45deg, transparent 75%, rgb(250 250 248 / 0.025) 75%) !important;
+  background-position: 0 0, 0 2px, 2px -2px, -2px 0 !important;
+  background-size: 4px 4px !important;
+}
+
+.windows98 .dashboard-shell > main {
+  background: var(--win98-desktop) !important;
+  padding: 6px;
+}
+
+.windows98 .dashboard-shell > main > div {
+  min-height: calc(100% - 2px);
+  background: var(--win98-face);
+  box-shadow: var(--win98-raised);
+}
+
+.windows98 .dashboard-shell aside,
+.windows98 .dashboard-shell > div:first-child {
+  border-color: var(--win98-dark-shadow) !important;
+  background: var(--win98-face) !important;
+  box-shadow: inset -1px 0 var(--win98-dark-shadow), inset -2px 0 var(--win98-highlight);
+}
+
+.windows98 .win98-window,
+.windows98 [class~="bg-card"][class*="border"]:not(.widget-theme-preview *),
+.windows98 [class~="bg-popover"][class*="border"]:not(.widget-theme-preview *) {
+  border: 0 !important;
+  background-color: var(--win98-face) !important;
+  box-shadow: var(--win98-raised) !important;
+}
+
+.windows98 .win98-window {
+  padding: 3px;
+}
+
+.windows98 .win98-titlebar,
+.windows98 .win98-page-title {
+  border: 0 !important;
+  background: linear-gradient(90deg, var(--win98-title), var(--win98-title-end)) !important;
+  color: var(--win98-highlight) !important;
+  box-shadow: none !important;
+}
+
+.windows98 .win98-titlebar {
+  min-height: 22px;
+  margin: 0;
+  padding: 4px 6px !important;
+}
+
+.windows98 .win98-page-title {
+  margin-bottom: 6px;
+  padding: 6px 8px !important;
+  box-shadow: var(--win98-raised) !important;
+}
+
+.windows98 .win98-titlebar :is(h1, h2, h3, p, span, a),
+.windows98 .win98-page-title :is(h1, h2, h3, p, span, a) {
+  color: inherit !important;
+  letter-spacing: 0 !important;
+}
+
+.windows98 .win98-titlebar :is(h1, h2, h3),
+.windows98 .win98-page-title :is(h1, h2, h3) {
+  font-size: 0.8125rem !important;
+  font-weight: 700 !important;
+  line-height: 1.15 !important;
+}
+
+.windows98 .win98-window > [class*="border-t"],
+.windows98 .win98-window > [class*="border-b"] {
+  border-color: var(--win98-shadow) !important;
+}
+
+.windows98 button:not(.widget-theme-preview *),
+.windows98 a[class*="inline-flex"][class~="border"]:not(.widget-theme-preview *),
+.windows98 a[class*="inline-flex"][class~="bg-primary"]:not(.widget-theme-preview *) {
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: var(--win98-face) !important;
+  color: var(--win98-text) !important;
+  box-shadow: var(--win98-raised) !important;
+  filter: none !important;
+  transform: none;
+}
+
+.windows98 button[class*="hover:bg-accent"]:not([class~="border"], [aria-pressed="true"], [aria-checked="true"], .widget-theme-preview *) {
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+.windows98 button[class*="hover:bg-accent"]:not([class~="border"], .widget-theme-preview *):hover {
+  background: var(--win98-face) !important;
+  box-shadow: var(--win98-raised) !important;
+}
+
+.windows98 button:not(.widget-theme-preview *):hover,
+.windows98 a[class*="inline-flex"][class~="border"]:not(.widget-theme-preview *):hover,
+.windows98 a[class*="inline-flex"][class~="bg-primary"]:not(.widget-theme-preview *):hover {
+  background: var(--win98-light) !important;
+  color: var(--win98-text) !important;
+}
+
+.windows98 button:not(.widget-theme-preview *):active,
+.windows98 button[aria-pressed="true"]:not(.widget-theme-preview *),
+.windows98 [role="radio"][aria-checked="true"]:not(.widget-theme-preview *) {
+  background: var(--win98-face) !important;
+  color: var(--win98-text) !important;
+  box-shadow: var(--win98-sunken) !important;
+  transform: translate(1px, 1px) !important;
+}
+
+.windows98 button[class~="bg-primary"]:not(.widget-theme-preview *),
+.windows98 a[class~="bg-primary"]:not(.widget-theme-preview *) {
+  font-weight: 700;
+  box-shadow:
+    0 0 0 1px var(--win98-text),
+    var(--win98-raised) !important;
+}
+
+.windows98 button:disabled:not(.widget-theme-preview *) {
+  color: var(--win98-shadow) !important;
+  opacity: 1 !important;
+  text-shadow: 1px 1px var(--win98-highlight);
+}
+
+.windows98 input:not([type="checkbox"], [type="radio"], [type="range"], .widget-theme-preview *),
+.windows98 textarea:not(.widget-theme-preview *),
+.windows98 select:not(.widget-theme-preview *) {
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: var(--win98-window) !important;
+  color: var(--win98-text) !important;
+  box-shadow: var(--win98-sunken) !important;
+}
+
+.windows98 input::placeholder,
+.windows98 textarea::placeholder {
+  color: var(--win98-shadow) !important;
+  opacity: 1;
+}
+
+.windows98 input:is([type="checkbox"], [type="radio"], [type="range"]) {
+  accent-color: var(--win98-title);
+}
+
+.windows98 [role="switch"][data-state="checked"] {
+  background: var(--win98-title) !important;
+  color: var(--win98-highlight) !important;
+}
+
+.windows98 [role="menu"],
+.windows98 [role="listbox"],
+.windows98 [role="dialog"],
+.windows98 [data-radix-popper-content-wrapper] > div {
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: var(--win98-face) !important;
+  box-shadow:
+    2px 2px 0 rgb(5 5 8 / 0.72),
+    var(--win98-raised) !important;
+}
+
+.windows98 [role="option"][data-highlighted],
+.windows98 [role="menuitem"][data-highlighted],
+.windows98 a[aria-current="page"],
+.windows98 a[class*="bg-surface-selected"] {
+  background: var(--win98-title) !important;
+  color: var(--win98-highlight) !important;
+}
+
+.windows98 table {
+  background: var(--win98-window);
+  box-shadow: var(--win98-sunken);
+}
+
+.windows98 th {
+  background: var(--win98-face) !important;
+  box-shadow: var(--win98-raised);
+}
+
+.windows98 td,
+.windows98 th {
+  border-color: var(--win98-shadow) !important;
+}
+
+.windows98 hr,
+.windows98 [data-orientation="horizontal"],
+.windows98 [class~="divide-y"] > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--win98-shadow) !important;
+}
+
+.windows98 code,
+.windows98 pre,
+.windows98 kbd {
+  font-family: "Lucida Console", "Courier New", monospace;
+}
+
+.windows98 pre:not(.widget-theme-preview *),
+.windows98 [class~="bg-zinc-950"]:not(.widget-theme-preview *) {
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: var(--surface-code) !important;
+  color: oklch(0.92 0.012 145) !important;
+  box-shadow: var(--win98-sunken) !important;
+}
+
+.windows98 .skeleton,
+.windows98 [class*="animate-pulse"]:not(.widget-theme-preview *) {
+  animation: none !important;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      var(--win98-face) 0 2px,
+      var(--win98-light) 2px 4px
+    ) !important;
+}
+
+.windows98 .animate-fade-in,
+.windows98 .animate-slide-up,
+.windows98 .animate-slide-in,
+.windows98 .animate-shimmer {
+  animation: none !important;
+}
+
+.windows98 .public-theme-control {
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: var(--win98-face) !important;
+  box-shadow:
+    2px 2px 0 rgb(5 5 8 / 0.65),
+    var(--win98-raised) !important;
+}
+
+.windows98 .landing-header,
+.windows98 .landing-header-scrolled,
+.windows98 .docs-titlebar,
+.windows98 .board-directory-shell > header {
+  border-color: var(--win98-dark-shadow) !important;
+  background: var(--win98-face) !important;
+  box-shadow: var(--win98-raised) !important;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+}
+
+.windows98 .landing-hero {
+  overflow: visible;
+  border: 0 !important;
+  background: var(--win98-desktop) !important;
+}
+
+.windows98 .landing-hero-grain {
+  display: none;
+}
+
+.windows98 .landing-hero > .relative {
+  margin: 12px auto;
+  padding: 3px 3px 28px !important;
+  gap: 1.5rem;
+  border: 0;
+  background: var(--win98-face);
+  box-shadow:
+    3px 3px 0 rgb(5 5 8 / 0.45),
+    var(--win98-raised);
+}
+
+.windows98 .landing-hero > .relative::before {
+  content: "feedbacks.dev - Welcome";
+  display: flex;
+  grid-column: 1 / -1;
+  min-height: 22px;
+  align-items: center;
+  padding: 3px 6px;
+  background: linear-gradient(90deg, var(--win98-title), var(--win98-title-end));
+  color: var(--win98-highlight);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.windows98 .landing-hero > .relative > div {
+  padding: 1rem;
+}
+
+.windows98 .landing-product-loop {
+  border: 0;
+  border-radius: 0;
+  box-shadow: var(--win98-sunken);
+  animation: none;
+}
+
+.windows98 .marketing-shell > main > section:not(.landing-hero),
+.windows98 .marketing-shell > footer {
+  background: var(--win98-face) !important;
+  border-color: var(--win98-shadow) !important;
+}
+
+.windows98 .marketing-shell h1,
+.windows98 .marketing-shell h2,
+.windows98 .marketing-shell h3,
+.windows98 .board-directory-shell h1,
+.windows98 .public-board-shell h1 {
+  letter-spacing: 0 !important;
+}
+
+.windows98 .docs-shell {
+  background: var(--win98-face) !important;
+}
+
+.windows98 .docs-shell aside {
+  background: var(--win98-face);
+}
+
+.windows98 .docs-content {
+  margin-block: 8px;
+  padding: 1.5rem !important;
+  background: var(--win98-window);
+  box-shadow: var(--win98-sunken);
+}
+
+.windows98 .docs-content > h1,
+.windows98 .legal-shell h1 {
+  margin: -1.5rem -1.5rem 1rem !important;
+  padding: 5px 8px;
+  background: linear-gradient(90deg, var(--win98-title), var(--win98-title-end));
+  color: var(--win98-highlight);
+  font-size: 0.875rem !important;
+  letter-spacing: 0 !important;
+}
+
+.windows98 .docs-shell a[class*="bg-primary/10"] {
+  background: var(--win98-title) !important;
+  color: var(--win98-highlight) !important;
+}
+
+.windows98 .docs-content [class*="rounded-lg"][class*="border"],
+.windows98 .legal-shell .prose {
+  border-radius: 0 !important;
+  box-shadow: var(--win98-raised);
+}
+
+.windows98 .legal-shell {
+  background: var(--win98-desktop) !important;
+  padding-block: 8px;
+}
+
+.windows98 .legal-shell > div {
+  background: var(--win98-face);
+  box-shadow: var(--win98-raised);
+}
+
+.windows98 .legal-shell .prose {
+  padding: 1.25rem;
+  background: var(--win98-window);
+  color: var(--win98-text);
+}
+
+.windows98 .auth-shell > div.relative {
+  margin: 10px auto;
+  min-height: calc(100vh - 20px);
+  background: var(--win98-face);
+  box-shadow:
+    3px 3px 0 rgb(5 5 8 / 0.45),
+    var(--win98-raised);
+}
+
+.windows98 .auth-shell > .pointer-events-none {
+  display: none;
+}
+
+.windows98 .board-directory-shell > main,
+.windows98 .public-board-shell > div {
+  background: var(--win98-face);
+}
+
+.windows98 .board-directory-shell main > section:first-child,
+.windows98 .public-board-shell section[class*="rounded"],
+.windows98 .public-board-shell article,
+.windows98 .public-board-shell footer {
+  border-radius: 0 !important;
+  background: var(--win98-face) !important;
+  box-shadow: var(--win98-raised) !important;
+}
+
+.windows98 [class*="backdrop-blur"] {
+  -webkit-backdrop-filter: none !important;
+  backdrop-filter: none !important;
+}
+
+.windows98 [class*="bg-gradient"],
+.windows98 [class*="bg-[linear-gradient"] {
+  background-image: none !important;
+}
+
+@media (max-width: 767px) {
+  .windows98 .dashboard-shell > main {
+    padding: 3px;
+  }
+
+  .windows98 .dashboard-shell > main > div {
+    min-height: 100%;
+    padding-inline: 0.75rem;
+  }
+
+  .windows98 .landing-hero > .relative {
+    margin: 6px;
+  }
+
+  .windows98 .docs-content {
+    margin-inline: -0.5rem;
+    padding: 1rem !important;
+  }
+
+  .windows98 .docs-content > h1 {
+    margin: -1rem -1rem 1rem !important;
+  }
 }
 
 /* Respect reduced motion */

--- a/packages/dashboard/src/app/layout.tsx
+++ b/packages/dashboard/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Inter } from 'next/font/google'
 import { headers } from 'next/headers'
 import './globals.css'
 import { ThemeProvider } from '@/components/theme-provider'
+import { PublicThemeControl } from '@/components/public-theme-control'
 import { Toaster } from '@/components/toaster'
 import { SITE_ORIGIN } from '@/lib/site'
 import { Analytics } from '@vercel/analytics/next'
@@ -54,11 +55,13 @@ export default async function RootLayout({
         <ThemeProvider
           attribute="class"
           defaultTheme="light"
+          themes={['light', 'dark', 'windows98']}
           enableSystem
           disableTransitionOnChange
           nonce={nonce}
         >
           {children}
+          <PublicThemeControl />
           <Toaster />
           <Analytics />
           <SpeedInsights />

--- a/packages/dashboard/src/app/p/[slug]/public-board.tsx
+++ b/packages/dashboard/src/app/p/[slug]/public-board.tsx
@@ -294,7 +294,7 @@ export function PublicBoard({
     <div
       data-public-board
       data-public-board-ready={ready ? 'true' : 'false'}
-      className="min-h-screen bg-background"
+      className="public-board-shell min-h-screen bg-background"
     >
       {board.customCss ? <style>{board.customCss}</style> : null}
       {viewerSignedIn && (

--- a/packages/dashboard/src/app/page.tsx
+++ b/packages/dashboard/src/app/page.tsx
@@ -81,7 +81,7 @@ const softwareApplicationJsonLd = {
 
 export default function LandingPage() {
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <div className="marketing-shell min-h-screen bg-background text-foreground">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{

--- a/packages/dashboard/src/app/privacy/page.tsx
+++ b/packages/dashboard/src/app/privacy/page.tsx
@@ -4,7 +4,7 @@ import { ArrowLeft } from 'lucide-react'
 
 export default function PrivacyPage() {
   return (
-    <div className="min-h-screen bg-background">
+    <div className="legal-shell min-h-screen bg-background">
       <div className="container mx-auto max-w-3xl px-4 py-8">
         <Button variant="ghost" asChild className="mb-6 gap-2">
           <Link href="/">

--- a/packages/dashboard/src/app/terms/page.tsx
+++ b/packages/dashboard/src/app/terms/page.tsx
@@ -4,7 +4,7 @@ import { ArrowLeft } from 'lucide-react'
 
 export default function TermsPage() {
   return (
-    <div className="min-h-screen bg-background">
+    <div className="legal-shell min-h-screen bg-background">
       <div className="container mx-auto max-w-3xl px-4 py-8">
         <Button variant="ghost" asChild className="mb-6 gap-2">
           <Link href="/">

--- a/packages/dashboard/src/components/public-theme-control.tsx
+++ b/packages/dashboard/src/components/public-theme-control.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { ThemeToggle } from '@/components/theme-toggle'
+
+const DASHBOARD_ROUTES = [
+  '/api-docs',
+  '/billing',
+  '/dashboard',
+  '/feedback',
+  '/integrations',
+  '/projects',
+  '/settings',
+  '/tutorials',
+  '/updates',
+]
+
+export function PublicThemeControl() {
+  const pathname = usePathname()
+  const hasDashboardAppearanceControl = DASHBOARD_ROUTES.some(
+    (route) => pathname === route || pathname.startsWith(`${route}/`),
+  )
+
+  if (hasDashboardAppearanceControl) return null
+
+  return (
+    <div className="public-theme-control fixed bottom-[max(1rem,env(safe-area-inset-bottom))] right-4 z-[70] w-11 rounded-lg border bg-popover p-1 shadow-[var(--shadow-float)]">
+      <ThemeToggle collapsed />
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/theme-toggle.tsx
+++ b/packages/dashboard/src/components/theme-toggle.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import { flushSync } from 'react-dom'
-import { Moon, Sun } from 'lucide-react'
+import { Laptop, Moon, Palette, Sun } from 'lucide-react'
 import { useTheme } from 'next-themes'
 import { cn } from '@/lib/utils'
 
@@ -16,7 +16,15 @@ type ViewTransitionDocument = Document & {
 
 interface ThemeToggleProps {
   collapsed?: boolean
+  className?: string
 }
+
+const APPEARANCE_OPTIONS = [
+  { value: 'light', label: 'Light', icon: Sun },
+  { value: 'dark', label: 'Dark', icon: Moon },
+  { value: 'windows98', label: 'Windows 98', shortLabel: '98', icon: Palette },
+  { value: 'system', label: 'Device', icon: Laptop },
+] as const
 
 function getMaxRadius(x: number, y: number) {
   return Math.hypot(
@@ -25,18 +33,28 @@ function getMaxRadius(x: number, y: number) {
   )
 }
 
-export function ThemeToggle({ collapsed = false }: ThemeToggleProps) {
-  const { resolvedTheme, setTheme } = useTheme()
+export function ThemeToggle({ collapsed = false, className }: ThemeToggleProps) {
+  const { theme, resolvedTheme, setTheme } = useTheme()
   const [mounted, setMounted] = React.useState(false)
 
   React.useEffect(() => {
     setMounted(true)
   }, [])
 
-  const isDark = mounted && resolvedTheme === 'dark'
-  const nextTheme = isDark ? 'light' : 'dark'
+  const currentTheme = mounted ? (theme || resolvedTheme || 'light') : 'light'
+  const currentIndex = Math.max(
+    0,
+    APPEARANCE_OPTIONS.findIndex((option) => option.value === currentTheme),
+  )
+  const currentOption = APPEARANCE_OPTIONS[currentIndex]
+  const nextOption = APPEARANCE_OPTIONS[(currentIndex + 1) % APPEARANCE_OPTIONS.length]
 
-  const toggleTheme = async (event: React.MouseEvent<HTMLButtonElement>) => {
+  const changeTheme = async (
+    nextTheme: (typeof APPEARANCE_OPTIONS)[number]['value'],
+    target: HTMLElement,
+  ) => {
+    if (nextTheme === currentTheme) return
+
     const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
     const viewTransitionDocument = document as ViewTransitionDocument
 
@@ -45,7 +63,7 @@ export function ThemeToggle({ collapsed = false }: ThemeToggleProps) {
       return
     }
 
-    const rect = event.currentTarget.getBoundingClientRect()
+    const rect = target.getBoundingClientRect()
     const x = rect.left + rect.width / 2
     const y = rect.top + rect.height / 2
     const maxRadius = getMaxRadius(x, y)
@@ -66,38 +84,68 @@ export function ThemeToggle({ collapsed = false }: ThemeToggleProps) {
         ],
       },
       {
-        duration: 520,
+        duration: nextTheme === 'windows98' ? 260 : 520,
         easing: 'cubic-bezier(0.16, 1, 0.3, 1)',
         pseudoElement: '::view-transition-new(root)',
       },
     )
   }
 
-  return (
-    <button
-      type="button"
-      role="switch"
-      aria-checked={isDark}
-      aria-label={isDark ? 'Use light appearance' : 'Use dark appearance'}
-      title={collapsed ? (isDark ? 'Use light appearance' : 'Use dark appearance') : undefined}
-      onClick={toggleTheme}
-      className={cn(
-        'group flex w-full items-center rounded-lg text-[13px] font-medium',
-        'text-muted-foreground transition-colors duration-150 hover:bg-accent hover:text-foreground',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
-        collapsed ? 'justify-center px-2 py-2' : 'justify-between gap-3 px-3 py-2',
-      )}
-    >
-      <span className={cn('flex items-center', collapsed ? 'justify-center' : 'gap-2.5')}>
-        {isDark ? (
-          <Moon className="h-[17px] w-[17px] shrink-0" />
-        ) : (
-          <Sun className="h-[17px] w-[17px] shrink-0" />
-        )}
-        {!collapsed && <span>Appearance</span>}
-      </span>
+  if (collapsed) {
+    const CurrentIcon = currentOption.icon
 
-      {!collapsed && <span className="text-[11px] font-medium text-muted-foreground">{isDark ? 'Dark' : 'Light'}</span>}
-    </button>
+    return (
+      <button
+        type="button"
+        aria-label={`Appearance: ${currentOption.label}. Switch to ${nextOption.label}`}
+        title={`${currentOption.label}. Switch to ${nextOption.label}`}
+        onClick={(event) => void changeTheme(nextOption.value, event.currentTarget)}
+        className={cn(
+          'flex h-10 w-full items-center justify-center rounded-lg text-muted-foreground transition-colors duration-150 hover:bg-accent hover:text-accent-foreground',
+          className,
+        )}
+      >
+        <CurrentIcon className="h-[17px] w-[17px]" />
+      </button>
+    )
+  }
+
+  return (
+    <div className={cn('space-y-1.5', className)}>
+      <div className="flex items-center justify-between px-1 text-[11px] font-medium text-muted-foreground">
+        <span>Appearance</span>
+        <span aria-live="polite">{currentOption.label}</span>
+      </div>
+      <div
+        role="radiogroup"
+        aria-label="Appearance"
+        className="grid grid-cols-4 gap-1 rounded-lg border bg-surface-inset/45 p-1"
+      >
+        {APPEARANCE_OPTIONS.map((option) => {
+          const Icon = option.icon
+          const selected = currentTheme === option.value
+          return (
+            <button
+              key={option.value}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              aria-label={option.label}
+              title={option.label}
+              onClick={(event) => void changeTheme(option.value, event.currentTarget)}
+              className={cn(
+                'flex h-8 min-w-0 items-center justify-center gap-1 rounded-md text-[11px] font-semibold transition-colors',
+                selected
+                  ? 'bg-card text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+              )}
+            >
+              <Icon className="h-3.5 w-3.5 shrink-0" />
+              {'shortLabel' in option && option.shortLabel ? <span>{option.shortLabel}</span> : null}
+            </button>
+          )
+        })}
+      </div>
+    </div>
   )
 }

--- a/packages/dashboard/src/components/ui/card.tsx
+++ b/packages/dashboard/src/components/ui/card.tsx
@@ -6,7 +6,7 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
     <div
       ref={ref}
       className={cn(
-        "overflow-hidden rounded-lg border border-border bg-card text-card-foreground shadow-[var(--shadow-card)]",
+        "win98-window overflow-hidden rounded-lg border border-border bg-card text-card-foreground shadow-[var(--shadow-card)]",
         className,
       )}
       {...props}
@@ -17,7 +17,7 @@ Card.displayName = "Card"
 
 const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex flex-col space-y-1.5 border-b bg-surface-raised/70 p-5", className)} {...props} />
+    <div ref={ref} className={cn("win98-titlebar flex flex-col space-y-1.5 border-b bg-surface-raised/70 p-5", className)} {...props} />
   )
 )
 CardHeader.displayName = "CardHeader"

--- a/packages/dashboard/src/components/ui/workspace-section.tsx
+++ b/packages/dashboard/src/components/ui/workspace-section.tsx
@@ -23,14 +23,14 @@ export function WorkspaceSection({
   return (
     <section
       className={cn(
-        'overflow-hidden rounded-lg border bg-card text-card-foreground shadow-[var(--shadow-card)]',
+        'win98-window overflow-hidden rounded-lg border bg-card text-card-foreground shadow-[var(--shadow-card)]',
         tone === 'danger' && 'border-destructive/35',
         className,
       )}
     >
       <header
         className={cn(
-          'flex flex-col gap-3 border-b bg-surface-raised/70 px-5 py-4 sm:flex-row sm:items-start sm:justify-between',
+          'win98-titlebar flex flex-col gap-3 border-b bg-surface-raised/70 px-5 py-4 sm:flex-row sm:items-start sm:justify-between',
           tone === 'danger' && 'border-destructive/25 bg-destructive/[0.045]',
         )}
       >

--- a/packages/dashboard/src/components/ui/workspace-shell.tsx
+++ b/packages/dashboard/src/components/ui/workspace-shell.tsx
@@ -19,7 +19,7 @@ export function PageHeader({
   className?: string
 }) {
   return (
-    <header className={cn('flex flex-col gap-4 border-b pb-5 sm:flex-row sm:items-end sm:justify-between', className)}>
+    <header className={cn('win98-page-title flex flex-col gap-4 border-b pb-5 sm:flex-row sm:items-end sm:justify-between', className)}>
       <div className="min-w-0">
         {eyebrow && (
           <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-primary">
@@ -59,9 +59,9 @@ export function SectionPanel({
   dataTour?: string
 }) {
   return (
-    <section data-tour={dataTour} className={cn('overflow-hidden rounded-lg border bg-card shadow-[var(--shadow-card)]', className)}>
+    <section data-tour={dataTour} className={cn('win98-window overflow-hidden rounded-lg border bg-card shadow-[var(--shadow-card)]', className)}>
       {(title || description || action) && (
-        <header className="flex flex-col gap-3 border-b bg-surface-raised/70 px-5 py-4 sm:flex-row sm:items-start sm:justify-between">
+        <header className="win98-titlebar flex flex-col gap-3 border-b bg-surface-raised/70 px-5 py-4 sm:flex-row sm:items-start sm:justify-between">
           <div className="min-w-0">
             {title && <h2 className="text-sm font-semibold text-foreground">{title}</h2>}
             {description && <p className="mt-1 max-w-[68ch] text-sm leading-5 text-muted-foreground">{description}</p>}

--- a/packages/dashboard/src/lib/types.ts
+++ b/packages/dashboard/src/lib/types.ts
@@ -252,7 +252,7 @@ export interface Vote {
 export interface UserSettings {
   user_id: string
   preferences: {
-    theme?: 'light' | 'dark' | 'system'
+    theme?: 'light' | 'dark' | 'windows98' | 'system'
     defaultProject?: string
   }
   notification_settings: NotificationSettings

--- a/packages/dashboard/tests/unit/product-experience.test.ts
+++ b/packages/dashboard/tests/unit/product-experience.test.ts
@@ -158,6 +158,28 @@ test('theme tokens use perceptual OKLCH colors in both themes', () => {
   assert.doesNotMatch(tailwind, /hsl\(var\(--primary\)/)
 })
 
+test('Windows 98 is a complete selectable appearance across product and public surfaces', () => {
+  const css = read('../../src/app/globals.css')
+  const layout = read('../../src/app/layout.tsx')
+  const toggle = read('../../src/components/theme-toggle.tsx')
+  const publicControl = read('../../src/components/public-theme-control.tsx')
+  const settings = read('../../src/app/(dashboard)/settings/page.tsx')
+
+  assert.match(layout, /themes=\{\['light', 'dark', 'windows98'\]\}/)
+  assert.match(toggle, /value: 'windows98', label: 'Windows 98'/)
+  assert.match(toggle, /role="radiogroup"/)
+  assert.match(settings, /\['windows98', 'Windows 98'\]/)
+  assert.match(publicControl, /<ThemeToggle collapsed \/>/)
+  assert.match(css, /\.windows98 \{/)
+  assert.match(css, /--win98-raised:/)
+  assert.match(css, /\.windows98 \.dashboard-shell/)
+  assert.match(css, /\.windows98 \.landing-hero/)
+  assert.match(css, /\.windows98 \.docs-content/)
+  assert.match(css, /\.windows98 \.public-board-shell/)
+  assert.match(css, /\.windows98 input/)
+  assert.match(css, /\.windows98 table/)
+})
+
 test('authenticated workspaces use page headers, section panels, and progressive disclosure', () => {
   const card = read('../../src/components/ui/card.tsx')
   const install = read('../../src/app/(dashboard)/projects/[id]/install-tab.tsx')


### PR DESCRIPTION
## What changed

- adds Windows 98 as a persisted appearance alongside light, dark, and device preference
- applies researched Windows Classic system colors, raised and sunken edges, title bars, controls, tables, menus, code panes, and loading states
- covers marketing, auth, dashboard, setup, inbox, settings, billing, docs, legal pages, board directory, public boards, and responsive navigation
- keeps installed widgets and widget previews isolated from the app appearance
- documents the theme contract and adds regression coverage

## Why

Users can opt into a cohesive retro interface without changing the default light-first product experience or weakening the install and triage hierarchy.

## Validation

- dashboard TypeScript and ESLint
- 154/154 unit tests
- full production build
- widget gzip and dashboard route budgets
- Playwright suite preflight (29 tests correctly skipped because isolated E2E credentials are not configured locally)
- desktop and 390px browser checks for home and docs, including light/dark/Windows 98 persistence, no overflow, and no runtime overlay