### PR TITLE
Harden product-wide error recovery

### DIFF
--- a/docs/review/2026-07-30-comprehensive-product-engineering-ux-audit.md
+++ b/docs/review/2026-07-30-comprehensive-product-engineering-ux-audit.md
@@ -48,6 +48,9 @@ All five P0 issues are remediated in code and the hosted data. The dark-mode cri
 
 ### Verified remediation evidence
 
+- [fixed 2026-07-31] Product-wide form failures now use a shared field-error contract: invalid controls are visibly highlighted and programmatically marked, field-specific recovery copy stays beside the input, and persistent summaries preserve context across project creation/settings, account settings, feedback-form customization, integrations, public-board posting/reporting/moderation, and board publishing.
+- [fixed 2026-07-31] Native public-board alerts were replaced with accessible in-page recovery states; network failures preserve drafts, public report dialogs trap focus and close with Escape, and mobile page overflow is clipped at the application shell while intentional horizontal filter rails remain scrollable.
+- [verified 2026-07-31] Desktop and 320px authenticated browser checks covered project validation, account settings, inbox, billing, API/MCP, public directories, docs, system-theme default behavior, and Windows 98 propagation. No browser runtime errors were observed.
 - [fixed] Publishable `fb_pub_…` browser keys and hashed, scoped, revocable `fb_live_…` credentials are structurally separate; public-key rejection and legacy embed migration are unit-tested.
 - [fixed] The install snippet is always visible and browser-verified; no secret generation or fresh-key action gates installation.
 - [fixed] 1,036 historical E2E projects were quarantined, the final manual audit projects were quarantined, the last test board was unpublished/unlisted, and live checks report zero active E2E projects and zero listed production test boards.
@@ -59,7 +62,7 @@ All five P0 issues are remediated in code and the hosted data. The dark-mode cri
 - [fixed] Product Updates, inbox presentation, and integration operations are decomposed into focused domain modules without increasing route budgets.
 - [fixed] Documentation pages and individual code blocks expose revision `2026-07-30`; REST pagination guidance matches the cursor contract.
 - [fixed] Signed, replay-safe Resend delivery ingestion stores hashed recipients and suppresses future sends after bounces, complaints, or provider suppression.
-- [fixed] Production build, lint, type checks, 153 unit tests, widget size (16,996 bytes gzip), dashboard route budgets, expanded live-schema checks, live advisor review, and the production dependency audit pass.
+- [fixed] Production build, lint, type checks, 161 unit tests, widget size, dashboard route budgets, expanded live-schema checks, live advisor review, and the production dependency audit pass.
 - [blocked: explicit recurring-cost approval required] Separate Supabase preview/development/E2E branches cost $0.01344/hour each ($0.04032/hour for three) and were not created without the owner's explicit acceptance.
 - [blocked: external credentials and a real charge required] Production Dodo is configured in test mode; live product/webhook credentials and one controlled real transaction are still required. Production checkout fails closed until then.
 - [blocked: provider console configuration required] Add the production Resend signing secret and trigger one controlled bounce/complaint event before calling bounce operations live-proven.

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/customize-tab.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/customize-tab.tsx
@@ -16,6 +16,7 @@ import { toast } from '@/hooks/use-toast'
 import { WidgetFormPreview } from './widget-form-preview'
 import { PageHeader } from '@/components/ui/workspace-shell'
 import { formatVersionEtag } from '@/lib/optimistic-concurrency'
