### PR TITLE
Open update display settings in a drawer

### DIFF
--- a/packages/dashboard/src/app/globals.css
+++ b/packages/dashboard/src/app/globals.css
@@ -195,6 +195,15 @@
   to   { opacity: 1; }
 }
 
+@keyframes drawer-in {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
 @keyframes slide-up {
   from { opacity: 0; transform: translateY(12px); }
   to   { opacity: 1; transform: translateY(0); }
@@ -248,6 +257,10 @@
   /* Entrance animations */
   .animate-fade-in {
     animation: fade-in 0.35s var(--ease-out-expo) both;
+  }
+
+  .animate-drawer-in {
+    animation: drawer-in 0.2s var(--ease-out-expo) both;
   }
 
   .animate-slide-up {

--- a/packages/dashboard/src/components/product-updates/ProductUpdatesSettings.tsx
+++ b/packages/dashboard/src/components/product-updates/ProductUpdatesSettings.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -17,142 +18,230 @@ export function ProductUpdatesSettings({
   settings,
   entitlements,
   onSave,
-  onBack,
+  onClose,
 }: {
   settings: ProductUpdateSettings;
   entitlements: ProductUpdateEntitlements | null;
-  onSave: (settings: ProductUpdateSettings) => Promise<void>;
-  onBack: () => void;
+  onSave: (settings: ProductUpdateSettings) => Promise<boolean>;
+  onClose: () => void;
 }) {
   const [draft, setDraft] = React.useState(settings);
+  const [submitting, setSubmitting] = React.useState(false);
+  const dialogRef = React.useRef<HTMLDivElement>(null);
+  const closeRef = React.useRef<HTMLButtonElement>(null);
+  const previousFocus = React.useRef<HTMLElement | null>(null);
   const delaySeconds = draft.displayDelayMs / 1000;
   const hasCustomDelay = ![0, 3, 5].includes(delaySeconds);
 
+  React.useEffect(() => {
+    previousFocus.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    closeRef.current?.focus();
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      previousFocus.current?.focus();
+    };
+  }, []);
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      if (!submitting) onClose();
+      return;
+    }
+    if (event.key !== "Tab") return;
+    const focusable = Array.from(
+      dialogRef.current?.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, summary, [tabindex]:not([tabindex="-1"])',
+      ) || [],
+    ).filter((element) => !element.hasAttribute("disabled"));
+    if (!focusable.length) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  async function save() {
+    setSubmitting(true);
+    const saved = await onSave(draft);
+    setSubmitting(false);
+    if (saved) onClose();
+  }
+
   return (
-    <div className="mx-auto max-w-3xl space-y-6">
-      <section className="flex flex-wrap items-start justify-between gap-4 rounded-lg border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
-        <div>
-          <p className="text-xs font-semibold text-primary">
-            Updates for your users
-          </p>
-          <h2 className="mt-2 text-2xl font-semibold tracking-[-0.035em]">
-            Display settings
-          </h2>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Control how “What’s new” announcements appear inside your product.
-          </p>
-        </div>
-        <Button variant="outline" onClick={onBack}>
-          Back to updates
-        </Button>
-      </section>
-      <div className="space-y-5 rounded-lg border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
-        <ProductUpdateCheck
-          label="Show product updates to users"
-          value={draft.enabled}
-          onChange={(enabled) => setDraft({ ...draft, enabled })}
-        />
-        <ProductUpdateCheck
-          label="Auto-show the newest unseen update"
-          value={draft.autoShow}
-          onChange={(autoShow) => setDraft({ ...draft, autoShow })}
-        />
-        <ProductUpdateField label="Appearance">
-          <select
-            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-            value={draft.theme}
-            onChange={(event) =>
-              setDraft({
-                ...draft,
-                theme: event.target.value as ProductUpdateSettings["theme"],
-              })
-            }
+    <div
+      ref={dialogRef}
+      className="fixed inset-0 z-50 bg-foreground/35 animate-fade-in"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="product-update-settings-title"
+      onKeyDown={handleKeyDown}
+      onMouseDown={(event) => {
+        if (!submitting && event.target === event.currentTarget) onClose();
+      }}
+    >
+      <aside className="ml-auto flex h-full w-full max-w-xl animate-drawer-in flex-col border-l bg-background shadow-[var(--shadow-float)]">
+        <header className="flex shrink-0 items-start justify-between gap-4 border-b bg-surface-raised px-5 py-4 sm:px-6">
+          <div>
+            <p className="text-xs font-semibold text-primary">
+              Updates for your users
+            </p>
+            <h2
+              id="product-update-settings-title"
+              className="mt-1 text-xl font-semibold tracking-[-0.025em]"
+            >
+              Display settings
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Control how “What’s new” appears inside your product.
+            </p>
+          </div>
+          <Button
+            ref={closeRef}
+            type="button"
+            size="sm"
+            variant="ghost"
+            aria-label="Close display settings"
+            disabled={submitting}
+            onClick={onClose}
           >
-            <option value="auto">Match visitor device</option>
-            <option value="light">Light</option>
-            <option value="dark">Dark</option>
-          </select>
-        </ProductUpdateField>
-        <ProductUpdateField label="Show after">
-          <select
-            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-            value={delaySeconds}
-            onChange={(event) =>
-              setDraft({
-                ...draft,
-                displayDelayMs: Number(event.target.value) * 1000,
-              })
-            }
-          >
-            {hasCustomDelay && (
-              <option value={delaySeconds}>
-                {delaySeconds} seconds (current)
-              </option>
-            )}
-            <option value="0">Immediately</option>
-            <option value="3">3 seconds</option>
-            <option value="5">5 seconds</option>
-          </select>
-        </ProductUpdateField>
-        <ProductUpdateField label="Accent color">
-          <Input
-            value={draft.accentColor}
-            onChange={(event) =>
-              setDraft({ ...draft, accentColor: event.target.value })
+            <X className="h-4 w-4" />
+          </Button>
+        </header>
+
+        <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-5 py-5 sm:px-6">
+          <ProductUpdateCheck
+            label="Show product updates to users"
+            value={draft.enabled}
+            onChange={(enabled) => setDraft({ ...draft, enabled })}
+          />
+          <ProductUpdateCheck
+            label="Auto-show the newest unseen update"
+            value={draft.autoShow}
+            onChange={(autoShow) => setDraft({ ...draft, autoShow })}
+          />
+          <ProductUpdateField label="Appearance">
+            <select
+              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+              value={draft.theme}
+              onChange={(event) =>
+                setDraft({
+                  ...draft,
+                  theme: event.target.value as ProductUpdateSettings["theme"],
+                })
+              }
+            >
+              <option value="auto">Match visitor device</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </ProductUpdateField>
+          <ProductUpdateField label="Show after">
+            <select
+              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+              value={delaySeconds}
+              onChange={(event) =>
+                setDraft({
+                  ...draft,
+                  displayDelayMs: Number(event.target.value) * 1000,
+                })
+              }
+            >
+              {hasCustomDelay && (
+                <option value={delaySeconds}>
+                  {delaySeconds} seconds (current)
+                </option>
+              )}
+              <option value="0">Immediately</option>
+              <option value="3">3 seconds</option>
+              <option value="5">5 seconds</option>
+            </select>
+          </ProductUpdateField>
+          <ProductUpdateField label="Accent color">
+            <Input
+              value={draft.accentColor}
+              onChange={(event) =>
+                setDraft({ ...draft, accentColor: event.target.value })
+              }
+            />
+          </ProductUpdateField>
+          <details className="rounded-md border p-4">
+            <summary className="cursor-pointer text-sm font-medium">
+              Page targeting
+            </summary>
+            <p className="mt-2 text-xs leading-5 text-muted-foreground">
+              Use pathname prefixes such as /dashboard or /settings. Leave both
+              lists empty to show updates everywhere.
+            </p>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2">
+              <ProductUpdateField label="Show on specific pages">
+                <Textarea
+                  rows={4}
+                  placeholder={"/dashboard\n/changelog"}
+                  value={draft.includePaths.join("\n")}
+                  onChange={(event) =>
+                    setDraft({
+                      ...draft,
+                      includePaths: event.target.value
+                        .split("\n")
+                        .map((item) => item.trim())
+                        .filter(Boolean),
+                    })
+                  }
+                />
+              </ProductUpdateField>
+              <ProductUpdateField label="Hide on specific pages">
+                <Textarea
+                  rows={4}
+                  placeholder={"/checkout\n/admin"}
+                  value={draft.excludePaths.join("\n")}
+                  onChange={(event) =>
+                    setDraft({
+                      ...draft,
+                      excludePaths: event.target.value
+                        .split("\n")
+                        .map((item) => item.trim())
+                        .filter(Boolean),
+                    })
+                  }
+                />
+              </ProductUpdateField>
+            </div>
+          </details>
+          <ProductUpdateCheck
+            label="Show feedbacks.dev branding"
+            value={draft.showPoweredBy}
+            disabled={!entitlements?.customBranding}
+            onChange={(showPoweredBy) =>
+              setDraft({ ...draft, showPoweredBy })
             }
           />
-        </ProductUpdateField>
-        <details className="rounded-md border p-4">
-          <summary className="cursor-pointer text-sm font-medium">
-            Page targeting
-          </summary>
-          <p className="mt-2 text-xs leading-5 text-muted-foreground">
-            Use pathname prefixes such as /dashboard or /settings. Leave both
-            lists empty to show updates everywhere.
-          </p>
-          <div className="mt-4 grid gap-4 sm:grid-cols-2">
-            <ProductUpdateField label="Show on specific pages">
-              <Textarea
-                rows={4}
-                placeholder={"/dashboard\n/changelog"}
-                value={draft.includePaths.join("\n")}
-                onChange={(event) =>
-                  setDraft({
-                    ...draft,
-                    includePaths: event.target.value
-                      .split("\n")
-                      .map((item) => item.trim())
-                      .filter(Boolean),
-                  })
-                }
-              />
-            </ProductUpdateField>
-            <ProductUpdateField label="Hide on specific pages">
-              <Textarea
-                rows={4}
-                placeholder={"/checkout\n/admin"}
-                value={draft.excludePaths.join("\n")}
-                onChange={(event) =>
-                  setDraft({
-                    ...draft,
-                    excludePaths: event.target.value
-                      .split("\n")
-                      .map((item) => item.trim())
-                      .filter(Boolean),
-                  })
-                }
-              />
-            </ProductUpdateField>
-          </div>
-        </details>
-        <ProductUpdateCheck
-          label="Show feedbacks.dev branding"
-          value={draft.showPoweredBy}
-          disabled={!entitlements?.customBranding}
-          onChange={(showPoweredBy) => setDraft({ ...draft, showPoweredBy })}
-        />
-        <Button onClick={() => void onSave(draft)}>Save settings</Button>
-      </div>
+        </div>
+
+        <footer className="flex shrink-0 justify-end gap-2 border-t bg-surface-raised px-5 py-4 sm:px-6">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={submitting}
+            onClick={onClose}
+          >
+            Cancel
+          </Button>
+          <Button type="button" disabled={submitting} onClick={() => void save()}>
+            {submitting ? "Saving…" : "Save settings"}
+          </Button>
+        </footer>
+      </aside>
     </div>
   );
 }

--- a/packages/dashboard/src/components/product-updates/ProductUpdatesTab.tsx
+++ b/packages/dashboard/src/components/product-updates/ProductUpdatesTab.tsx
@@ -96,10 +96,15 @@ export function ProductUpdatesTab({
     null,
   );
   const [privateTestOpen, setPrivateTestOpen] = React.useState(false);
+  const [settingsOpen, setSettingsOpen] = React.useState(view === "settings");
   const [publishConfirmation, setPublishConfirmation] = React.useState<
     "published" | "scheduled" | null
   >(null);
   const selected = updates.find((update) => update.id === selectedId) || null;
+
+  React.useEffect(() => {
+    if (view === "settings") setSettingsOpen(true);
+  }, [view]);
 
   const load = React.useCallback(async () => {
     setLoading(true);
@@ -443,6 +448,8 @@ export function ProductUpdatesTab({
       );
       setSettings(result.settings);
       setSettingsVersion(result.settingsVersion);
+      toast({ title: "Display settings saved" });
+      return true;
     } catch (error) {
       toast({
         title: "Could not save settings",
@@ -450,6 +457,14 @@ export function ProductUpdatesTab({
         variant: "destructive",
       });
       void load();
+      return false;
+    }
+  }
+
+  function closeSettings() {
+    setSettingsOpen(false);
+    if (view === "settings") {
+      router.replace(`/projects/${projectId}/release-notes`);
     }
   }
 
@@ -512,67 +527,67 @@ export function ProductUpdatesTab({
       />
     );
   }
-  if (view === "settings") {
+  const settingsPanel = settingsOpen ? (
+    <ProductUpdatesSettings
+      settings={settings}
+      entitlements={entitlements}
+      onSave={saveSettings}
+      onClose={closeSettings}
+    />
+  ) : null;
+
+  if (view === "overview" || view === "settings") {
     return (
-      <ProductUpdatesSettings
-        settings={settings}
-        entitlements={entitlements}
-        onSave={saveSettings}
-        onBack={() => router.push(`/projects/${projectId}/release-notes`)}
-      />
-    );
-  }
-  if (view === "overview") {
-    return (
-      <ProductUpdatesOverview
-        updates={updates}
-        onNew={() => router.push(`/projects/${projectId}/release-notes/new`)}
-        onEdit={(id) =>
-          router.push(`/projects/${projectId}/release-notes/${id}`)
-        }
-        onSettings={() =>
-          router.push(`/projects/${projectId}/release-notes/settings`)
-        }
-        onAction={async (update, action) => {
-          if (
-            action === "delete" &&
-            !window.confirm(`Delete “${update.title}”? This cannot be undone.`)
-          )
-            return;
-          setSaving(true);
-          try {
-            await request(
-              `/api/projects/${projectId}/updates/${update.id}${action === "archive" || action === "restore" ? `/${action}` : ""}`,
-              {
-                method: action === "delete" ? "DELETE" : "POST",
-                headers: {
-                  "If-Match": formatVersionEtag(update.updated_at),
-                },
-              },
-            );
-            toast({
-              title:
-                action === "delete"
-                  ? "Update deleted"
-                  : action === "archive"
-                    ? "Update archived"
-                    : "Update restored",
-            });
-            await load();
-          } catch (error) {
-            toast({
-              title: `Could not ${action} update`,
-              description:
-                error instanceof Error ? error.message : "Try again.",
-              variant: "destructive",
-            });
-            await load();
-          } finally {
-            setSaving(false);
+      <>
+        <ProductUpdatesOverview
+          updates={updates}
+          onNew={() => router.push(`/projects/${projectId}/release-notes/new`)}
+          onEdit={(id) =>
+            router.push(`/projects/${projectId}/release-notes/${id}`)
           }
-        }}
-        busy={saving}
-      />
+          onSettings={() => setSettingsOpen(true)}
+          onAction={async (update, action) => {
+            if (
+              action === "delete" &&
+              !window.confirm(`Delete “${update.title}”? This cannot be undone.`)
+            )
+              return;
+            setSaving(true);
+            try {
+              await request(
+                `/api/projects/${projectId}/updates/${update.id}${action === "archive" || action === "restore" ? `/${action}` : ""}`,
+                {
+                  method: action === "delete" ? "DELETE" : "POST",
+                  headers: {
+                    "If-Match": formatVersionEtag(update.updated_at),
+                  },
+                },
+              );
+              toast({
+                title:
+                  action === "delete"
+                    ? "Update deleted"
+                    : action === "archive"
+                      ? "Update archived"
+                      : "Update restored",
+              });
+              await load();
+            } catch (error) {
+              toast({
+                title: `Could not ${action} update`,
+                description:
+                  error instanceof Error ? error.message : "Try again.",
+                variant: "destructive",
+              });
+              await load();
+            } finally {
+              setSaving(false);
+            }
+          }}
+          busy={saving}
+        />
+        {settingsPanel}
+      </>
     );
   }
 
@@ -659,9 +674,7 @@ export function ProductUpdatesTab({
         <div className="flex flex-wrap gap-2">
           <Button
             variant="outline"
-            onClick={() =>
-              router.push(`/projects/${projectId}/release-notes/settings`)
-            }
+            onClick={() => setSettingsOpen(true)}
           >
             <Settings2 className="mr-2 h-4 w-4" />
             Display settings
@@ -1029,9 +1042,7 @@ export function ProductUpdatesTab({
           <Button
             className="w-full"
             variant="ghost"
-            onClick={() =>
-              router.push(`/projects/${projectId}/release-notes/settings`)
-            }
+            onClick={() => setSettingsOpen(true)}
           >
             <Settings2 className="mr-2 h-4 w-4" />
             Release note settings
@@ -1045,6 +1056,7 @@ export function ProductUpdatesTab({
           onClose={() => setPrivateTestOpen(false)}
         />
       )}
+      {settingsPanel}
     </div>
   );
 }


### PR DESCRIPTION
## What changed
- Replaced the standalone Product Update display-settings screen with an accessible right-side drawer.
- Opened the same drawer from the editor, overview, and legacy settings URLs.
- Preserved unsaved editor content while settings are open.
- Added focus trapping/restoration, Escape and backdrop dismissal, scroll locking, responsive full-width mobile behavior, save progress, and theme-token-based surfaces.
- Kept old `/release-notes/settings` and `/updates/settings` links backward compatible; closing normalizes to the updates overview.

## Why
Display settings took authors away from the update they were editing, which hid context and risked disrupting their draft workflow.

## Validation
- `pnpm type-check`
- `pnpm lint`
- `pnpm test:unit` (158/158)
- `pnpm build`
- Authenticated browser QA on desktop and 390px mobile: right-side motion, focus/Escape, scroll lock, unsaved draft preservation, successful save, legacy path behavior, and zero runtime errors
- Disposable QA project and update removed after verification