### PR TITLE
Fix editor recovery and image cropping

### DIFF
--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/customize-tab.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/customize-tab.tsx
@@ -53,6 +53,7 @@ export function CustomizeTab({
   const [fieldErrors, setFieldErrors] = React.useState<FieldErrors>({})
   const [draftRestored, setDraftRestored] = React.useState(false)
   const [draftHydrated, setDraftHydrated] = React.useState(false)
+  const [conflictingProject, setConflictingProject] = React.useState<Project | null>(null)
   const storageKey = React.useMemo(() => `feedbacks-widget-draft:${project.id}`, [project.id])
   const serverSavedConfig = React.useMemo(
     () => buildWidgetEditorConfig(previewProjectKey, project.settings?.widget_config || {}, { appOrigin }),
@@ -66,15 +67,62 @@ export function CustomizeTab({
     setSavedConfig(serverSavedConfig)
   }, [serverSavedConfig])
 
+  React.useEffect(() => {
+    setProjectVersion(project.updated_at)
+  }, [project.id, project.updated_at])
+
   const fingerprintConfig = React.useCallback(
-    (nextConfig: WidgetConfig) =>
-      JSON.stringify(
-        buildRuntimeWidgetConfig(previewProjectKey, nextConfig, {
-          appOrigin,
-        }),
+    (nextConfig: WidgetConfig) => {
+      const runtimeConfig = buildRuntimeWidgetConfig(previewProjectKey, nextConfig, {
+        appOrigin,
+      })
+      return JSON.stringify(
+        Object.fromEntries(
+          Object.entries(runtimeConfig).filter(
+            ([key]) => key !== 'feedbackEnabled' && key !== 'enableUpdates',
+          ),
+        ),
+      )
+    },
+    [appOrigin, previewProjectKey],
+  )
+
+  const editorConfigFromProject = React.useCallback(
+    (nextProject: Project) =>
+      buildWidgetEditorConfig(
+        previewProjectKey,
+        nextProject.settings?.widget_config || {},
+        { appOrigin },
       ),
     [appOrigin, previewProjectKey],
   )
+
+  const loadLatestProject = React.useCallback(async () => {
+    const response = await fetch(`/api/projects/${project.id}`, {
+      cache: 'no-store',
+    })
+    const payload = await response.json().catch(() => null)
+    if (!response.ok || !payload?.updated_at) {
+      throw new Error(readErrorMessage(payload, 'The latest saved feedback form could not be loaded.'))
+    }
+    return payload as Project
+  }, [project.id])
+
+  React.useEffect(() => {
+    let cancelled = false
+
+    void loadLatestProject()
+      .then((latestProject) => {
+        if (cancelled) return
+        setProjectVersion(latestProject.updated_at)
+        setSavedConfig(editorConfigFromProject(latestProject))
+      })
+      .catch(() => undefined)
+
+    return () => {
+      cancelled = true
+    }
+  }, [editorConfigFromProject, loadLatestProject])
 
   React.useEffect(() => {
     setDraftHydrated(false)
@@ -177,8 +225,32 @@ export function CustomizeTab({
   const handleReset = () => {
     setConfig(savedConfig)
     setDraftRestored(false)
+    setConflictingProject(null)
+    setSaveError('')
     if (typeof window !== 'undefined') {
       window.sessionStorage.removeItem(storageKey)
+    }
+  }
+
+  const reloadSavedSettings = async () => {
+    setSaving(true)
+    try {
+      const latestProject = await loadLatestProject()
+      const latestConfig = editorConfigFromProject(latestProject)
+      setProjectVersion(latestProject.updated_at)
+      setSavedConfig(latestConfig)
+      setConfig(latestConfig)
+      setConflictingProject(null)
+      setSaveError('')
+      setDraftRestored(false)
+      if (typeof window !== 'undefined') {
+        window.sessionStorage.removeItem(storageKey)
+      }
+      toast({ title: 'Latest saved feedback form loaded' })
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : 'The latest saved feedback form could not be loaded.')
+    } finally {
+      setSaving(false)
     }
   }
 
@@ -194,28 +266,70 @@ export function CustomizeTab({
     }
     setSaving(true)
     try {
-      const response = await fetch(`/api/projects/${project.id}`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          'If-Match': formatVersionEtag(projectVersion),
-        },
-        body: JSON.stringify({
-          settings: { widget_config: config },
-        }),
-      })
+      let expectedVersion = projectVersion
+      let payload: Project | null = null
 
-      if (!response.ok) {
-        const data = await response.json().catch(() => ({ error: 'Failed to save widget settings' }))
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const response = await fetch(`/api/projects/${project.id}`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            'If-Match': formatVersionEtag(expectedVersion),
+          },
+          body: JSON.stringify({
+            settings: { widget_config: config },
+          }),
+        })
+        const data = await response.json().catch(() => null)
+
+        if (response.ok) {
+          payload = data as Project
+          break
+        }
+
+        if (response.status === 409 && data?.code === 'EDIT_CONFLICT') {
+          const latestProject = await loadLatestProject()
+          const latestConfig = editorConfigFromProject(latestProject)
+          const latestFingerprint = fingerprintConfig(latestConfig)
+
+          if (latestFingerprint === draftFingerprint) {
+            setProjectVersion(latestProject.updated_at)
+            setSavedConfig(latestConfig)
+            setConfig(latestConfig)
+            setConflictingProject(null)
+            setDraftRestored(false)
+            if (typeof window !== 'undefined') {
+              window.sessionStorage.removeItem(storageKey)
+            }
+            toast({
+              title: 'Feedback form already saved',
+              description: 'The saved version already matches this draft.',
+            })
+            return
+          }
+
+          if (attempt === 0 && latestFingerprint === savedFingerprint) {
+            expectedVersion = latestProject.updated_at
+            setProjectVersion(latestProject.updated_at)
+            setSavedConfig(latestConfig)
+            continue
+          }
+
+          setConflictingProject(latestProject)
+          setSaveError('The saved feedback form changed while this draft was open. Reload the saved settings, review them, then make your changes again.')
+          return
+        }
+
         setFieldErrors(readFieldErrors(data))
         throw new Error(readErrorMessage(data, 'Failed to save widget settings'))
       }
 
-      const payload = await response.json()
+      if (!payload) throw new Error('Failed to save widget settings')
       setProjectVersion(payload.updated_at)
       const nextSavedConfig = buildWidgetEditorConfig(previewProjectKey, payload.settings?.widget_config || {}, { appOrigin })
       setSavedConfig(nextSavedConfig)
       setConfig(nextSavedConfig)
+      setConflictingProject(null)
 
       if (typeof window !== 'undefined') {
         window.sessionStorage.removeItem(storageKey)
@@ -512,7 +626,14 @@ export function CustomizeTab({
 
       {hasUnsavedChanges && (
         <div className="sticky bottom-[max(1rem,env(safe-area-inset-bottom))] z-20 rounded-lg border border-amber-300/80 bg-amber-50 p-3 shadow-lg dark:bg-amber-950">
-          <FormErrorSummary className="mb-3">{saveError}</FormErrorSummary>
+          {conflictingProject ? (
+            <div className="mb-3 rounded-md border border-destructive/40 bg-destructive/10 p-3" role="alert">
+              <p className="text-sm font-semibold text-foreground">Saved settings changed</p>
+              <p className="mt-1 text-sm leading-6 text-muted-foreground">{saveError}</p>
+            </div>
+          ) : (
+            <FormErrorSummary className="mb-3">{saveError}</FormErrorSummary>
+          )}
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <p className="text-sm font-semibold text-foreground">Publish remote changes</p>
@@ -521,12 +642,16 @@ export function CustomizeTab({
               </p>
             </div>
             <div className="flex flex-wrap gap-2">
-              <Button onClick={handleSave} disabled={saving}>
+              <Button onClick={handleSave} disabled={saving || Boolean(conflictingProject)}>
                 {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                 Save changes
               </Button>
-              <Button variant="outline" onClick={handleReset} disabled={saving}>
-                Discard
+              <Button
+                variant="outline"
+                onClick={conflictingProject ? () => void reloadSavedSettings() : handleReset}
+                disabled={saving}
+              >
+                {conflictingProject ? 'Reload saved settings' : 'Discard'}
               </Button>
             </div>
           </div>

--- a/packages/dashboard/src/app/api/projects/[id]/route.ts
+++ b/packages/dashboard/src/app/api/projects/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getAuthedUserAndProject } from '@/lib/api-auth'
 import { sanitizeWidgetOriginRestriction } from '@/lib/origin-allowlist'
 import { cleanupFeedbackStorageForProjectIds } from '@/lib/feedback-storage-cleanup'
-import { sanitizeSavedWidgetConfig } from '@feedbacks/shared'
+import { mergeOwnerEditableWidgetConfig, sanitizeSavedWidgetConfig } from '@feedbacks/shared'
 import { readJsonBody } from '@/lib/api-request'
 import { normalizeProjectDomain } from '@/lib/project-input'
 import {
@@ -130,8 +130,9 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
             fieldErrors: { primaryColor: ['Enter a hex color such as #6366f1.'] },
           }, { status: 400 })
         }
-        settings.widget_config = sanitizeSavedWidgetConfig(
-          widgetConfig as Parameters<typeof sanitizeSavedWidgetConfig>[0],
+        settings.widget_config = mergeOwnerEditableWidgetConfig(
+          project.settings?.widget_config,
+          widgetConfig as Parameters<typeof sanitizeSavedWidgetConfig>[0] & object,
         )
       }
       if ('widget_origin_restriction' in body.settings) {

--- a/packages/dashboard/src/app/api/projects/[id]/updates/[updateId]/image/route.ts
+++ b/packages/dashboard/src/app/api/projects/[id]/updates/[updateId]/image/route.ts
@@ -62,5 +62,8 @@ export async function DELETE(request: NextRequest, { params }: { params: Promise
   if (error) return NextResponse.json({ error: 'Unable to remove image.' }, { status: 500, headers })
   if (!data) return NextResponse.json(editConflictResponse(update.updated_at), { status: 409, headers })
   if (update.image_path) await auth.admin.storage.from('product_update_images').remove([update.image_path])
-  return new NextResponse(null, { status: 204, headers: { ...headers, ETag: formatVersionEtag(data.updated_at) } })
+  return NextResponse.json(
+    { update: { updated_at: data.updated_at, imageUrl: null } },
+    { headers: { ...headers, ETag: formatVersionEtag(data.updated_at) } },
+  )
 }

--- a/packages/dashboard/src/components/product-updates/ProductUpdateImageEditor.tsx
+++ b/packages/dashboard/src/components/product-updates/ProductUpdateImageEditor.tsx
@@ -1,11 +1,16 @@
 "use client";
 
 import * as React from "react";
+import NextImage from "next/image";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import {
   calculateProductUpdateCrop,
   calculateProductUpdateOutput,
+  moveProductUpdateCrop,
+  resizeProductUpdateCropFromCorner,
+  type ProductUpdateCrop,
+  type ProductUpdateCropCorner,
   type ProductUpdateImageAspect,
 } from "./product-update-image";
 
@@ -18,6 +23,45 @@ const ASPECTS: Array<{ value: ProductUpdateImageAspect; label: string }> = [
 
 const OUTPUT_WIDTHS = [640, 960, 1280, 1600] as const;
 const MAX_UPLOAD_BYTES = 2 * 1024 * 1024;
+const CROP_CORNERS: Array<{
+  value: ProductUpdateCropCorner;
+  label: string;
+  className: string;
+}> = [
+  {
+    value: "nw",
+    label: "Resize from top left",
+    className: "-left-2 -top-2 cursor-nwse-resize",
+  },
+  {
+    value: "ne",
+    label: "Resize from top right",
+    className: "-right-2 -top-2 cursor-nesw-resize",
+  },
+  {
+    value: "se",
+    label: "Resize from bottom right",
+    className: "-bottom-2 -right-2 cursor-nwse-resize",
+  },
+  {
+    value: "sw",
+    label: "Resize from bottom left",
+    className: "-bottom-2 -left-2 cursor-nesw-resize",
+  },
+];
+
+type CropInteraction =
+  | {
+      kind: "move";
+      startClientX: number;
+      startClientY: number;
+      startCrop: ProductUpdateCrop;
+    }
+  | {
+      kind: "resize";
+      corner: ProductUpdateCropCorner;
+      startCrop: ProductUpdateCrop;
+    };
 
 export function ProductUpdateImageEditor({
   file,
@@ -31,10 +75,11 @@ export function ProductUpdateImageEditor({
   onApply: (file: File) => Promise<void>;
 }) {
   const canvasRef = React.useRef<HTMLCanvasElement>(null);
+  const imageRef = React.useRef<HTMLImageElement>(null);
+  const interactionRef = React.useRef<CropInteraction | null>(null);
   const [image, setImage] = React.useState<HTMLImageElement | null>(null);
   const [aspect, setAspect] = React.useState<ProductUpdateImageAspect>("16:9");
-  const [focalX, setFocalX] = React.useState(50);
-  const [focalY, setFocalY] = React.useState(50);
+  const [crop, setCrop] = React.useState<ProductUpdateCrop | null>(null);
   const [outputWidth, setOutputWidth] = React.useState(1280);
   const [editorError, setEditorError] = React.useState<string | null>(null);
 
@@ -44,6 +89,16 @@ export function ProductUpdateImageEditor({
     nextImage.onload = () => {
       setEditorError(null);
       setImage(nextImage);
+      setAspect("16:9");
+      setCrop(
+        calculateProductUpdateCrop(
+          nextImage.naturalWidth,
+          nextImage.naturalHeight,
+          "16:9",
+          50,
+          50,
+        ),
+      );
     };
     nextImage.onerror = () =>
       setEditorError("This image could not be opened. Choose a valid JPEG or PNG file.");
@@ -51,20 +106,143 @@ export function ProductUpdateImageEditor({
     return () => URL.revokeObjectURL(url);
   }, [file]);
 
-  const crop = image
-    ? calculateProductUpdateCrop(
-        image.naturalWidth,
-        image.naturalHeight,
-        aspect,
-        focalX,
-        focalY,
-      )
-    : null;
   const output = crop
     ? calculateProductUpdateOutput(crop, outputWidth)
     : { width: outputWidth, height: Math.round(outputWidth / (16 / 9)) };
   const finalWidth = output.width;
   const finalHeight = output.height;
+
+  function selectAspect(nextAspect: ProductUpdateImageAspect) {
+    setAspect(nextAspect);
+    if (!image) return;
+    setCrop(
+      calculateProductUpdateCrop(
+        image.naturalWidth,
+        image.naturalHeight,
+        nextAspect,
+        50,
+        50,
+      ),
+    );
+  }
+
+  function displayedImageRect() {
+    return imageRef.current?.getBoundingClientRect() ?? null;
+  }
+
+  function clientToImagePoint(clientX: number, clientY: number) {
+    const rect = displayedImageRect();
+    if (!rect || !image) return null;
+    return {
+      x: ((clientX - rect.left) / rect.width) * image.naturalWidth,
+      y: ((clientY - rect.top) / rect.height) * image.naturalHeight,
+    };
+  }
+
+  function beginMove(event: React.PointerEvent<HTMLButtonElement>) {
+    if (!crop) return;
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    interactionRef.current = {
+      kind: "move",
+      startClientX: event.clientX,
+      startClientY: event.clientY,
+      startCrop: crop,
+    };
+  }
+
+  function beginResize(
+    event: React.PointerEvent<HTMLButtonElement>,
+    corner: ProductUpdateCropCorner,
+  ) {
+    if (!crop) return;
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    interactionRef.current = { kind: "resize", corner, startCrop: crop };
+  }
+
+  function continueInteraction(event: React.PointerEvent<HTMLButtonElement>) {
+    const interaction = interactionRef.current;
+    const rect = displayedImageRect();
+    if (!interaction || !rect || !image) return;
+    event.preventDefault();
+    if (interaction.kind === "move") {
+      setCrop(
+        moveProductUpdateCrop(
+          interaction.startCrop,
+          ((event.clientX - interaction.startClientX) / rect.width) *
+            image.naturalWidth,
+          ((event.clientY - interaction.startClientY) / rect.height) *
+            image.naturalHeight,
+          image.naturalWidth,
+          image.naturalHeight,
+        ),
+      );
+      return;
+    }
+    const point = clientToImagePoint(event.clientX, event.clientY);
+    if (!point) return;
+    const minimumWidth = (48 / rect.width) * image.naturalWidth;
+    setCrop(
+      resizeProductUpdateCropFromCorner(
+        interaction.startCrop,
+        interaction.corner,
+        point.x,
+        point.y,
+        image.naturalWidth,
+        image.naturalHeight,
+        minimumWidth,
+      ),
+    );
+  }
+
+  function endInteraction(event: React.PointerEvent<HTMLButtonElement>) {
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    interactionRef.current = null;
+  }
+
+  function moveWithKeyboard(event: React.KeyboardEvent<HTMLButtonElement>) {
+    if (!crop || !image || !event.key.startsWith("Arrow")) return;
+    event.preventDefault();
+    const step = event.shiftKey ? 10 : 2;
+    const deltaX = event.key === "ArrowLeft" ? -step : event.key === "ArrowRight" ? step : 0;
+    const deltaY = event.key === "ArrowUp" ? -step : event.key === "ArrowDown" ? step : 0;
+    setCrop(
+      moveProductUpdateCrop(
+        crop,
+        deltaX,
+        deltaY,
+        image.naturalWidth,
+        image.naturalHeight,
+      ),
+    );
+  }
+
+  function resizeWithKeyboard(
+    event: React.KeyboardEvent<HTMLButtonElement>,
+    corner: ProductUpdateCropCorner,
+  ) {
+    if (!crop || !image || !event.key.startsWith("Arrow")) return;
+    event.preventDefault();
+    const step = event.shiftKey ? 10 : 2;
+    const cornerX = corner === "ne" || corner === "se" ? crop.x + crop.width : crop.x;
+    const cornerY = corner === "se" || corner === "sw" ? crop.y + crop.height : crop.y;
+    const deltaX = event.key === "ArrowLeft" ? -step : event.key === "ArrowRight" ? step : 0;
+    const deltaY = event.key === "ArrowUp" ? -step : event.key === "ArrowDown" ? step : 0;
+    setCrop(
+      resizeProductUpdateCropFromCorner(
+        crop,
+        corner,
+        cornerX + deltaX,
+        cornerY + deltaY,
+        image.naturalWidth,
+        image.naturalHeight,
+        Math.max(1, image.naturalWidth * 0.05),
+      ),
+    );
+  }
 
   React.useEffect(() => {
     const canvas = canvasRef.current;
@@ -118,13 +296,66 @@ export function ProductUpdateImageEditor({
       aria-label="Crop and resize image"
     >
       <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_260px]">
-        <div className="overflow-hidden rounded-md border bg-surface-inset p-2">
-          <canvas
-            ref={canvasRef}
-            role="img"
-            aria-label="Cropped image preview"
-            className="h-auto max-h-[360px] w-full object-contain"
-          />
+        <div>
+          <div className="flex min-h-64 items-center justify-center overflow-hidden rounded-md border bg-surface-inset p-2">
+            {image && crop ? (
+              <div className="relative inline-block max-w-full overflow-hidden leading-none">
+                <NextImage
+                  ref={imageRef}
+                  src={image.src}
+                  alt="Image being cropped"
+                  width={image.naturalWidth}
+                  height={image.naturalHeight}
+                  unoptimized
+                  draggable={false}
+                  className="block h-auto max-h-[420px] max-w-full select-none"
+                />
+                <div
+                  className="pointer-events-none absolute border-2 border-primary shadow-[0_0_0_9999px_rgb(0_0_0_/_0.58)]"
+                  style={{
+                    left: `${(crop.x / image.naturalWidth) * 100}%`,
+                    top: `${(crop.y / image.naturalHeight) * 100}%`,
+                    width: `${(crop.width / image.naturalWidth) * 100}%`,
+                    height: `${(crop.height / image.naturalHeight) * 100}%`,
+                  }}
+                >
+                  <div className="absolute inset-x-0 top-1/3 border-t border-white/55" />
+                  <div className="absolute inset-x-0 top-2/3 border-t border-white/55" />
+                  <div className="absolute inset-y-0 left-1/3 border-l border-white/55" />
+                  <div className="absolute inset-y-0 left-2/3 border-l border-white/55" />
+                  <button
+                    type="button"
+                    className="pointer-events-auto absolute inset-3 cursor-move touch-none rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-primary"
+                    aria-label="Move crop selection. Use arrow keys for precise movement."
+                    onPointerDown={beginMove}
+                    onPointerMove={continueInteraction}
+                    onPointerUp={endInteraction}
+                    onPointerCancel={endInteraction}
+                    onKeyDown={moveWithKeyboard}
+                  />
+                  {CROP_CORNERS.map((corner) => (
+                    <button
+                      key={corner.value}
+                      type="button"
+                      className={`pointer-events-auto absolute size-5 touch-none rounded-sm border-2 border-primary bg-background shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${corner.className}`}
+                      aria-label={`${corner.label}. Use arrow keys for precise resizing.`}
+                      onPointerDown={(event) => beginResize(event, corner.value)}
+                      onPointerMove={continueInteraction}
+                      onPointerUp={endInteraction}
+                      onPointerCancel={endInteraction}
+                      onKeyDown={(event) => resizeWithKeyboard(event, corner.value)}
+                    />
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">Opening image…</p>
+            )}
+          </div>
+          <p className="mt-2 text-xs leading-5 text-muted-foreground">
+            Drag inside the frame to move it. Drag a corner handle to resize it.
+          </p>
+          <canvas ref={canvasRef} aria-hidden="true" className="hidden" />
         </div>
         <div className="space-y-4">
           <div>
@@ -142,35 +373,13 @@ export function ProductUpdateImageEditor({
                   variant={aspect === option.value ? "secondary" : "outline"}
                   role="radio"
                   aria-checked={aspect === option.value}
-                  onClick={() => setAspect(option.value)}
+                  onClick={() => selectAspect(option.value)}
                 >
                   {option.label}
                 </Button>
               ))}
             </div>
           </div>
-          <label className="block text-sm font-medium">
-            Horizontal crop position
-            <input
-              className="mt-2 w-full accent-primary"
-              type="range"
-              min="0"
-              max="100"
-              value={focalX}
-              onChange={(event) => setFocalX(Number(event.target.value))}
-            />
-          </label>
-          <label className="block text-sm font-medium">
-            Vertical crop position
-            <input
-              className="mt-2 w-full accent-primary"
-              type="range"
-              min="0"
-              max="100"
-              value={focalY}
-              onChange={(event) => setFocalY(Number(event.target.value))}
-            />
-          </label>
           <label className="block text-sm font-medium">
             Output width
             <select

--- a/packages/dashboard/src/components/product-updates/ProductUpdatesOverview.tsx
+++ b/packages/dashboard/src/components/product-updates/ProductUpdatesOverview.tsx
@@ -56,7 +56,7 @@ export function ProductUpdatesOverview({
         </section>
         <section className="rounded-lg border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
           <h3 className="text-lg font-semibold">
-            Create the first product update
+            Create the first release note
           </h3>
           <p className="mt-2 text-sm text-muted-foreground">
             Start with a title and summary. Add an image or delivery rules only
@@ -64,7 +64,7 @@ export function ProductUpdatesOverview({
           </p>
           <Button className="mt-5" onClick={onNew}>
             <Plus className="mr-2 h-4 w-4" />
-            Create first update
+            Create first release note
           </Button>
         </section>
       </div>
@@ -85,7 +85,7 @@ export function ProductUpdatesOverview({
             </Button>
             <Button onClick={onNew}>
               <Plus className="mr-2 h-4 w-4" />
-              New product update
+              New release note
             </Button>
           </div>
         }

--- a/packages/dashboard/src/components/product-updates/ProductUpdatesTab.tsx
+++ b/packages/dashboard/src/components/product-updates/ProductUpdatesTab.tsx
@@ -48,6 +48,7 @@ class ApiRequestError extends Error {
   constructor(
     message: string,
     readonly fieldErrors: Record<string, string> = {},
+    readonly code?: string,
   ) {
     super(message);
   }
@@ -89,8 +90,12 @@ export function ProductUpdatesTab({
   const [fieldErrors, setFieldErrors] = React.useState<Record<string, string>>(
     {},
   );
+  const [editorConflict, setEditorConflict] = React.useState<string | null>(
+    null,
+  );
   const editorRef = React.useRef<HTMLElement>(null);
   const advancedRef = React.useRef<HTMLDetailsElement>(null);
+  const hydratedUpdateRef = React.useRef<string | null>(null);
   const [modules, setModules] = React.useState<Modules | null>(null);
   const [embedStatus, setEmbedStatus] = React.useState<EmbedStatus | null>(
     null,
@@ -158,12 +163,15 @@ export function ProductUpdatesTab({
     }).catch(() => undefined);
   }, [projectId]);
   React.useEffect(() => {
+    const update = updates.find((item) => item.id === updateId);
     if (
       view === "composer" &&
       updateId &&
-      updates.some((update) => update.id === updateId)
-    )
-      edit(updates.find((update) => update.id === updateId)!);
+      update &&
+      hydratedUpdateRef.current !== updateId
+    ) {
+      edit(update);
+    }
   }, [updateId, updates, view]);
 
   const updateForm = (
@@ -200,9 +208,11 @@ export function ProductUpdatesTab({
   };
 
   function edit(update: Update) {
+    hydratedUpdateRef.current = update.id;
     setSelectedId(update.id);
     setForm(toProductUpdateForm(update));
     setPublishAt(localDateTime(update.published_at));
+    setEditorConflict(null);
   }
 
   async function request(url: string, options?: RequestInit) {
@@ -226,9 +236,17 @@ export function ProductUpdatesTab({
             ? "A temporary service problem prevented this save. Your draft is still in the editor; wait a moment and try again."
             : "The server rejected this request. Your draft is still in the editor; reload the latest version and try again."),
         errors,
+        typeof data?.code === "string" ? data.code : undefined,
       );
     }
     return data;
+  }
+
+  function captureEditConflict(error: unknown) {
+    if (!(error instanceof ApiRequestError) || error.code !== "EDIT_CONFLICT")
+      return false;
+    setEditorConflict(error.message);
+    return true;
   }
 
   function formBody() {
@@ -268,9 +286,10 @@ export function ProductUpdatesTab({
         setSelectedId(data.update.id);
         router.replace(`/projects/${projectId}/release-notes/${data.update.id}`);
       }
-      toast({ title: selected ? "Update saved" : "Draft saved" });
+      toast({ title: selected ? "Release note saved" : "Draft saved" });
       await load();
     } catch (error) {
+      captureEditConflict(error);
       const errors =
         error instanceof ApiRequestError ? error.fieldErrors : {};
       setFieldErrors(errors);
@@ -337,6 +356,7 @@ export function ProductUpdatesTab({
       setPublishConfirmation(scheduled ? "scheduled" : "published");
       await load();
     } catch (error) {
+      captureEditConflict(error);
       toast({
         title: "Could not publish release note",
         description: error instanceof Error ? error.message : "Try again.",
@@ -398,6 +418,7 @@ export function ProductUpdatesTab({
         description: "The preview now shows the saved image.",
       });
     } catch (error) {
+      captureEditConflict(error);
       const message =
         error instanceof Error
           ? error.message
@@ -431,6 +452,100 @@ export function ProductUpdatesTab({
       message: `${file.name} is ready to crop and resize.`,
     });
     setPendingImage(file);
+  }
+
+  async function reloadSavedVersion() {
+    if (!selectedId) return;
+    setSaving(true);
+    try {
+      const result = await request(
+        `/api/projects/${projectId}/updates/${selectedId}`,
+        { cache: "no-store" },
+      );
+      const currentMetrics =
+        updates.find((update) => update.id === selectedId)?.metrics ||
+        { impressions: 0, dismissals: 0, ctaClicks: 0 };
+      const latest = { ...result.update, metrics: currentMetrics } as Update;
+      setUpdates((current) =>
+        current.map((update) => (update.id === latest.id ? latest : update)),
+      );
+      edit(latest);
+      setPendingImage(null);
+      setImageStatus({
+        kind: "idle",
+        message: "Latest saved version loaded.",
+      });
+      setFieldErrors({});
+      toast({ title: "Latest saved version loaded" });
+    } catch (error) {
+      toast({
+        title: "Could not reload the saved version",
+        description: error instanceof Error ? error.message : "Try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function removeImage() {
+    if (!selected?.imageUrl) return;
+    if (!window.confirm("Remove this image from the release note?")) return;
+    setSaving(true);
+    try {
+      const result = await request(
+        `/api/projects/${projectId}/updates/${selected.id}/image`,
+        {
+          method: "DELETE",
+          headers: { "If-Match": formatVersionEtag(selected.updated_at) },
+        },
+      );
+      setUpdates((current) =>
+        current.map((update) =>
+          update.id === selected.id ? { ...update, ...result.update } : update,
+        ),
+      );
+      setForm((current) => ({ ...current, imageUrl: "" }));
+      setImageStatus({ kind: "success", message: "Image removed." });
+      toast({ title: "Image removed" });
+    } catch (error) {
+      captureEditConflict(error);
+      toast({
+        title: "Could not remove image",
+        description: error instanceof Error ? error.message : "Try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function deleteSelectedUpdate() {
+    if (!selected) return;
+    if (
+      !window.confirm(
+        `Delete “${selected.title}”? This release note and its metrics will be permanently removed.`,
+      )
+    )
+      return;
+    setSaving(true);
+    try {
+      await request(`/api/projects/${projectId}/updates/${selected.id}`, {
+        method: "DELETE",
+        headers: { "If-Match": formatVersionEtag(selected.updated_at) },
+      });
+      toast({ title: "Release note deleted" });
+      router.push(`/projects/${projectId}/release-notes`);
+    } catch (error) {
+      captureEditConflict(error);
+      toast({
+        title: "Could not delete release note",
+        description: error instanceof Error ? error.message : "Try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setSaving(false);
+    }
   }
 
   async function saveSettings(next: Settings) {
@@ -597,7 +712,7 @@ export function ProductUpdatesTab({
   if (updateId && !updates.some((update) => update.id === updateId)) {
     return (
       <div className="mx-auto max-w-2xl py-8">
-        <h2 className="text-xl font-semibold">Product update not found</h2>
+        <h2 className="text-xl font-semibold">Release note not found</h2>
         <p className="mt-2 text-sm text-muted-foreground">
           It may have been deleted, or the link may be out of date.
         </p>
@@ -661,13 +776,35 @@ export function ProductUpdatesTab({
 
   return (
     <div className="space-y-6">
+      {editorConflict && selected ? (
+        <section
+          className="flex flex-col gap-4 rounded-md border border-destructive/40 bg-destructive/10 p-4 sm:flex-row sm:items-center sm:justify-between"
+          role="alert"
+        >
+          <div className="max-w-2xl">
+            <h2 className="text-sm font-semibold">The saved version changed</h2>
+            <p className="mt-1 text-sm leading-6 text-muted-foreground">
+              {editorConflict} Reloading replaces the text currently shown in
+              this editor with the latest saved content.
+            </p>
+          </div>
+          <Button
+            className="shrink-0"
+            variant="outline"
+            disabled={saving}
+            onClick={() => void reloadSavedVersion()}
+          >
+            {saving ? "Reloading…" : "Reload saved version"}
+          </Button>
+        </section>
+      ) : null}
       <section className="flex flex-wrap items-start justify-between gap-4 rounded-lg border bg-card p-5 shadow-[var(--shadow-card)] sm:p-6">
         <div className="max-w-2xl">
           <p className="text-xs font-semibold text-primary">
             Update shown to your users
           </p>
           <h2 className="mt-1 text-xl font-semibold">
-            {selected ? "Edit product update" : "Create product update"}
+            {selected ? "Edit release note" : "Create release note"}
           </h2>
           <p className="mt-1 text-sm text-muted-foreground">
             Keep the announcement concise. You can review it privately before
@@ -688,6 +825,17 @@ export function ProductUpdatesTab({
           >
             Back to updates
           </Button>
+          {selected ? (
+            <Button
+              variant="ghost"
+              className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+              disabled={saving}
+              onClick={() => void deleteSelectedUpdate()}
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              Delete release note
+            </Button>
+          ) : null}
         </div>
       </section>
 
@@ -697,7 +845,7 @@ export function ProductUpdatesTab({
             <div className="mb-4 flex items-center justify-between">
               <div>
                 <h3 className="font-semibold">
-                  {selected ? "Edit release note" : "Draft details"}
+                  Release note content
                 </h3>
                 <p className="mt-1 text-sm text-muted-foreground">
                   Plain text only. A live release note keeps its existing seen
@@ -774,13 +922,26 @@ export function ProductUpdatesTab({
               ) : null}
               {selected?.imageUrl && (
                 <div className="mt-3 space-y-3">
-                  {/* Dynamic Supabase URLs are user-owned content and bypass optimization. */}
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    src={selected.imageUrl}
-                    alt={form.imageAltText || "Current product update image"}
-                    className="aspect-video w-full max-w-md rounded-md border object-cover"
-                  />
+                  <div className="flex flex-wrap items-end gap-3">
+                    {/* Dynamic Supabase URLs are user-owned content and bypass optimization. */}
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={selected.imageUrl}
+                      alt={form.imageAltText || "Current release note image"}
+                      className="aspect-video w-full max-w-md rounded-md border object-cover"
+                    />
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                      disabled={saving}
+                      onClick={() => void removeImage()}
+                    >
+                      <Trash2 className="mr-2 h-4 w-4" />
+                      Remove image
+                    </Button>
+                  </div>
                   <ProductUpdateField label="Image description" error={fieldErrors.imageAltText}>
                     <Input
                       aria-invalid={Boolean(fieldErrors.imageAltText)}

--- a/packages/dashboard/src/components/product-updates/product-update-image.ts
+++ b/packages/dashboard/src/components/product-updates/product-update-image.ts
@@ -1,4 +1,11 @@
 export type ProductUpdateImageAspect = "original" | "16:9" | "4:3" | "1:1";
+export type ProductUpdateCrop = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+export type ProductUpdateCropCorner = "nw" | "ne" | "se" | "sw";
 
 function aspectValue(
   aspect: ProductUpdateImageAspect,
@@ -38,5 +45,59 @@ export function calculateProductUpdateOutput(
   return {
     width,
     height: Math.max(1, Math.round(width / (crop.width / crop.height))),
+  };
+}
+
+function clamp(value: number, minimum: number, maximum: number) {
+  return Math.min(Math.max(value, minimum), maximum);
+}
+
+export function moveProductUpdateCrop(
+  crop: ProductUpdateCrop,
+  deltaX: number,
+  deltaY: number,
+  imageWidth: number,
+  imageHeight: number,
+): ProductUpdateCrop {
+  return {
+    ...crop,
+    x: clamp(crop.x + deltaX, 0, Math.max(0, imageWidth - crop.width)),
+    y: clamp(crop.y + deltaY, 0, Math.max(0, imageHeight - crop.height)),
+  };
+}
+
+export function resizeProductUpdateCropFromCorner(
+  crop: ProductUpdateCrop,
+  corner: ProductUpdateCropCorner,
+  pointerX: number,
+  pointerY: number,
+  imageWidth: number,
+  imageHeight: number,
+  minimumWidth = 1,
+): ProductUpdateCrop {
+  const growsRight = corner === "ne" || corner === "se";
+  const growsDown = corner === "se" || corner === "sw";
+  const anchorX = growsRight ? crop.x : crop.x + crop.width;
+  const anchorY = growsDown ? crop.y : crop.y + crop.height;
+  const directionX = growsRight ? 1 : -1;
+  const directionY = growsDown ? 1 : -1;
+  const aspect = crop.width / crop.height;
+  const requestedWidthX = (pointerX - anchorX) * directionX;
+  const requestedHeight = (pointerY - anchorY) * directionY;
+  const requestedWidthY = requestedHeight * aspect;
+  const projectedWidth =
+    (requestedWidthX + requestedWidthY / (aspect * aspect)) /
+    (1 + 1 / (aspect * aspect));
+  const horizontalCapacity = growsRight ? imageWidth - anchorX : anchorX;
+  const verticalCapacity = growsDown ? imageHeight - anchorY : anchorY;
+  const maximumWidth = Math.max(1, Math.min(horizontalCapacity, verticalCapacity * aspect));
+  const width = clamp(projectedWidth, Math.min(minimumWidth, maximumWidth), maximumWidth);
+  const height = width / aspect;
+
+  return {
+    x: growsRight ? anchorX : anchorX - width,
+    y: growsDown ? anchorY : anchorY - height,
+    width,
+    height,
   };
 }

--- a/packages/dashboard/src/components/product-updates/product-update-model.ts
+++ b/packages/dashboard/src/components/product-updates/product-update-model.ts
@@ -9,7 +9,7 @@ export type ProductUpdate = {
   cta_label: string | null;
   cta_url: string | null;
   ctas?: Array<{ label: string; url: string }>;
-  imageUrl?: string;
+  imageUrl?: string | null;
   image_alt_text: string | null;
   published_at: string | null;
   expires_at: string | null;

--- a/packages/dashboard/src/lib/optimistic-concurrency.ts
+++ b/packages/dashboard/src/lib/optimistic-concurrency.ts
@@ -13,7 +13,7 @@ export function parseIfMatchVersion(value: string | null): string | null {
 export function editConflictResponse(currentVersion: string) {
   return {
     code: 'EDIT_CONFLICT',
-    error: 'A newer saved version is available. Your text is still in the editor. Reload the page to get the latest version, review your changes, then save again.',
+    error: 'A newer saved version is available. Your text is still in the editor. Use Reload saved version to load it, review your changes, then save again.',
     currentVersion,
   }
 }

--- a/packages/dashboard/tests/e2e/customize.spec.ts
+++ b/packages/dashboard/tests/e2e/customize.spec.ts
@@ -70,3 +70,38 @@ test('publishes saved feedback-form changes remotely without changing install co
   await expect(page.getByTestId('install-verify-instruction')).toContainText('Ideas')
   await expect(page.locator('[data-tour="install-code"]')).not.toContainText('Ideas')
 })
+
+test('retries feedback-form saves after an unrelated project version change', async ({ page }) => {
+  await signInWithTestSession(page)
+  const project = await createProjectViaApi(page, { name: `Playwright Widget Conflict ${Date.now().toString(36)}` })
+  const initialProjectRead = page.waitForResponse((response) =>
+    response.url().includes(`/api/projects/${project.id}`)
+      && response.request().method() === 'GET'
+      && response.status() === 200,
+  )
+
+  await page.goto(projectCustomizePath(project.id), { waitUntil: 'domcontentloaded' })
+  await initialProjectRead
+  await expect(page.locator('[data-project-tabs-ready="true"]')).toBeVisible()
+
+  const current = await page.request.get(`/api/projects/${project.id}`)
+  const accepted = await page.request.patch(`/api/projects/${project.id}`, {
+    headers: { 'If-Match': current.headers().etag },
+    data: { name: `${project.name} renamed` },
+  })
+  expect(accepted.ok()).toBe(true)
+
+  await page.getByLabel('Button text').fill('Recovered save')
+  await page.getByRole('button', { name: 'Save changes' }).click()
+
+  await expect(page.getByText('Showing saved version')).toBeVisible()
+  await expect(page.getByText('Recovered save')).toBeVisible()
+
+  const bootstrapResponse = await page.request.get(
+    `/api/widget/bootstrap?projectKey=${encodeURIComponent(project.apiKey)}&runtimeVersion=e2e`,
+  )
+  expect(bootstrapResponse.ok()).toBeTruthy()
+  await expect(bootstrapResponse.json()).resolves.toMatchObject({
+    feedbackConfig: { buttonText: 'Recovered save' },
+  })
+})

--- a/packages/dashboard/tests/unit/optimistic-concurrency.test.ts
+++ b/packages/dashboard/tests/unit/optimistic-concurrency.test.ts
@@ -21,7 +21,7 @@ test('malformed or wildcard If-Match values are rejected', () => {
 test('edit conflicts preserve a safe recovery instruction and current version', () => {
   assert.deepEqual(editConflictResponse('new-version'), {
     code: 'EDIT_CONFLICT',
-    error: 'A newer saved version is available. Your text is still in the editor. Reload the page to get the latest version, review your changes, then save again.',
+    error: 'A newer saved version is available. Your text is still in the editor. Use Reload saved version to load it, review your changes, then save again.',
     currentVersion: 'new-version',
   })
 })

--- a/packages/dashboard/tests/unit/product-experience.test.ts
+++ b/packages/dashboard/tests/unit/product-experience.test.ts
@@ -120,6 +120,32 @@ test('navigation gives product updates user context instead of an ambiguous rele
   assert.doesNotMatch(sidebar, /label: 'Release notes'/)
 })
 
+test('release note editor exposes recovery and destructive actions without vague page naming', () => {
+  const editor = read('../../src/components/product-updates/ProductUpdatesTab.tsx')
+  const imageEditor = read('../../src/components/product-updates/ProductUpdateImageEditor.tsx')
+
+  assert.match(editor, /Edit release note/)
+  assert.doesNotMatch(editor, /Edit product update/)
+  assert.match(editor, /Reload saved version/)
+  assert.match(editor, /Delete release note/)
+  assert.match(editor, /Remove image/)
+  assert.match(editor, /hydratedUpdateRef/)
+  assert.match(imageEditor, /Drag inside the frame to move it/)
+  assert.match(imageEditor, /Resize from top left/)
+  assert.match(imageEditor, /resizeProductUpdateCropFromCorner/)
+  assert.doesNotMatch(imageEditor, /Horizontal crop position/)
+})
+
+test('feedback form editor refreshes stale baselines and exposes explicit recovery', () => {
+  const editor = read('../../src/app/(dashboard)/projects/[id]/customize-tab.tsx')
+
+  assert.match(editor, /loadLatestProject/)
+  assert.match(editor, /latestFingerprint === draftFingerprint/)
+  assert.match(editor, /latestFingerprint === savedFingerprint/)
+  assert.match(editor, /Feedback form already saved/)
+  assert.match(editor, /Reload saved settings/)
+})
+
 test('dense dashboard forms use clear tonal sections instead of one flat canvas', () => {
   const section = read('../../src/components/ui/workspace-section.tsx')
   const boardIdentity = read('../../src/components/board-settings/BoardIdentitySection.tsx')

--- a/packages/dashboard/tests/unit/product-update-image.test.ts
+++ b/packages/dashboard/tests/unit/product-update-image.test.ts
@@ -3,6 +3,8 @@ import test from 'node:test'
 import {
   calculateProductUpdateCrop,
   calculateProductUpdateOutput,
+  moveProductUpdateCrop,
+  resizeProductUpdateCropFromCorner,
 } from '../../src/components/product-updates/product-update-image.ts'
 
 test('product update image crop follows aspect ratio and focal point', () => {
@@ -22,4 +24,45 @@ test('product update image resize never enlarges the crop', () => {
     calculateProductUpdateOutput({ width: 1600, height: 900 }, 640),
     { width: 640, height: 360 },
   )
+})
+
+test('matching image and crop ratios have no movable crop area', () => {
+  assert.deepEqual(
+    calculateProductUpdateCrop(588, 441, '4:3', 0, 0),
+    { x: 0, y: 0, width: 588, height: 441 },
+  )
+  assert.deepEqual(
+    calculateProductUpdateCrop(588, 441, '4:3', 100, 100),
+    { x: 0, y: 0, width: 588, height: 441 },
+  )
+})
+
+test('crop rectangle movement stays within the image', () => {
+  const crop = { x: 200, y: 100, width: 800, height: 450 }
+
+  assert.deepEqual(moveProductUpdateCrop(crop, -500, 900, 1600, 900), {
+    x: 0,
+    y: 450,
+    width: 800,
+    height: 450,
+  })
+})
+
+test('corner resizing preserves the crop ratio and image bounds', () => {
+  const crop = { x: 400, y: 225, width: 800, height: 450 }
+  const resized = resizeProductUpdateCropFromCorner(
+    crop,
+    'se',
+    2000,
+    1200,
+    1600,
+    900,
+    100,
+  )
+
+  assert.equal(resized.x, 400)
+  assert.equal(resized.y, 225)
+  assert.equal(resized.x + resized.width, 1600)
+  assert.equal(resized.y + resized.height, 900)
+  assert.equal(resized.width / resized.height, 16 / 9)
 })

--- a/packages/dashboard/tests/unit/security-boundaries.test.ts
+++ b/packages/dashboard/tests/unit/security-boundaries.test.ts
@@ -12,10 +12,13 @@ test('owner project resolution does not select private credential hashes', () =>
 
 test('generic project mutation rejects unknown property bags and merges settings server-side', () => {
   const route = read('../../src/app/api/projects/[id]/route.ts')
+  const widgetInstall = read('../../../shared/src/widget-install.ts')
   assert.match(route, /allowedTopLevel/)
   assert.match(route, /allowedSettings/)
   assert.match(route, /\{ \.\.\.\(project\.settings \|\| \{\}\) \}/)
   assert.doesNotMatch(route, /updates\.settings = body\.settings/)
+  assert.match(route, /mergeOwnerEditableWidgetConfig/)
+  assert.match(widgetInstall, /'feedbackEnabled', 'enableUpdates'/)
 })
 
 test('all API route bodies use bounded readers instead of request.json', () => {

--- a/packages/dashboard/tests/unit/widget-install.test.ts
+++ b/packages/dashboard/tests/unit/widget-install.test.ts
@@ -113,9 +113,21 @@ test('install snippets stay stable when remotely managed settings change', async
 })
 
 test('server module preference survives customization without leaking into install markup', async () => {
-  const { sanitizeSavedWidgetConfig, generateInstallSnippets } = await loadWidgetInstall()
+  const {
+    generateInstallSnippets,
+    mergeOwnerEditableWidgetConfig,
+    sanitizeSavedWidgetConfig,
+  } = await loadWidgetInstall()
   const saved = sanitizeSavedWidgetConfig({ feedbackEnabled: false, buttonText: 'Contact us' })
   assert.equal(saved.feedbackEnabled, false)
+
+  const merged = mergeOwnerEditableWidgetConfig(
+    { feedbackEnabled: false, enableUpdates: true, buttonText: 'Old label' },
+    { feedbackEnabled: true, enableUpdates: false, buttonText: 'New label' },
+  )
+  assert.equal(merged.feedbackEnabled, false)
+  assert.equal(merged.enableUpdates, true)
+  assert.equal(merged.buttonText, 'New label')
 
   const websiteSnippet = generateInstallSnippets({
     projectKey: 'fb_live_demo',

--- a/packages/shared/src/widget-install.ts
+++ b/packages/shared/src/widget-install.ts
@@ -352,6 +352,26 @@ export function sanitizeSavedWidgetConfig(
   ) as SavedWidgetConfig
 }
 
+export function mergeOwnerEditableWidgetConfig(
+  current: SavedWidgetConfig | null | undefined,
+  requested: SavedWidgetConfig,
+): SavedWidgetConfig {
+  const currentConfig = sanitizeSavedWidgetConfig(current)
+  const nextConfig = sanitizeSavedWidgetConfig(requested)
+
+  // Module switches are controlled by their dedicated product settings flow.
+  // A form customization save must not reverse them from a stale browser copy.
+  for (const key of ['feedbackEnabled', 'enableUpdates'] as const) {
+    if (typeof currentConfig[key] === 'boolean') {
+      nextConfig[key] = currentConfig[key]
+    } else {
+      delete nextConfig[key]
+    }
+  }
+
+  return nextConfig
+}
+
 export function normalizeAppOrigin(appOrigin?: string): string {
   return stripTrailingSlash(appOrigin?.trim() || DEFAULT_APP_ORIGIN)
 }


### PR DESCRIPTION
## What changed

- recovers cleanly from stale release-note and feedback-form editor versions
- renames vague product-update editor copy to release-note language
- adds reload, image removal, and release-note deletion actions
- replaces invisible crop-position sliders with a draggable, resizable crop rectangle
- preserves independent widget module settings when feedback-form customization is saved

## Why

Editors could become stuck on a stale optimistic-concurrency version, and the image controls did not visibly show what was changing. The new recovery actions refresh the saved baseline, while the crop frame makes the output directly manipulable.

## User impact

Users can recover without abandoning their work, remove images or drafts explicitly, and crop images with a familiar direct-manipulation interface.

## Validation

- 176 unit tests pass
- dashboard type-check passes
- focused ESLint passes
- production dashboard build passes