+import { FormErrorSummary } from '@/components/ui/field-error'
 
 interface CustomizeTabProps {
   project: Project
@@ -45,6 +46,7 @@ export function CustomizeTab({
   const appOrigin = publicEnv.NEXT_PUBLIC_APP_ORIGIN
   const previewProjectKey = projectKey
   const [saving, setSaving] = React.useState(false)
+  const [saveError, setSaveError] = React.useState('')
   const [draftRestored, setDraftRestored] = React.useState(false)
   const [draftHydrated, setDraftHydrated] = React.useState(false)
   const storageKey = React.useMemo(() => `feedbacks-widget-draft:${project.id}`, [project.id])
@@ -164,6 +166,7 @@ export function CustomizeTab({
 
   const updateConfig = (key: keyof WidgetConfig, value: unknown) => {
     setConfig((prev) => ({ ...prev, [key]: value }))
+    setSaveError('')
   }
 
   const handleReset = () => {
@@ -176,6 +179,7 @@ export function CustomizeTab({
 
   const handleSave = async () => {
     setSaving(true)
+    setSaveError('')
     try {
       const response = await fetch(`/api/projects/${project.id}`, {
         method: 'PATCH',
@@ -209,11 +213,7 @@ export function CustomizeTab({
       })
       router.refresh()
     } catch (error) {
-      toast({
-        title: 'Failed to save',
-        description: error instanceof Error ? error.message : 'Failed to save widget settings',
-        variant: 'destructive',
-      })
+      setSaveError(error instanceof Error ? error.message : 'Feedback form settings could not be saved. Check your connection and try again.')
     } finally {
       setSaving(false)
     }
@@ -494,6 +494,7 @@ export function CustomizeTab({
 
       {hasUnsavedChanges && (
         <div className="sticky bottom-[max(1rem,env(safe-area-inset-bottom))] z-20 rounded-lg border border-amber-300/80 bg-amber-50 p-3 shadow-lg dark:bg-amber-950">
+          <FormErrorSummary className="mb-3">{saveError}</FormErrorSummary>
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <p className="text-sm font-semibold text-foreground">Publish remote changes</p>

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/integrations-tab.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/integrations-tab.tsx
@@ -27,6 +27,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input'
 import { toast } from '@/hooks/use-toast'
 import { PageHeader } from '@/components/ui/workspace-shell'
+import { FormErrorSummary } from '@/components/ui/field-error'
 import {
   Github,
   Loader2,
@@ -154,6 +155,7 @@ export function IntegrationsTab({ project, initialBillingSummary }: Integrations
   const [billingSummary, setBillingSummary] = React.useState<BillingSummary | null>(initialBillingSummary)
   const [loadingOps, setLoadingOps] = React.useState(initialBillingSummary?.entitlements.webhooks !== false)
   const [saving, setSaving] = React.useState(false)
+  const [saveError, setSaveError] = React.useState('')
   const [testingKey, setTestingKey] = React.useState<string | null>(null)
   const [resendingId, setResendingId] = React.useState<string | null>(null)
   const [featureLocked, setFeatureLocked] = React.useState(initialBillingSummary?.entitlements.webhooks === false)
@@ -288,6 +290,7 @@ export function IntegrationsTab({ project, initialBillingSummary }: Integrations
 
   const handleSave = async () => {
     setSaving(true)
+    setSaveError('')
     try {
       const response = await fetch(`/api/projects/${project.id}/webhooks`, {
         method: 'PUT',
@@ -313,11 +316,7 @@ export function IntegrationsTab({ project, initialBillingSummary }: Integrations
       toast({ title: 'Integrations saved' })
       await loadOperations()
     } catch (error) {
-      toast({
-        title: 'Failed to save integrations',
-        description: error instanceof Error ? error.message : 'Failed to save integrations',
-        variant: 'destructive',
-      })
+      setSaveError(error instanceof Error ? error.message : 'Integrations could not be saved. Check the endpoint details and try again.')
     } finally {
       setSaving(false)
     }
@@ -690,13 +689,15 @@ export function IntegrationsTab({ project, initialBillingSummary }: Integrations
           </Card>
 
           {isDirty && (
-            <div className="sticky bottom-[calc(1rem+env(safe-area-inset-bottom,0px))] z-20 flex flex-wrap items-center justify-between gap-3 rounded-lg border bg-background/95 p-3 shadow-xl backdrop-blur">
-              <p className="text-sm text-muted-foreground">You have unsaved integration changes.</p>
-              <div className="flex gap-2">
+            <div className="sticky bottom-[calc(1rem+env(safe-area-inset-bottom,0px))] z-20 rounded-lg border bg-background/95 p-3 shadow-xl backdrop-blur">
+              <FormErrorSummary className="mb-3">{saveError}</FormErrorSummary>
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <p className="text-sm text-muted-foreground">You have unsaved integration changes.</p>
+                <div className="flex gap-2">
                 <Button
                   variant="outline"
                   disabled={saving}
-                  onClick={() => setConfig(savedConfig)}
+                  onClick={() => { setConfig(savedConfig); setSaveError('') }}
                 >
                   Discard
                 </Button>
@@ -704,6 +705,7 @@ export function IntegrationsTab({ project, initialBillingSummary }: Integrations
                   {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                   Save integrations
                 </Button>
+                </div>
               </div>
             </div>
           )}

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/project-tabs.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/project-tabs.tsx
@@ -23,6 +23,8 @@ import { SetupProgress } from './project-flow-nav'
 import { ProjectHome } from './project-home'
 import { PageHeader } from '@/components/ui/workspace-shell'
 import { formatVersionEtag } from '@/lib/optimistic-concurrency'
+import { FieldError, FormErrorSummary } from '@/components/ui/field-error'
+import { readErrorMessage, readFieldErrors, type FieldErrors } from '@/lib/form-errors'
 
 function SectionLoading() {
   return <div className="rounded-lg border bg-card p-6 text-sm text-muted-foreground">Loading this workspace…</div>
@@ -186,71 +188,77 @@ function SettingsTab({ project }: { project: Project }) {
   const [confirmDelete, setConfirmDelete] = React.useState(false)
   const [deleteInput, setDeleteInput] = React.useState('')
   const [projectVersion, setProjectVersion] = React.useState(project.updated_at)
+  const [saveError, setSaveError] = React.useState('')
+  const [fieldErrors, setFieldErrors] = React.useState<FieldErrors>({})
+  const [deleteError, setDeleteError] = React.useState('')
 
   const handleSave = async () => {
     setSaving(true)
+    setSaveError('')
+    setFieldErrors({})
     const origins = parseAllowedOrigins(allowedOriginsText)
 
     if (restrictOrigins && origins.length === 0) {
       setSaving(false)
-      toast({
-        title: 'Add at least one allowed site',
-        description: 'Use full URLs like https://example.com, one per line.',
-        variant: 'destructive',
-      })
+      setFieldErrors({ origins: 'Add at least one full URL, such as https://example.com.' })
+      setSaveError('Review the highlighted allowed sites before saving.')
       return
     }
 
-    const response = await fetch(`/api/projects/${project.id}`, {
-      method: 'PATCH',
-      headers: {
-        'Content-Type': 'application/json',
-        'If-Match': formatVersionEtag(projectVersion),
-      },
-      body: JSON.stringify({
-        name: name.trim(),
-        domain: domain.trim() || null,
-        settings: {
-          widget_origin_restriction: {
-            enabled: restrictOrigins,
-            origins,
-          },
+    try {
+      const response = await fetch(`/api/projects/${project.id}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'If-Match': formatVersionEtag(projectVersion),
         },
-      }),
-    })
-    const payload = await response.json().catch(() => null)
-    setSaving(false)
-    if (!response.ok) {
-      toast({
-        title: 'Failed to save settings',
-        description: payload?.error || 'Please try again.',
-        variant: 'destructive',
+        body: JSON.stringify({
+          name: name.trim(),
+          domain: domain.trim() || null,
+          settings: {
+            widget_origin_restriction: {
+              enabled: restrictOrigins,
+              origins,
+            },
+          },
+        }),
       })
-      return
+      const payload = await response.json().catch(() => null)
+      if (!response.ok) {
+        setFieldErrors(readFieldErrors(payload))
+        setSaveError(readErrorMessage(payload, 'Project settings could not be saved. Check your connection and try again.'))
+        return
+      }
+      setProjectVersion(payload.updated_at)
+      toast({ title: 'Project settings saved' })
+      router.refresh()
+    } catch {
+      setSaveError('Project settings could not be saved. Check your connection and try again.')
+    } finally {
+      setSaving(false)
     }
-    setProjectVersion(payload.updated_at)
-    toast({ title: 'Project settings saved' })
-    router.refresh()
   }
 
   const handleDelete = async () => {
     setDeleting(true)
-    const response = await fetch(`/api/projects/${project.id}`, { method: 'DELETE' })
-    const payload = await response.json().catch(() => null)
-    if (!response.ok) {
-      toast({
-        title: 'Failed to delete project',
-        description: payload?.error || 'Please try again.',
-        variant: 'destructive',
-      })
+    setDeleteError('')
+    try {
+      const response = await fetch(`/api/projects/${project.id}`, { method: 'DELETE' })
+      const payload = await response.json().catch(() => null)
+      if (!response.ok) {
+        setDeleteError(readErrorMessage(payload, 'The project could not be deleted. Check your connection and try again.'))
+        return
+      }
+      window.dispatchEvent(
+        new CustomEvent('feedbacks:project-deleted', { detail: { projectId: project.id } }),
+      )
+      router.replace('/projects')
+      router.refresh()
+    } catch {
+      setDeleteError('The project could not be deleted. Check your connection and try again.')
+    } finally {
       setDeleting(false)
-      return
     }
-    window.dispatchEvent(
-      new CustomEvent('feedbacks:project-deleted', { detail: { projectId: project.id } }),
-    )
-    router.replace('/projects')
-    router.refresh()
   }
 
   return (
@@ -263,16 +271,20 @@ function SettingsTab({ project }: { project: Project }) {
         <CardContent className="space-y-4">
           <div className="space-y-2">
             <Label htmlFor="project-name">Project Name</Label>
-            <Input id="project-name" value={name} onChange={(e) => setName(e.target.value)} />
+            <Input id="project-name" value={name} onChange={(e) => { setName(e.target.value); setFieldErrors((current) => ({ ...current, name: '' })) }} aria-invalid={Boolean(fieldErrors.name)} aria-describedby={fieldErrors.name ? 'project-settings-name-error' : undefined} maxLength={80} />
+            <FieldError id="project-settings-name-error">{fieldErrors.name}</FieldError>
           </div>
           <div className="space-y-2">
             <Label htmlFor="project-domain">Domain</Label>
             <Input
               id="project-domain"
               value={domain}
-              onChange={(e) => setDomain(e.target.value)}
+              onChange={(e) => { setDomain(e.target.value); setFieldErrors((current) => ({ ...current, domain: '' })) }}
               placeholder="myapp.com"
+              aria-invalid={Boolean(fieldErrors.domain)}
+              aria-describedby={fieldErrors.domain ? 'project-settings-domain-error' : undefined}
             />
+            <FieldError id="project-settings-domain-error">{fieldErrors.domain}</FieldError>
           </div>
           <div className="rounded-lg border border-border/80 bg-muted/30 p-4">
             <div className="flex items-start gap-3">
@@ -292,18 +304,22 @@ function SettingsTab({ project }: { project: Project }) {
                 </p>
                 <Textarea
                   value={allowedOriginsText}
-                  onChange={(event) => setAllowedOriginsText(event.target.value)}
+                  onChange={(event) => { setAllowedOriginsText(event.target.value); setFieldErrors((current) => ({ ...current, origins: '' })) }}
                   placeholder={`https://example.com\nhttps://app.example.com`}
                   rows={3}
                   disabled={!restrictOrigins}
                   aria-label="Allowed widget origins"
+                  aria-invalid={Boolean(fieldErrors.origins)}
+                  aria-describedby={fieldErrors.origins ? 'project-origins-error' : undefined}
                 />
+                <FieldError id="project-origins-error">{fieldErrors.origins}</FieldError>
                 <p className="text-xs text-muted-foreground">
                   One origin per line. Use only scheme and domain, like https://example.com. Do not include paths.
                 </p>
               </div>
             </div>
           </div>
+          <FormErrorSummary>{saveError}</FormErrorSummary>
           <Button onClick={handleSave} disabled={saving}>
             {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
             Save
@@ -350,6 +366,7 @@ function SettingsTab({ project }: { project: Project }) {
                   Cancel
                 </Button>
               </div>
+              <FormErrorSummary>{deleteError}</FormErrorSummary>
             </div>
           )}
         </CardContent>

--- a/packages/dashboard/src/app/(dashboard)/projects/new/page.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/new/page.tsx
@@ -11,6 +11,8 @@ import Link from 'next/link'
 import { cn } from '@/lib/utils'
 import { DEFAULT_PROJECT_ICON, PROJECT_ICONS } from '@/lib/project-icons'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { FieldError, FormErrorSummary } from '@/components/ui/field-error'
+import { readErrorMessage, readFieldErrors, type FieldErrors } from '@/lib/form-errors'
 
 export default function NewProjectPage() {
   const [name, setName] = React.useState('')
@@ -18,6 +20,7 @@ export default function NewProjectPage() {
   const [icon, setIcon] = React.useState<string>(DEFAULT_PROJECT_ICON)
   const [loading, setLoading] = React.useState(false)
   const [error, setError] = React.useState('')
+  const [fieldErrors, setFieldErrors] = React.useState<FieldErrors>({})
   const [limitMessage, setLimitMessage] = React.useState('')
   const creationRequestId = React.useRef('')
   const router = useRouter()
@@ -27,6 +30,7 @@ export default function NewProjectPage() {
     if (!name.trim()) return
     setLoading(true)
     setError('')
+    setFieldErrors({})
     setLimitMessage('')
     if (!creationRequestId.current && typeof crypto.randomUUID === 'function') {
       creationRequestId.current = crypto.randomUUID()
@@ -51,7 +55,8 @@ export default function NewProjectPage() {
         if (payload.code === 'project_limit_reached') {
           setLimitMessage(payload.error || 'Free plan includes 2 projects. Upgrade to Pro to create more.')
         }
-        setError(payload.error || 'Failed to create project')
+        setFieldErrors(readFieldErrors(payload))
+        setError(readErrorMessage(payload, 'The project could not be created. Check your connection and try again.'))
         return
       }
 
@@ -61,7 +66,7 @@ export default function NewProjectPage() {
       router.push(`/projects/${payload.id}/install?created=1`)
       router.refresh()
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : 'Failed to create project')
+      setError(caught instanceof Error ? caught.message : 'The project could not be created. Check your connection and try again.')
     } finally {
       setLoading(false)
     }
@@ -91,15 +96,18 @@ export default function NewProjectPage() {
                 id="name"
                 placeholder="For example: Acme"
                 value={name}
-                onChange={(e) => setName(e.target.value)}
+                onChange={(e) => { setName(e.target.value); setFieldErrors((current) => ({ ...current, name: '' })) }}
+                aria-invalid={Boolean(fieldErrors.name)}
+                aria-describedby={fieldErrors.name ? 'project-name-error' : 'project-name-help'}
                 required
                 autoFocus
                 maxLength={80}
                 className="h-12 text-base"
               />
-              <p className="text-xs text-muted-foreground">
+              <p id="project-name-help" className="text-xs text-muted-foreground">
                 Use the name your users know. You can change it later.
               </p>
+              <FieldError id="project-name-error">{fieldErrors.name}</FieldError>
             </div>
 
             <details className="overflow-hidden rounded-lg border bg-[oklch(var(--surface-raised))] px-4">
@@ -116,7 +124,7 @@ export default function NewProjectPage() {
                         <button
                           key={option.emoji}
                           type="button"
-                          onClick={() => setIcon(option.emoji)}
+                          onClick={() => { setIcon(option.emoji); setFieldErrors((current) => ({ ...current, icon: '' })) }}
                           className={cn(
                             'relative flex h-10 items-center justify-center rounded-md border text-lg transition-colors',
                             'hover:border-primary/40 hover:bg-primary/[0.05] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
@@ -137,6 +145,7 @@ export default function NewProjectPage() {
                     })}
                   </div>
                   <p className="text-xs text-muted-foreground">This makes projects easier to spot in the menu.</p>
+                  <FieldError id="project-icon-error">{fieldErrors.icon}</FieldError>
                 </fieldset>
                 <div className="space-y-2">
                   <Label htmlFor="domain">Domain (optional)</Label>
@@ -144,17 +153,18 @@ export default function NewProjectPage() {
                     id="domain"
                     placeholder="myapp.com"
                     value={domain}
-                    onChange={(e) => setDomain(e.target.value)}
+                    onChange={(e) => { setDomain(e.target.value); setFieldErrors((current) => ({ ...current, domain: '' })) }}
+                    aria-invalid={Boolean(fieldErrors.domain)}
+                    aria-describedby={fieldErrors.domain ? 'project-domain-error' : 'project-domain-help'}
                   />
-                  <p className="text-xs text-muted-foreground">
+                  <p id="project-domain-help" className="text-xs text-muted-foreground">
                     You do not need this to set up the feedback form.
                   </p>
+                  <FieldError id="project-domain-error">{fieldErrors.domain}</FieldError>
                 </div>
               </div>
             </details>
-            {error && (
-              <p role="alert" className="text-sm text-destructive">{error}</p>
-            )}
+            <FormErrorSummary>{error}</FormErrorSummary>
             {limitMessage && (
               <div className="rounded-lg border border-primary/30 bg-primary/[0.04] p-4">
                 <p className="text-sm font-medium text-foreground">Free plan project limit reached</p>

--- a/packages/dashboard/src/app/(dashboard)/settings/page.tsx
+++ b/packages/dashboard/src/app/(dashboard)/settings/page.tsx
@@ -12,6 +12,7 @@ import { PageHeader } from '@/components/ui/workspace-shell'
 import { AlertTriangle, Loader2, Mail } from 'lucide-react'
 import { toast } from '@/hooks/use-toast'
 import Link from 'next/link'
+import { FieldError, FormErrorSummary } from '@/components/ui/field-error'
 
 export default function SettingsPage() {
   const supabase = React.useMemo(() => createClient(), [])
@@ -28,6 +29,9 @@ export default function SettingsPage() {
   const [deleting, setDeleting] = React.useState(false)
   const [deleteConfirmation, setDeleteConfirmation] = React.useState('')
   const [saveState, setSaveState] = React.useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+  const [saveError, setSaveError] = React.useState('')
+  const [nameError, setNameError] = React.useState('')
+  const [deleteError, setDeleteError] = React.useState('')
   const savedValues = React.useRef('')
 
   const currentValues = JSON.stringify({
@@ -79,6 +83,8 @@ export default function SettingsPage() {
   const handleSaveProfile = async () => {
     setSaving(true)
     setSaveState('saving')
+    setSaveError('')
+    setNameError('')
     const { error } = await supabase.auth.updateUser({
       data: { full_name: displayName.trim() },
     })
@@ -102,11 +108,9 @@ export default function SettingsPage() {
       : { error: null }
     setSaving(false)
     if (error || settingsResult.error) {
-      toast({
-        title: 'Failed to save profile',
-        description: error?.message || settingsResult.error?.message || 'Please try again.',
-        variant: 'destructive',
-      })
+      const message = error?.message || settingsResult.error?.message || 'Account settings could not be saved. Check your connection and try again.'
+      setSaveError(message)
+      if (error) setNameError(message)
       setSaveState('error')
       return
     }
@@ -117,6 +121,7 @@ export default function SettingsPage() {
 
   const handleDeleteAccount = async () => {
     setDeleting(true)
+    setDeleteError('')
     try {
       const response = await fetch('/api/account/delete', {
         method: 'POST',
@@ -132,11 +137,7 @@ export default function SettingsPage() {
       toast({ title: payload.pending ? 'Account deletion queued' : 'Account deleted', description: payload.message })
       window.location.href = '/auth'
     } catch (error) {
-      toast({
-        title: 'Failed to delete account',
-        description: error instanceof Error ? error.message : 'Please try again.',
-        variant: 'destructive',
-      })
+      setDeleteError(error instanceof Error ? error.message : 'The account could not be deleted. Check your connection and try again.')
     } finally {
       setDeleting(false)
     }
@@ -200,11 +201,15 @@ export default function SettingsPage() {
               <Input
                 id="settings-name"
                 value={displayName}
-                onChange={(e) => { setDisplayName(e.target.value); setSaveState('idle') }}
+                onChange={(e) => { setDisplayName(e.target.value); setSaveState('idle'); setNameError(''); setSaveError('') }}
                 placeholder="Your name"
                 maxLength={80}
+                aria-invalid={Boolean(nameError)}
+                aria-describedby={nameError ? 'settings-name-error' : undefined}
               />
+              <FieldError id="settings-name-error">{nameError}</FieldError>
             </div>
+            <FormErrorSummary>{saveError}</FormErrorSummary>
             <Button onClick={handleSaveProfile} disabled={saving || !hasUnsavedChanges}>
               {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               Save account settings
@@ -356,9 +361,12 @@ export default function SettingsPage() {
             <Input
               id="delete-confirmation"
               value={deleteConfirmation}
-              onChange={(event) => setDeleteConfirmation(event.target.value)}
+              onChange={(event) => { setDeleteConfirmation(event.target.value); setDeleteError('') }}
               placeholder={email || 'you@example.com'}
+              aria-invalid={Boolean(deleteError)}
+              aria-describedby={deleteError ? 'delete-account-error' : undefined}
             />
+            <FieldError id="delete-account-error">{deleteError}</FieldError>
           </div>
           <Button
             variant="destructive"

--- a/packages/dashboard/src/app/api/boards/[slug]/report/route.ts
+++ b/packages/dashboard/src/app/api/boards/[slug]/report/route.ts
@@ -50,15 +50,24 @@ export async function POST(
   const reporterEmail = typeof body.email === 'string' ? body.email.trim() : ''
 
   if (!reason || reason.length > 160) {
-    return NextResponse.json({ error: 'Please share a short reason (1-160 characters).' }, { status: 400 })
+    return NextResponse.json({
+      error: 'Review the highlighted report reason.',
+      fieldErrors: { reason: ['Share a short reason between 1 and 160 characters.'] },
+    }, { status: 400 })
   }
 
   if (details.length > 2000) {
-    return NextResponse.json({ error: 'Report details are too long.' }, { status: 400 })
+    return NextResponse.json({
+      error: 'Review the highlighted report details.',
+      fieldErrors: { details: ['Keep report details under 2,000 characters.'] },
+    }, { status: 400 })
   }
 
   if (reporterEmail && !EMAIL_RE.test(reporterEmail)) {
-    return NextResponse.json({ error: 'Please enter a valid email address or leave it blank.' }, { status: 400 })
+    return NextResponse.json({
+      error: 'Review the highlighted email address.',
+      fieldErrors: { email: ['Enter a valid email address or leave it blank.'] },
+    }, { status: 400 })
   }
 
   const supabase = await createServerSupabase()

--- a/packages/dashboard/src/app/api/boards/[slug]/submit/route.ts
+++ b/packages/dashboard/src/app/api/boards/[slug]/submit/route.ts
@@ -74,21 +74,33 @@ export async function POST(
   }
 
   if (!message || typeof message !== 'string' || message.trim().length < 5) {
-    return NextResponse.json({ error: 'Message must be at least 5 characters' }, { status: 400 })
+    return NextResponse.json({
+      error: 'Review the highlighted request title.',
+      fieldErrors: { title: ['Write at least 5 characters so the team knows what you need.'] },
+    }, { status: 400 })
   }
 
   if (message.length > 2000) {
-    return NextResponse.json({ error: 'Message too long (max 2000 chars)' }, { status: 400 })
+    return NextResponse.json({
+      error: 'Review the highlighted request details.',
+      fieldErrors: { details: ['Keep the title and details under 2,000 characters total.'] },
+    }, { status: 400 })
   }
 
   // Validate email if provided
   const trimmedEmail = email?.trim() || null
   if (trimmedEmail && !EMAIL_RE.test(trimmedEmail)) {
-    return NextResponse.json({ error: 'Invalid email format' }, { status: 400 })
+    return NextResponse.json({
+      error: 'Review the highlighted email address.',
+      fieldErrors: { email: ['Enter a valid email address or leave it blank.'] },
+    }, { status: 400 })
   }
 
   if (isLikelySpam(message)) {
-    return NextResponse.json({ error: 'This message looks automated or overly repetitive. Please rewrite it more clearly.' }, { status: 400 })
+    return NextResponse.json({
+      error: 'Rewrite the highlighted request before posting.',
+      fieldErrors: { title: ['This looks automated or overly repetitive. Rewrite it in your own words.'] },
+    }, { status: 400 })
   }
 
   const allowedTypes = board.show_types || ['idea', 'bug']

--- a/packages/dashboard/src/app/api/projects/[id]/board/route.ts
+++ b/packages/dashboard/src/app/api/projects/[id]/board/route.ts
@@ -213,7 +213,10 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     const body = bodyResult.data
     const slug = sanitizeSlug(body.slug)
     if (!slug) {
-      return NextResponse.json({ error: 'A board slug is required' }, { status: 400 })
+      return NextResponse.json({
+        error: 'Review the highlighted public link.',
+        fieldErrors: { slug: ['Enter at least one letter or number for the public link.'] },
+      }, { status: 400 })
     }
 
     let customCss: string | null

--- a/packages/dashboard/src/app/api/projects/[id]/route.ts
+++ b/packages/dashboard/src/app/api/projects/[id]/route.ts
@@ -91,12 +91,18 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     const updates: Record<string, unknown> = { updated_at: new Date().toISOString() }
     if (body.name !== undefined) {
       const name = body.name?.trim()
-      if (!name || name.length > 80) return NextResponse.json({ error: 'Project name must be 1–80 characters.' }, { status: 400 })
+      if (!name || name.length > 80) return NextResponse.json({
+        error: 'Review the highlighted project name.',
+        fieldErrors: { name: ['Project name must be 1–80 characters.'] },
+      }, { status: 400 })
       updates.name = name
     }
     if (body.domain !== undefined) {
       const domain = normalizeProjectDomain(body.domain)
-      if (domain === undefined) return NextResponse.json({ error: 'Enter a valid website domain or URL.' }, { status: 400 })
+      if (domain === undefined) return NextResponse.json({
+        error: 'Review the highlighted domain.',
+        fieldErrors: { domain: ['Enter a valid website domain or URL.'] },
+      }, { status: 400 })
       updates.domain = domain
     }
 

--- a/packages/dashboard/src/app/api/projects/route.ts
+++ b/packages/dashboard/src/app/api/projects/route.ts
@@ -79,16 +79,25 @@ export async function POST(request: NextRequest) {
 
     const name = body.name?.trim()
     if (!name || name.length < 1 || name.length > 80) {
-      return NextResponse.json({ error: 'Project name is required (1–80 characters)' }, { status: 400 })
+      return NextResponse.json({
+        error: 'Review the highlighted project name.',
+        fieldErrors: { name: ['Project name must be 1–80 characters.'] },
+      }, { status: 400 })
     }
 
     const domain = normalizeProjectDomain(body.domain)
     if (domain === undefined) {
-      return NextResponse.json({ error: 'Enter a valid website domain or URL' }, { status: 400 })
+      return NextResponse.json({
+        error: 'Review the highlighted domain.',
+        fieldErrors: { domain: ['Enter a valid website domain or URL.'] },
+      }, { status: 400 })
     }
     const icon = body.icon === undefined ? DEFAULT_PROJECT_ICON : body.icon
     if (!isProjectIcon(icon)) {
-      return NextResponse.json({ error: 'Choose a valid project icon' }, { status: 400 })
+      return NextResponse.json({
+        error: 'Review the highlighted project icon.',
+        fieldErrors: { icon: ['Choose one of the available project icons.'] },
+      }, { status: 400 })
     }
 
     const rawApiKey = generateProjectApiKey()

--- a/packages/dashboard/src/app/globals.css
+++ b/packages/dashboard/src/app/globals.css
@@ -134,6 +134,7 @@
 
   body {
     @apply bg-background text-foreground;
+    overflow-x: clip;
     font-feature-settings: "rlig" 1, "calt" 1;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;

--- a/packages/dashboard/src/app/p/[slug]/public-board.tsx
+++ b/packages/dashboard/src/app/p/[slug]/public-board.tsx
@@ -68,6 +68,8 @@ export function PublicBoard({
   const [showRecommendations, setShowRecommendations] = React.useState(false)
   const [voteError, setVoteError] = React.useState<string | null>(null)
   const [followLoading, setFollowLoading] = React.useState(false)
+  const [actionError, setActionError] = React.useState<string | null>(null)
+  const [actionErrorId, setActionErrorId] = React.useState<string | null>(null)
   const votesKey = `votes:${board.slug}`
 
   const commentsByFeedback = React.useMemo(() => {
@@ -100,6 +102,8 @@ export function PublicBoard({
   const toggleFollow = async () => {
     if (followLoading) return
     setFollowLoading(true)
+    setActionError(null)
+    setActionErrorId(null)
     const following = !followed
     try {
       const response = await fetch(`/api/boards/${board.slug}/follow`, {
@@ -114,44 +118,62 @@ export function PublicBoard({
       }
 
       if (!response.ok) {
-        window.alert('Could not update your board follow right now.')
+        const payload = await response.json().catch(() => null)
+        setActionError(payload?.error || 'The board follow could not be updated. Check your connection and try again.')
         return
       }
 
       setFollowed(following)
+    } catch {
+      setActionError('The board follow could not be updated. Check your connection and try again.')
     } finally {
       setFollowLoading(false)
     }
   }
 
   const toggleWatched = async (feedbackId: string) => {
+    if (busyId) return
+    setBusyId(feedbackId)
+    setActionError(null)
+    setActionErrorId(null)
     const next = new Set(watchedIds)
     const watching = !next.has(feedbackId)
-    const response = await fetch(`/api/boards/${board.slug}/watch`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ feedback_id: feedbackId, watching }),
-    })
+    try {
+      const response = await fetch(`/api/boards/${board.slug}/watch`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ feedback_id: feedbackId, watching }),
+      })
 
-    if (response.status === 401) {
-      redirectToAuth()
-      return
+      if (response.status === 401) {
+        redirectToAuth()
+        return
+      }
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null)
+        setActionError(payload?.error || 'This watch could not be updated. Check your connection and try again.')
+        setActionErrorId(feedbackId)
+        return
+      }
+
+      if (watching) next.add(feedbackId)
+      else next.delete(feedbackId)
+      setWatchedIds(next)
+    } catch {
+      setActionError('This watch could not be updated. Check your connection and try again.')
+      setActionErrorId(feedbackId)
+    } finally {
+      setBusyId(null)
     }
-
-    if (!response.ok) {
-      window.alert('Could not update your watch right now.')
-      return
-    }
-
-    if (watching) next.add(feedbackId)
-    else next.delete(feedbackId)
-    setWatchedIds(next)
   }
 
   const handleVote = async (feedbackId: string) => {
     if (votingId) return
     setVotingId(feedbackId)
     setVoteError(null)
+    setActionError(null)
+    setActionErrorId(null)
     try {
       const response = await fetch(`/api/boards/${board.slug}/vote`, {
         method: 'POST',
@@ -175,6 +197,8 @@ export function PublicBoard({
       else next.delete(feedbackId)
       setVotedIds(next)
       writeSetStorage(votesKey, next)
+    } catch {
+      setVoteError('Your vote could not be saved. Check your connection and try again.')
     } finally {
       setVotingId(null)
     }
@@ -199,6 +223,8 @@ export function PublicBoard({
     const draft = replyDrafts[feedbackId]?.trim()
     if (!draft) return
     setBusyId(feedbackId)
+    setActionError(null)
+    setActionErrorId(null)
     try {
       const response = await fetch(`/api/boards/${board.slug}/comment`, {
         method: 'POST',
@@ -218,7 +244,8 @@ export function PublicBoard({
       ])
       setReplyDrafts((prev) => ({ ...prev, [feedbackId]: '' }))
     } catch (error) {
-      window.alert(error instanceof Error ? error.message : 'Failed to post public reply')
+      setActionError(error instanceof Error ? error.message : 'The public reply could not be posted. Try again.')
+      setActionErrorId(feedbackId)
     } finally {
       setBusyId(null)
     }
@@ -230,6 +257,8 @@ export function PublicBoard({
     value?: string,
   ) => {
     setBusyId(feedbackId)
+    setActionError(null)
+    setActionErrorId(null)
     try {
       const response = await fetch(`/api/boards/${board.slug}/moderate`, {
         method: 'POST',
@@ -247,7 +276,8 @@ export function PublicBoard({
           ),
         )
     } catch (error) {
-      window.alert(error instanceof Error ? error.message : 'Failed to update board item')
+      setActionError(error instanceof Error ? error.message : 'This board item could not be updated. Try again.')
+      setActionErrorId(feedbackId)
     } finally {
       setBusyId(null)
     }
@@ -346,6 +376,13 @@ export function PublicBoard({
           </div>
         )}
 
+        {actionError && (
+          <div role="alert" aria-live="assertive" className="mb-5 flex items-start justify-between gap-3 rounded-md border border-destructive/35 bg-destructive/[0.07] px-4 py-3 text-sm text-destructive">
+            <span>{actionError}</span>
+            <button type="button" className="shrink-0 font-semibold underline underline-offset-2" onClick={() => { setActionError(null); setActionErrorId(null) }}>Dismiss</button>
+          </div>
+        )}
+
         <div className="space-y-6">
           <BoardAnnouncements announcements={initialAnnouncements} />
 
@@ -388,6 +425,7 @@ export function PublicBoard({
                   canWatchUpdates={viewerSignedIn}
                   replyDraft={replyDrafts[item.id] || ''}
                   busy={busyId === item.id}
+                  actionError={actionErrorId === item.id ? actionError : null}
                   onVote={() => handleVote(item.id)}
                   onToggle={() => setExpandedId(expandedId === item.id ? null : item.id)}
                   onToggleWatch={() => void toggleWatched(item.id)}

--- a/packages/dashboard/src/components/board-settings/BoardAdvancedSection.tsx
+++ b/packages/dashboard/src/components/board-settings/BoardAdvancedSection.tsx
@@ -5,6 +5,8 @@ import { Badge } from '@/components/ui/badge'
 import { WorkspaceSection } from '@/components/ui/workspace-section'
 import { Loader2 } from 'lucide-react'
 import type { BoardReport } from '@/lib/types'
+import { FieldError } from '@/components/ui/field-error'
+import type { FieldErrors } from '@/lib/form-errors'
 
 interface BoardAdvancedSettings {
   custom_css: string
@@ -16,6 +18,7 @@ interface BoardAdvancedSectionProps {
   reports: BoardReport[]
   reportBusyId: string | null
   onReportStatusUpdate: (reportId: string, status: BoardReport['status']) => void
+  fieldErrors?: FieldErrors
 }
 
 function formatReportTarget(report: BoardReport): string {
@@ -34,6 +37,7 @@ export function BoardAdvancedSection({
   reports,
   reportBusyId,
   onReportStatusUpdate,
+  fieldErrors = {},
 }: BoardAdvancedSectionProps) {
   return (
     <div className="space-y-6">
@@ -41,12 +45,16 @@ export function BoardAdvancedSection({
         <summary className="cursor-pointer border-b bg-muted/25 px-5 py-4 text-base font-semibold">Custom CSS <span className="text-sm font-normal text-muted-foreground">· optional</span></summary>
         <div className="space-y-3 p-5 sm:p-6">
           <textarea
+            id="board-custom-css"
             value={settings.custom_css}
             onChange={(e) => onSettingsChange({ custom_css: e.target.value.slice(0, 6000) })}
             rows={6}
-            className="min-h-[160px] w-full rounded-md border bg-background px-3 py-2 font-mono text-sm"
+            aria-invalid={Boolean(fieldErrors.custom_css)}
+            aria-describedby={fieldErrors.custom_css ? 'board-custom-css-error' : undefined}
+            className="min-h-[160px] w-full rounded-md border bg-background px-3 py-2 font-mono text-sm aria-[invalid=true]:border-destructive aria-[invalid=true]:ring-1 aria-[invalid=true]:ring-destructive/35"
             placeholder=".feedbacks-board { --feedbacks-accent: #0f766e; }"
           />
+          <FieldError id="board-custom-css-error">{fieldErrors.custom_css}</FieldError>
           <p className="text-xs text-muted-foreground">
             Use this only if the color and logo settings are not enough.
           </p>

--- a/packages/dashboard/src/components/board-settings/BoardIdentitySection.tsx
+++ b/packages/dashboard/src/components/board-settings/BoardIdentitySection.tsx
@@ -5,6 +5,8 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { WorkspaceSection } from '@/components/ui/workspace-section'
 import type { BoardBranding } from '@/lib/public-board'
+import { FieldError } from '@/components/ui/field-error'
+import type { FieldErrors } from '@/lib/form-errors'
 
 interface BoardSettingsSlice {
   display_name: string
@@ -18,6 +20,7 @@ interface BoardIdentitySectionProps {
   onSettingsChange: (patch: Partial<BoardSettingsSlice>) => void
   onBrandingChange: (patch: Partial<BoardBranding>) => void
   slugManuallyEdited: React.RefObject<boolean>
+  fieldErrors?: FieldErrors
 }
 
 function slugify(text: string): string {
@@ -34,6 +37,7 @@ export function BoardIdentitySection({
   onSettingsChange,
   onBrandingChange,
   slugManuallyEdited,
+  fieldErrors = {},
 }: BoardIdentitySectionProps) {
   const [slugStatus, setSlugStatus] = React.useState<'idle' | 'checking' | 'available' | 'taken' | 'error'>('idle')
   const handleDisplayNameChange = (value: string) => {
@@ -103,7 +107,8 @@ export function BoardIdentitySection({
               value={settings.slug}
               onChange={(e) => handleSlugChange(e.target.value)}
               placeholder="my-product"
-              aria-describedby="board-slug-status"
+              aria-invalid={Boolean(fieldErrors.slug || slugStatus === 'taken')}
+              aria-describedby={fieldErrors.slug ? 'board-slug-error' : 'board-slug-status'}
             />
           </div>
           <p
@@ -117,6 +122,7 @@ export function BoardIdentitySection({
             {slugStatus === 'taken' && 'That link is already in use. Choose another slug.'}
             {slugStatus === 'error' && 'Availability could not be checked. It will be checked again when you save.'}
           </p>
+          <FieldError id="board-slug-error">{fieldErrors.slug}</FieldError>
         </div>
 
         <div className="grid gap-4 md:grid-cols-2">

--- a/packages/dashboard/src/components/board-settings/BoardSettingsTabs.tsx
+++ b/packages/dashboard/src/components/board-settings/BoardSettingsTabs.tsx
@@ -18,6 +18,8 @@ import { BoardVisibilitySection } from './BoardVisibilitySection'
 import { BoardAdvancedSection } from './BoardAdvancedSection'
 import { PageHeader } from '@/components/ui/workspace-shell'
 import { getMarketingOrigin } from '@/lib/domain-routing'
+import { FormErrorSummary } from '@/components/ui/field-error'
+import { readErrorMessage, readFieldErrors, type FieldErrors } from '@/lib/form-errors'
 
 interface BoardSettingsState {
   id?: string
@@ -103,22 +105,34 @@ interface BoardSettingsTabsProps {
 export function BoardSettingsTabs({ project }: BoardSettingsTabsProps) {
   const router = useRouter()
   const [loading, setLoading] = React.useState(true)
+  const [loadError, setLoadError] = React.useState('')
+  const [reloadKey, setReloadKey] = React.useState(0)
   const [saving, setSaving] = React.useState(false)
   const [activeTab, setActiveTab] = React.useState<TabId>('identity')
   const [settings, setSettings] = React.useState<BoardSettingsState>(createDefaultSettings(project))
   const [reports, setReports] = React.useState<BoardReport[]>([])
   const [stats, setStats] = React.useState<BoardStats>({ followerCount: 0, watchCount: 0, openReportCount: 0 })
   const [reportBusyId, setReportBusyId] = React.useState<string | null>(null)
+  const [saveError, setSaveError] = React.useState('')
+  const [fieldErrors, setFieldErrors] = React.useState<FieldErrors>({})
   const slugManuallyEdited = React.useRef(false)
 
   React.useEffect(() => {
     async function load() {
-      const response = await fetch(`/api/projects/${project.id}/board`, { cache: 'no-store' })
-      const data = await response.json().catch(() => null)
+      setLoading(true)
+      setLoadError('')
+      try {
+        const response = await fetch(`/api/projects/${project.id}/board`, { cache: 'no-store' })
+        const data = await response.json().catch(() => null)
 
-      if (response.ok && data?.board) {
-        const defaults = createDefaultSettings(project)
-        setSettings({
+        if (!response.ok) {
+          setLoadError(readErrorMessage(data, 'Board settings could not be loaded. Check your connection and try again.'))
+          return
+        }
+
+        if (data?.board) {
+          const defaults = createDefaultSettings(project)
+          setSettings({
           id: data.board.id,
           enabled: data.board.enabled,
           slug: data.board.slug,
@@ -135,20 +149,22 @@ export function BoardSettingsTabs({ project }: BoardSettingsTabsProps) {
           },
           announcements: data.board.announcements || [],
         })
-        setReports(data.reports || [])
-        setStats(data.stats || { followerCount: 0, watchCount: 0, openReportCount: 0 })
+          setReports(data.reports || [])
+          setStats(data.stats || { followerCount: 0, watchCount: 0, openReportCount: 0 })
 
-        // If there's already a slug, assume it was manually set
-        if (data.board.slug) {
-          slugManuallyEdited.current = true
+          if (data.board.slug) {
+            slugManuallyEdited.current = true
+          }
         }
+      } catch {
+        setLoadError('Board settings could not be loaded. Check your connection and try again.')
+      } finally {
+        setLoading(false)
       }
-
-      setLoading(false)
     }
 
     void load()
-  }, [project])
+  }, [project, reloadKey])
 
   const boardOrigin = typeof window !== 'undefined' && ['localhost', '127.0.0.1'].includes(window.location.hostname)
     ? window.location.origin
@@ -159,6 +175,11 @@ export function BoardSettingsTabs({ project }: BoardSettingsTabsProps) {
   const canOpenBoard = settings.enabled && !isLegacyPrivate
   const updateSettings = (patch: Partial<BoardSettingsState>) => {
     setSettings((prev) => ({ ...prev, ...patch }))
+    setFieldErrors((current) => {
+      const next = { ...current }
+      Object.keys(patch).forEach((key) => { delete next[key] })
+      return next
+    })
   }
 
   const updateBranding = (patch: Partial<BoardBranding>) => {
@@ -173,62 +194,72 @@ export function BoardSettingsTabs({ project }: BoardSettingsTabsProps) {
     successTitle = 'Board settings saved',
   ) => {
     setSaving(true)
+    setSaveError('')
+    setFieldErrors({})
 
-    const response = await fetch(`/api/projects/${project.id}/board`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        id: nextSettings.id,
-        enabled: nextSettings.enabled,
-        slug: nextSettings.slug,
-        display_name: nextSettings.display_name,
-        title: nextSettings.title,
-        description: nextSettings.description,
-        show_types: nextSettings.show_types,
-        allow_submissions: nextSettings.allow_submissions,
-        require_email_to_vote: nextSettings.require_email_to_vote,
-        custom_css: nextSettings.custom_css,
-        branding: {
-          ...nextSettings.branding,
-          displayName: nextSettings.display_name,
-        },
-        announcements: nextSettings.announcements,
-      }),
-    })
-    const payload = await response.json().catch(() => null)
-
-    if (!response.ok) {
-      toast({ title: 'Failed to save board settings', description: payload?.error || 'Please try again.', variant: 'destructive' })
-      setSaving(false)
-      return
-    }
-
-    if (payload?.board) {
-      const defaults = createDefaultSettings(project)
-      setSettings({
-        id: payload.board.id,
-        enabled: payload.board.enabled,
-        slug: payload.board.slug,
-        display_name: payload.board.display_name || '',
-        title: payload.board.title || '',
-        description: payload.board.description || '',
-        show_types: payload.board.show_types || ['idea', 'bug'],
-        allow_submissions: payload.board.allow_submissions,
-        require_email_to_vote: payload.board.require_email_to_vote,
-        custom_css: payload.board.custom_css || '',
-        branding: {
-          ...defaults.branding,
-          ...payload.board.profile,
-        },
-        announcements: payload.board.announcements || [],
+    try {
+      const response = await fetch(`/api/projects/${project.id}/board`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          id: nextSettings.id,
+          enabled: nextSettings.enabled,
+          slug: nextSettings.slug,
+          display_name: nextSettings.display_name,
+          title: nextSettings.title,
+          description: nextSettings.description,
+          show_types: nextSettings.show_types,
+          allow_submissions: nextSettings.allow_submissions,
+          require_email_to_vote: nextSettings.require_email_to_vote,
+          custom_css: nextSettings.custom_css,
+          branding: {
+            ...nextSettings.branding,
+            displayName: nextSettings.display_name,
+          },
+          announcements: nextSettings.announcements,
+        }),
       })
-      setReports(payload.reports || [])
-      setStats(payload.stats || { followerCount: 0, watchCount: 0, openReportCount: 0 })
-    }
+      const payload = await response.json().catch(() => null)
 
-    toast({ title: successTitle })
-    setSaving(false)
-    router.refresh()
+      if (!response.ok) {
+        const nextFieldErrors = readFieldErrors(payload)
+        setFieldErrors(nextFieldErrors)
+        setSaveError(readErrorMessage(payload, 'Board settings could not be saved. Check your connection and try again.'))
+        if (nextFieldErrors.slug) setActiveTab('identity')
+        else if (nextFieldErrors.custom_css) setActiveTab('advanced')
+        return
+      }
+
+      if (payload?.board) {
+        const defaults = createDefaultSettings(project)
+        setSettings({
+          id: payload.board.id,
+          enabled: payload.board.enabled,
+          slug: payload.board.slug,
+          display_name: payload.board.display_name || '',
+          title: payload.board.title || '',
+          description: payload.board.description || '',
+          show_types: payload.board.show_types || ['idea', 'bug'],
+          allow_submissions: payload.board.allow_submissions,
+          require_email_to_vote: payload.board.require_email_to_vote,
+          custom_css: payload.board.custom_css || '',
+          branding: {
+            ...defaults.branding,
+            ...payload.board.profile,
+          },
+          announcements: payload.board.announcements || [],
+        })
+        setReports(payload.reports || [])
+        setStats(payload.stats || { followerCount: 0, watchCount: 0, openReportCount: 0 })
+      }
+
+      toast({ title: successTitle })
+      router.refresh()
+    } catch {
+      setSaveError('Board settings could not be saved. Check your connection and try again.')
+    } finally {
+      setSaving(false)
+    }
   }
 
   const handleSave = async () => {
@@ -327,6 +358,18 @@ export function BoardSettingsTabs({ project }: BoardSettingsTabsProps) {
     )
   }
 
+  if (loadError) {
+    return (
+      <Card>
+        <CardHeader>
+          <p className="text-lg font-semibold text-foreground">Board settings are unavailable</p>
+          <p role="alert" className="mt-2 text-sm text-destructive">{loadError}</p>
+        </CardHeader>
+        <CardContent><Button onClick={() => setReloadKey((value) => value + 1)}>Try again</Button></CardContent>
+      </Card>
+    )
+  }
+
   return (
     <div className="space-y-5">
       <PageHeader
@@ -409,6 +452,7 @@ export function BoardSettingsTabs({ project }: BoardSettingsTabsProps) {
           onSettingsChange={updateSettings}
           onBrandingChange={updateBranding}
           slugManuallyEdited={slugManuallyEdited}
+          fieldErrors={fieldErrors}
         />
       )}
 
@@ -438,13 +482,17 @@ export function BoardSettingsTabs({ project }: BoardSettingsTabsProps) {
           reports={reports}
           reportBusyId={reportBusyId}
           onReportStatusUpdate={updateReportStatus}
+          fieldErrors={fieldErrors}
         />
       )}
 
-      <div className="sticky bottom-4 flex justify-end rounded-lg border bg-card p-3 shadow-[var(--shadow-float)]"><Button onClick={() => void handleSave()} disabled={saving}>
-        {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-        Save changes
-      </Button></div>
+      <div className="sticky bottom-4 rounded-lg border bg-card p-3 shadow-[var(--shadow-float)]">
+        <FormErrorSummary className="mb-3">{saveError}</FormErrorSummary>
+        <div className="flex justify-end"><Button onClick={() => void handleSave()} disabled={saving}>
+          {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          Save changes
+        </Button></div>
+      </div>
     </div>
   )
 }

--- a/packages/dashboard/src/components/boards/BoardFeedbackCard.tsx
+++ b/packages/dashboard/src/components/boards/BoardFeedbackCard.tsx
@@ -55,6 +55,7 @@ interface BoardFeedbackCardProps {
   canWatchUpdates: boolean
   replyDraft: string
   busy: boolean
+  actionError?: string | null
   onVote: () => void
   onToggle: () => void
   onToggleWatch: () => void
@@ -76,6 +77,7 @@ export function BoardFeedbackCard({
   canWatchUpdates,
   replyDraft,
   busy,
+  actionError,
   onVote,
   onToggle,
   onToggleWatch,
@@ -231,7 +233,9 @@ export function BoardFeedbackCard({
                     rows={3}
                     className="min-h-[112px] w-full rounded-lg border border-border bg-card px-3 py-2.5 text-sm"
                     placeholder="Share a public update or clarify the plan."
+                    aria-invalid={Boolean(actionError)}
                   />
+                  {actionError && <p role="alert" className="text-xs font-medium text-destructive">{actionError}</p>}
                   <button
                     onClick={onReplySubmit}
                     disabled={busy || replyDraft.trim().length === 0}

--- a/packages/dashboard/src/components/boards/BoardReportModal.tsx
+++ b/packages/dashboard/src/components/boards/BoardReportModal.tsx
@@ -4,6 +4,8 @@ import * as React from 'react'
 import { X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import type { ReportTarget } from './board-types'
+import { FieldError, FormErrorSummary } from '@/components/ui/field-error'
+import { readErrorMessage, readFieldErrors, type FieldErrors } from '@/lib/form-errors'
 
 interface BoardReportModalProps {
   slug: string
@@ -12,17 +14,43 @@ interface BoardReportModalProps {
 }
 
 export function BoardReportModal({ slug, target, onClose }: BoardReportModalProps) {
+  const dialogRef = React.useRef<HTMLDivElement>(null)
   const [reason, setReason] = React.useState('')
   const [details, setDetails] = React.useState('')
   const [email, setEmail] = React.useState('')
   const [submitting, setSubmitting] = React.useState(false)
   const [success, setSuccess] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
+  const [fieldErrors, setFieldErrors] = React.useState<FieldErrors>({})
+
+  React.useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
+    const previous = document.activeElement as HTMLElement | null
+    dialog.querySelector<HTMLElement>('input, textarea, button')?.focus()
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        onClose()
+        return
+      }
+      if (event.key !== 'Tab') return
+      const focusable = Array.from(dialog.querySelectorAll<HTMLElement>('button:not([disabled]), input:not([disabled]), textarea:not([disabled])')).filter((element) => element.offsetParent !== null)
+      if (!focusable.length) return
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      if (event.shiftKey && document.activeElement === first) { event.preventDefault(); last.focus() }
+      else if (!event.shiftKey && document.activeElement === last) { event.preventDefault(); first.focus() }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => { document.removeEventListener('keydown', handleKeyDown); previous?.focus() }
+  }, [onClose])
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault()
     setSubmitting(true)
     setError(null)
+    setFieldErrors({})
 
     try {
       const response = await fetch(`/api/boards/${slug}/report`, {
@@ -36,11 +64,14 @@ export function BoardReportModal({ slug, target, onClose }: BoardReportModalProp
         }),
       })
       const data = await response.json().catch(() => ({}))
-      if (!response.ok) throw new Error(data.error || 'Failed to save report')
+      if (!response.ok) {
+        setFieldErrors(readFieldErrors(data))
+        throw new Error(readErrorMessage(data, 'The report could not be saved. Check your connection and try again.'))
+      }
       setSuccess(true)
       window.setTimeout(onClose, 1000)
     } catch (reportError) {
-      setError(reportError instanceof Error ? reportError.message : 'Something went wrong')
+      setError(reportError instanceof Error ? reportError.message : 'The report could not be saved. Check your connection and try again.')
     } finally {
       setSubmitting(false)
     }
@@ -50,6 +81,7 @@ export function BoardReportModal({ slug, target, onClose }: BoardReportModalProp
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       <div className="fixed inset-0 bg-slate-950/55 backdrop-blur-sm" onClick={onClose} />
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="board-report-modal-title"
@@ -86,34 +118,52 @@ export function BoardReportModal({ slug, target, onClose }: BoardReportModalProp
             </div>
           </div>
         ) : (
-          <form onSubmit={handleSubmit} className="space-y-4 p-5">
-            <input
+          <form onSubmit={handleSubmit} aria-busy={submitting} className="space-y-4 p-5">
+            <div className="space-y-2">
+              <label htmlFor="board-report-reason" className="text-sm font-medium text-foreground">Reason</label>
+              <input
+              id="board-report-reason"
               value={reason}
-              onChange={(event) => setReason(event.target.value)}
-              aria-label="Report reason"
+              onChange={(event) => { setReason(event.target.value); setFieldErrors((current) => ({ ...current, reason: '' })) }}
+              aria-invalid={Boolean(fieldErrors.reason)}
+              aria-describedby={fieldErrors.reason ? 'board-report-reason-error' : undefined}
               placeholder="What needs review?"
-              className="h-11 w-full rounded-lg border border-border bg-background px-3 text-sm text-foreground"
+              className="h-11 w-full rounded-lg border border-border bg-background px-3 text-sm text-foreground aria-[invalid=true]:border-destructive aria-[invalid=true]:ring-1 aria-[invalid=true]:ring-destructive/35"
               maxLength={160}
               required
             />
-            <textarea
+              <FieldError id="board-report-reason-error">{fieldErrors.reason}</FieldError>
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="board-report-details" className="text-sm font-medium text-foreground">Details <span className="font-normal text-muted-foreground">Optional</span></label>
+              <textarea
+              id="board-report-details"
               value={details}
-              onChange={(event) => setDetails(event.target.value)}
-              aria-label="Report details"
+              onChange={(event) => { setDetails(event.target.value); setFieldErrors((current) => ({ ...current, details: '' })) }}
+              aria-invalid={Boolean(fieldErrors.details)}
+              aria-describedby={fieldErrors.details ? 'board-report-details-error' : undefined}
               rows={4}
-              className="min-h-[128px] w-full rounded-lg border border-border bg-background px-4 py-3 text-sm text-foreground outline-none transition focus:border-primary"
+              className="min-h-[128px] w-full rounded-lg border border-border bg-background px-4 py-3 text-sm text-foreground outline-none transition focus:border-primary aria-[invalid=true]:border-destructive aria-[invalid=true]:ring-1 aria-[invalid=true]:ring-destructive/35"
               placeholder="Optional details that help the team review this faster."
               maxLength={2000}
             />
-            <input
+              <FieldError id="board-report-details-error">{fieldErrors.details}</FieldError>
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="board-report-email" className="text-sm font-medium text-foreground">Email <span className="font-normal text-muted-foreground">Optional</span></label>
+              <input
+              id="board-report-email"
               type="email"
               value={email}
-              onChange={(event) => setEmail(event.target.value)}
-              aria-label="Email (optional)"
+              onChange={(event) => { setEmail(event.target.value); setFieldErrors((current) => ({ ...current, email: '' })) }}
+              aria-invalid={Boolean(fieldErrors.email)}
+              aria-describedby={fieldErrors.email ? 'board-report-email-error' : undefined}
               placeholder="Email (optional)"
-              className="h-11 w-full rounded-lg border border-border bg-background px-3 text-sm text-foreground"
+              className="h-11 w-full rounded-lg border border-border bg-background px-3 text-sm text-foreground aria-[invalid=true]:border-destructive aria-[invalid=true]:ring-1 aria-[invalid=true]:ring-destructive/35"
             />
-            {error && <p className="text-sm text-destructive">{error}</p>}
+              <FieldError id="board-report-email-error">{fieldErrors.email}</FieldError>
+            </div>
+            <FormErrorSummary>{error}</FormErrorSummary>
             <div className="flex flex-wrap items-center gap-3">
               <Button
                 type="submit"

--- a/packages/dashboard/src/components/boards/BoardSubmitForm.tsx
+++ b/packages/dashboard/src/components/boards/BoardSubmitForm.tsx
@@ -6,6 +6,8 @@ import { X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { typeConfig, type BoardSuggestion } from './board-types'
+import { FieldError, FormErrorSummary } from '@/components/ui/field-error'
+import { readErrorMessage, readFieldErrors, type FieldErrors } from '@/lib/form-errors'
 
 interface BoardSubmitFormProps {
   slug: string
@@ -24,6 +26,7 @@ export function BoardSubmitForm({ slug, showTypes, onClose, onSubmitted }: Board
   const [hp, setHp] = React.useState('')
   const [submitting, setSubmitting] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
+  const [fieldErrors, setFieldErrors] = React.useState<FieldErrors>({})
   const [suggestions, setSuggestions] = React.useState<BoardSuggestion[]>([])
   const message = [title.trim(), details.trim()].filter(Boolean).join('\n')
   const deferredMessage = React.useDeferredValue(message)
@@ -121,6 +124,7 @@ export function BoardSubmitForm({ slug, showTypes, onClose, onSubmitted }: Board
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault()
     setError(null)
+    setFieldErrors({})
     setSubmitting(true)
 
     try {
@@ -132,12 +136,13 @@ export function BoardSubmitForm({ slug, showTypes, onClose, onSubmitted }: Board
       const data = await response.json().catch(() => ({}))
       if (!response.ok) {
         if (Array.isArray(data.suggestions)) setSuggestions(data.suggestions)
-        throw new Error(data.error || 'Failed to submit')
+        setFieldErrors(readFieldErrors(data))
+        throw new Error(readErrorMessage(data, 'Your request could not be posted. Check your connection and try again.'))
       }
       window.sessionStorage.removeItem(draftKey)
       onSubmitted()
     } catch (submitError) {
-      setError(submitError instanceof Error ? submitError.message : 'Something went wrong')
+      setError(submitError instanceof Error ? submitError.message : 'Your request could not be posted. Check your connection and try again.')
     } finally {
       setSubmitting(false)
     }
@@ -197,7 +202,8 @@ export function BoardSubmitForm({ slug, showTypes, onClose, onSubmitted }: Board
 
           <div className="space-y-2">
             <label htmlFor="board-post-title" className="text-sm font-medium text-foreground">What do you need?</label>
-            <input id="board-post-title" value={title} onChange={(event) => setTitle(event.target.value)} className="h-11 w-full rounded-lg border border-border bg-background px-3 text-sm text-foreground outline-none transition focus:border-primary" placeholder="For example: Let me sort by date" required minLength={5} maxLength={140}/>
+            <input id="board-post-title" value={title} onChange={(event) => { setTitle(event.target.value); setFieldErrors((current) => ({ ...current, title: '' })) }} aria-invalid={Boolean(fieldErrors.title)} aria-describedby={fieldErrors.title ? 'board-post-title-error' : undefined} className="h-11 w-full rounded-lg border border-border bg-background px-3 text-sm text-foreground outline-none transition focus:border-primary aria-[invalid=true]:border-destructive aria-[invalid=true]:ring-1 aria-[invalid=true]:ring-destructive/35" placeholder="For example: Let me sort by date" required minLength={5} maxLength={140}/>
+            <FieldError id="board-post-title-error">{fieldErrors.title}</FieldError>
           </div>
 
           <div className="space-y-2">
@@ -205,12 +211,15 @@ export function BoardSubmitForm({ slug, showTypes, onClose, onSubmitted }: Board
             <textarea
             id="board-post-details"
             value={details}
-            onChange={(event) => setDetails(event.target.value)}
+            onChange={(event) => { setDetails(event.target.value); setFieldErrors((current) => ({ ...current, details: '' })) }}
             rows={4}
-            className="min-h-[112px] w-full rounded-lg border border-border bg-background px-3 py-3 text-sm text-foreground outline-none transition focus:border-primary"
+            aria-invalid={Boolean(fieldErrors.details)}
+            aria-describedby={fieldErrors.details ? 'board-post-details-error' : undefined}
+            className="min-h-[112px] w-full rounded-lg border border-border bg-background px-3 py-3 text-sm text-foreground outline-none transition focus:border-primary aria-[invalid=true]:border-destructive aria-[invalid=true]:ring-1 aria-[invalid=true]:ring-destructive/35"
             placeholder="Add a short example or tell the team where you got stuck."
             maxLength={1850}
           />
+            <FieldError id="board-post-details-error">{fieldErrors.details}</FieldError>
           </div>
 
           <div>
@@ -219,11 +228,14 @@ export function BoardSubmitForm({ slug, showTypes, onClose, onSubmitted }: Board
               id="board-post-email"
               type="email"
               value={email}
-              onChange={(event) => setEmail(event.target.value)}
+              onChange={(event) => { setEmail(event.target.value); setFieldErrors((current) => ({ ...current, email: '' })) }}
               placeholder="you@example.com"
-              className="h-11 w-full rounded-lg border border-border bg-background px-3 text-sm text-foreground"
+              aria-invalid={Boolean(fieldErrors.email)}
+              aria-describedby={fieldErrors.email ? 'board-post-email-error' : 'board-post-email-help'}
+              className="h-11 w-full rounded-lg border border-border bg-background px-3 text-sm text-foreground aria-[invalid=true]:border-destructive aria-[invalid=true]:ring-1 aria-[invalid=true]:ring-destructive/35"
             />
-            <p className="mt-1.5 text-xs text-muted-foreground">The team can use this to ask a question. It is not shown on the board.</p>
+            <p id="board-post-email-help" className="mt-1.5 text-xs text-muted-foreground">The team can use this to ask a question. It is not shown on the board.</p>
+            <FieldError id="board-post-email-error" className="mt-1.5">{fieldErrors.email}</FieldError>
           </div>
 
           <input
@@ -262,7 +274,7 @@ export function BoardSubmitForm({ slug, showTypes, onClose, onSubmitted }: Board
             </div>
           )}
 
-          {error && <p role="alert" className="text-sm text-destructive">{error}</p>}
+          <FormErrorSummary>{error}</FormErrorSummary>
 
           <div className="flex flex-wrap items-center gap-3">
             <Button

--- a/packages/dashboard/src/components/ui/field-error.tsx
+++ b/packages/dashboard/src/components/ui/field-error.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react'
+import { AlertCircle } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export function FieldError({ id, children, className }: { id: string; children?: React.ReactNode; className?: string }) {
+  if (!children) return null
+
+  return (
+    <p id={id} role="alert" className={cn('flex items-start gap-1.5 text-xs font-medium text-destructive', className)}>
+      <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+      <span>{children}</span>
+    </p>
+  )
+}
+
+export function FormErrorSummary({ children, className }: { children?: React.ReactNode; className?: string }) {
+  if (!children) return null
+
+  return (
+    <div role="alert" aria-live="assertive" className={cn('rounded-md border border-destructive/35 bg-destructive/[0.07] px-3 py-2.5 text-sm text-destructive', className)}>
+      {children}
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/ui/input.tsx
+++ b/packages/dashboard/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 aria-[invalid=true]:border-destructive aria-[invalid=true]:ring-1 aria-[invalid=true]:ring-destructive/35 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/packages/dashboard/src/components/ui/textarea.tsx
+++ b/packages/dashboard/src/components/ui/textarea.tsx
@@ -8,7 +8,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 aria-[invalid=true]:border-destructive aria-[invalid=true]:ring-1 aria-[invalid=true]:ring-destructive/35 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/packages/dashboard/src/lib/form-errors.ts
+++ b/packages/dashboard/src/lib/form-errors.ts
@@ -1,0 +1,22 @@
+export type FieldErrors = Record<string, string>
+
+export type ErrorPayload = {
+  error?: unknown
+  code?: unknown
+  fieldErrors?: Record<string, unknown>
+}
+
+export function readFieldErrors(payload: ErrorPayload | null | undefined): FieldErrors {
+  if (!payload?.fieldErrors || typeof payload.fieldErrors !== 'object') return {}
+
+  return Object.fromEntries(
+    Object.entries(payload.fieldErrors).flatMap(([field, value]) => {
+      const message = Array.isArray(value) ? value.find((entry) => typeof entry === 'string') : value
+      return typeof message === 'string' && message.trim() ? [[field, message.trim()]] : []
+    }),
+  )
+}
+
+export function readErrorMessage(payload: ErrorPayload | null | undefined, fallback: string): string {
+  return typeof payload?.error === 'string' && payload.error.trim() ? payload.error.trim() : fallback
+}

--- a/packages/dashboard/tests/unit/form-errors.test.ts
+++ b/packages/dashboard/tests/unit/form-errors.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { readErrorMessage, readFieldErrors } from '../../src/lib/form-errors.ts'
+
+test('normalizes API field errors without exposing invalid payload values', () => {
+  assert.deepEqual(readFieldErrors({
+    fieldErrors: {
+      name: ['Project name is required.'],
+      domain: 'Enter a valid domain.',
+      empty: [],
+      unsafe: { message: 'not accepted' },
+    },
+  }), {
+    name: 'Project name is required.',
+    domain: 'Enter a valid domain.',
+  })
+})
+
+test('uses actionable API messages and safe fallbacks', () => {
+  assert.equal(readErrorMessage({ error: 'Check the highlighted field.' }, 'Fallback'), 'Check the highlighted field.')
+  assert.equal(readErrorMessage({ error: { private: 'details' } }, 'Try again.'), 'Try again.')
+})

--- a/packages/dashboard/tests/unit/product-experience.test.ts
+++ b/packages/dashboard/tests/unit/product-experience.test.ts
@@ -221,3 +221,22 @@ test('public board directory owns a main landmark without nesting one in the das
   assert.match(directorySurface, /<Root/)
   assert.match(directorySurface, /<\/Root>/)
 })
+
+test('forms identify failed fields and public interactions avoid blocking browser alerts', () => {
+  const input = read('../../src/components/ui/input.tsx')
+  const textarea = read('../../src/components/ui/textarea.tsx')
+  const newProject = read('../../src/app/(dashboard)/projects/new/page.tsx')
+  const projectRoute = read('../../src/app/api/projects/route.ts')
+  const boardSubmit = read('../../src/components/boards/BoardSubmitForm.tsx')
+  const boardSubmitRoute = read('../../src/app/api/boards/[slug]/submit/route.ts')
+  const publicBoard = read('../../src/app/p/[slug]/public-board.tsx')
+
+  assert.match(input, /aria-\[invalid=true\]:border-destructive/)
+  assert.match(textarea, /aria-\[invalid=true\]:border-destructive/)
+  assert.match(newProject, /project-name-error/)
+  assert.match(projectRoute, /fieldErrors: \{ name:/)
+  assert.match(boardSubmit, /board-post-email-error/)
+  assert.match(boardSubmitRoute, /fieldErrors: \{ email:/)
+  assert.doesNotMatch(publicBoard, /window\.alert/)
+  assert.match(publicBoard, /aria-live="assertive"/)
+})


### PR DESCRIPTION
## What changed
- Added a shared, accessible field-error contract and persistent error summaries across project, account, board, integrations, customization, and public submission flows.
- Replaced generic alerts and silent failures with actionable inline recovery, preserved user input, and retryable loading states.
- Added public-report focus trapping and Escape handling.
- Fixed narrow-screen horizontal overflow while preserving intended filter rails.
- Documented the verified product-wide remediation.

## Root cause
Several routes returned only generic error strings while clients relied on transient toasts or browser alerts. Users could not identify the invalid field or understand how to recover.

## Verification
- `pnpm type-check`
- `pnpm lint`
- `pnpm test:unit` — 161/161
- `pnpm build` — 62 static pages
- Authenticated browser QA at desktop and 320px widths
- Light, dark, device/system, and Windows 98 themes checked
- Zero browser runtime warnings/errors in the exercised flows