### PR TITLE
Harden versioned mutation flows

### DIFF
--- a/docs/review/2026-08-02-reliability-and-idiot-proofing-audit.md
+++ b/docs/review/2026-08-02-reliability-and-idiot-proofing-audit.md
@@ -1,0 +1,100 @@
+# Reliability and idiot-proofing audit — 2026-08-02
+
+## Scope and method
+
+This audit followed the authenticated owner journey from first-run setup through feedback collection, triage, widget customization, project settings, and Updates for users. It combined:
+
+- a production-browser reproduction using the dedicated `test@test.com` account and an isolated temporary release note;
+- production request-log correlation;
+- a static review of every optimistic-concurrency mutation and its recovery UI;
+- unit, dependency, schema, and Supabase advisor checks;
+- review against the current product brief, PRD, user stories, MVP scope, and technical direction.
+
+The primary acceptance rule is simple: a successful action performed in the same editor must never make the editor stale for the user's next action. Real cross-tab conflicts must preserve local input and provide a clear, reachable recovery path.
+
+## Baseline scorecard
+
+| Dimension | Score | Evidence |
+| --- | ---: | --- |
+| Accessibility | 8/10 | Semantic labels, live regions, focus-on-error behavior, keyboard-operable controls, and reduced-motion support are broadly present. Native blocking confirmations remain in a few authenticated destructive flows. |
+| Performance | 8/10 | Route budgets, widget gzip budget, bounded API bodies, pagination, and targeted Supabase indexes are enforced. Advisor INFO notices are limited to quarantined snapshot tables and currently unused indexes. |
+| Responsive behavior | 8/10 | Dashboard grids, mobile previews, sticky recovery actions, and compact controls cover the primary breakpoints. Dense authenticated forms still require continued small-viewport regression coverage. |
+| Theming | 9/10 | Semantic OKLCH tokens and complete light, dark, system, and Windows 98 themes are tested. No hardcoded-theme blocker was found in the audited mutation flows. |
+| Anti-patterns | 6/10 | Mutation concurrency is correctly enforced in the database, but clients use the standard `If-Match` transport header as an application version channel and some successive actions rely on React render timing. This is the main systemic reliability risk. |
+
+## Findings and remediation status
+
+### P1-01 — Standard `If-Match` is intercepted before app recovery [fixed]
+
+**Evidence:** In production, image upload returned 200 and the immediately following draft PATCH returned 412. The app's route code emits 409 for edit conflicts and contains no 412 response. The 412 therefore bypasses the JSON `EDIT_CONFLICT` envelope, current-version value, recovery banner, and safe retry code. The same header is used across release notes, feedback triage, customization, project settings, and update display settings.
+
+**Required fix:** Move the application version token to a namespaced header, retain server-side legacy `If-Match` parsing for compatibility, and keep ETag response headers for cache/version observability.
+
+**Remediation:** All authenticated browser clients now send `X-Feedbacks-Version`. All eight protected handlers parse the shared application header and retain legacy ETag parsing only for backward compatibility. Standard ETag response headers remain intact.
+
+### P1-02 — Media mutations leave the release-note editor on a render-stale version [fixed]
+
+**Evidence:** `applyMediaMutation` updates React state after upload/remove, while the next action reads `selected.updated_at` from the render that initiated the media request. A fast or immediate Save draft therefore sends the pre-upload version even though the same editor just received the new version.
+
+**Required fix:** Maintain a synchronous version ref, advance it on every successful mutation, merge media responses against the current state item, and use the ref for all subsequent release-note actions.
+
+**Remediation:** The composer now maintains `selectedVersionRef`, advances it synchronously after save, publish, upload, and remove, and merges media responses against the latest state item. Every following mutation reads that ref.
+
+### P1-03 — The exact successful-action → next-action sequence lacked regression coverage [fixed]
+
+**Evidence:** Existing concurrency tests verify stale-request rejection and media tests verify upload/delete independently, but no test asserts Save draft → Upload image → Save draft, Upload → Remove, or one mutation immediately following another with the returned version.
+
+**Required fix:** Add unit/static contract coverage for the namespaced header and Playwright/API coverage for chained mutations.
+
+**Remediation:** Added shared-header round-trip coverage, a source boundary test that rejects browser `If-Match` writes, and an end-to-end assertion for image upload followed immediately by a successful draft save.
+
+### P2-01 — Transport-level 412 responses degrade to a vague generic error [fixed]
+
+**Evidence:** The composer request helper recognizes only a JSON `EDIT_CONFLICT` code. A bodyless/non-JSON 412 becomes “The server rejected this request,” even though the user's recovery banner is available elsewhere.
+
+**Required fix:** Normalize 409/412 conflict statuses in the client error layer, recover the latest version when supplied, preserve local input, and keep the bottom recovery action reachable.
+
+**Remediation:** The release-note request layer normalizes both 409 and 412 to `EDIT_CONFLICT`, reads a current version from JSON or ETag when available, preserves the form, and activates the existing top and bottom recovery actions.
+
+### P2-02 — Version transport logic is duplicated across four clients and eight API handlers [fixed]
+
+**Evidence:** Header formatting/parsing and conflict branching are repeated in release-note, feedback, customize, project-settings, settings, publish, archive, restore, image, and delete paths. Duplication allowed server/client semantics to drift.
+
+**Required fix:** Centralize request header generation and request-header parsing in the optimistic-concurrency module, then add a source boundary test so future mutations cannot silently reintroduce standard `If-Match` writes.
+
+**Remediation:** `mutationVersionHeaders` and `parseMutationVersion` now own the client/server contract. The test suite enforces their use at every owner-editable mutation boundary.
+
+### P2-03 — Supabase leaked-password protection is disabled [blocked; platform setting]
+
+**Evidence:** The live Supabase security advisor reports `auth_leaked_password_protection` as WARN. Schema/RLS checks pass, and no application dependency vulnerability was found.
+
+**Required fix:** Enable leaked-password protection in Supabase Auth when the current plan supports it. This is an account-platform setting, not a repository migration.
+
+**Status:** No repository or schema change can enable this account-level Auth option through the connected database tooling. It remains the only security-advisor warning and is documented rather than falsely marked fixed.
+
+### P3-01 — Advisor noise from quarantine snapshots and unused indexes [accepted]
+
+The performance advisor reports INFO-only missing-primary-key notices for read-only `quarantine.e2e_*_20260730` snapshot tables and unused-index notices. Snapshot tables are deliberately non-production reference data. Unused-index removal is not justified from a short activity window and could harm less-frequent jobs, so no destructive database change is warranted in this audit.
+
+## Verification baseline
+
+- Unit tests: 176/176 passing.
+- Production dependency audit: no known vulnerabilities.
+- Live Supabase schema check: passing.
+- Production reproduction: confirmed 200 image upload followed by 412 draft PATCH.
+- Supabase security advisor: one WARN (leaked-password protection disabled).
+- Supabase performance advisor: INFO-only quarantine/unused-index notices.
+
+## Remediation log
+
+| Check | Result |
+| --- | --- |
+| Unit regression suite | 178/178 passing after remediation |
+| Lint | Passing |
+| TypeScript | Passing across all packages |
+| Production build | Passing; 66 pages generated |
+| Widget size budget | Passing at 17,266 bytes gzip |
+| Dashboard route budgets | All 33 routes passing |
+| Dependency audit | No known vulnerabilities |
+| Live Supabase schema contract | Passing |
+| Production browser verification | Required immediately after merge/deploy |

--- a/packages/dashboard/src/app/(dashboard)/feedback/[id]/feedback-actions.tsx
+++ b/packages/dashboard/src/app/(dashboard)/feedback/[id]/feedback-actions.tsx
@@ -11,7 +11,7 @@ import type { FeedbackPriority, FeedbackStatus } from '@/lib/types'
 import { useRouter } from 'next/navigation'
 import { AlertCircle, Archive, CheckCircle2, Loader2, RotateCcw, X } from 'lucide-react'
 import { toast } from '@/hooks/use-toast'
-import { formatVersionEtag } from '@/lib/optimistic-concurrency'
+import { mutationVersionHeaders } from '@/lib/optimistic-concurrency'
 
 const statuses: FeedbackStatus[] = ['new', 'reviewed', 'planned', 'in_progress', 'closed']
 
@@ -73,7 +73,7 @@ export function FeedbackActions({
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
-        'If-Match': formatVersionEtag(feedbackVersionRef.current),
+        ...mutationVersionHeaders(feedbackVersionRef.current),
       },
       body: JSON.stringify(changes),
     })

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/customize-tab.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/customize-tab.tsx
@@ -15,7 +15,7 @@ import { Loader2, MousePointerClick, PanelTop, Send, ShieldCheck } from 'lucide-
 import { toast } from '@/hooks/use-toast'
 import { WidgetFormPreview } from './widget-form-preview'
 import { PageHeader } from '@/components/ui/workspace-shell'
-import { formatVersionEtag } from '@/lib/optimistic-concurrency'
+import { mutationVersionHeaders } from '@/lib/optimistic-concurrency'
 import { FieldError, FormErrorSummary } from '@/components/ui/field-error'
 import { readErrorMessage, readFieldErrors, type FieldErrors } from '@/lib/form-errors'
 
@@ -274,7 +274,7 @@ export function CustomizeTab({
           method: 'PATCH',
           headers: {
             'Content-Type': 'application/json',
-            'If-Match': formatVersionEtag(expectedVersion),
+            ...mutationVersionHeaders(expectedVersion),
           },
           body: JSON.stringify({
             settings: { widget_config: config },

--- a/packages/dashboard/src/app/(dashboard)/projects/[id]/project-tabs.tsx
+++ b/packages/dashboard/src/app/(dashboard)/projects/[id]/project-tabs.tsx
@@ -18,7 +18,7 @@ import { InstallTab } from './install-tab'
 import { SetupProgress } from './project-flow-nav'
 import { ProjectHome } from './project-home'
 import { PageHeader } from '@/components/ui/workspace-shell'
-import { formatVersionEtag } from '@/lib/optimistic-concurrency'
+import { mutationVersionHeaders } from '@/lib/optimistic-concurrency'
 import { FieldError, FormErrorSummary } from '@/components/ui/field-error'
 import { readErrorMessage, readFieldErrors, type FieldErrors } from '@/lib/form-errors'
 
@@ -192,7 +192,7 @@ function SettingsTab({ project }: { project: Project }) {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
-          'If-Match': formatVersionEtag(projectVersion),
+          ...mutationVersionHeaders(projectVersion),
         },
         body: JSON.stringify({
           name: name.trim(),

--- a/packages/dashboard/src/app/api/feedback/[id]/route.ts
+++ b/packages/dashboard/src/app/api/feedback/[id]/route.ts
@@ -4,7 +4,7 @@ import { readJsonBody } from '@/lib/api-request'
 import {
   editConflictResponse,
   formatVersionEtag,
-  parseIfMatchVersion,
+  parseMutationVersion,
 } from '@/lib/optimistic-concurrency'
 import { createServerSupabase } from '@/lib/supabase-server'
 
@@ -35,7 +35,7 @@ export async function PATCH(
     return NextResponse.json({ error: 'Unsupported feedback change.' }, { status: 400 })
   }
 
-  const expectedVersion = parseIfMatchVersion(request.headers.get('if-match'))
+  const expectedVersion = parseMutationVersion(request.headers)
   const { data: current } = await supabase
     .from('feedback')
     .select('id, updated_at')

--- a/packages/dashboard/src/app/api/projects/[id]/route.ts
+++ b/packages/dashboard/src/app/api/projects/[id]/route.ts
@@ -8,7 +8,7 @@ import { normalizeProjectDomain } from '@/lib/project-input'
 import {
   editConflictResponse,
   formatVersionEtag,
-  parseIfMatchVersion,
+  parseMutationVersion,
 } from '@/lib/optimistic-concurrency'
 
 type RouteParams = { params: Promise<{ id: string }> }
@@ -59,7 +59,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     if ('error' in result) return result.error
 
     const { admin, project } = result as Exclude<typeof result, { error: NextResponse }>
-    const expectedVersion = parseIfMatchVersion(request.headers.get('if-match'))
+    const expectedVersion = parseMutationVersion(request.headers)
     if (!expectedVersion) {
       return NextResponse.json(
         {

--- a/packages/dashboard/src/app/api/projects/[id]/updates/[updateId]/archive/route.ts
+++ b/packages/dashboard/src/app/api/projects/[id]/updates/[updateId]/archive/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getAuthedUserAndProject } from '@/lib/api-auth'
-import { editConflictResponse, formatVersionEtag, parseIfMatchVersion } from '@/lib/optimistic-concurrency'
+import { editConflictResponse, formatVersionEtag, parseMutationVersion } from '@/lib/optimistic-concurrency'
 const headers = { 'Cache-Control': 'no-store' }
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string; updateId: string }> }) {
   const { id, updateId } = await params; const auth = await getAuthedUserAndProject(id); if ('error' in auth) return auth.error
   const { data: existing, error: existingError } = await auth.admin.from('product_updates').select('updated_at').eq('project_id', id).eq('id', updateId).maybeSingle()
   if (existingError || !existing) return NextResponse.json({ error: 'Update not found.' }, { status: 404, headers })
-  const expectedVersion = parseIfMatchVersion(request.headers.get('if-match'))
+  const expectedVersion = parseMutationVersion(request.headers)
   if (!expectedVersion) return NextResponse.json({ code: 'PRECONDITION_REQUIRED', error: 'Reload this update before archiving it.' }, { status: 428, headers: { ...headers, ETag: formatVersionEtag(existing.updated_at) } })
   if (expectedVersion !== existing.updated_at) return NextResponse.json(editConflictResponse(existing.updated_at), { status: 409, headers: { ...headers, ETag: formatVersionEtag(existing.updated_at) } })
   const { data, error } = await auth.admin.from('product_updates').update({ status: 'archived', updated_at: new Date().toISOString() }).eq('project_id', id).eq('id', updateId).eq('updated_at', expectedVersion).select('*').maybeSingle()

--- a/packages/dashboard/src/app/api/projects/[id]/updates/[updateId]/image/route.ts
+++ b/packages/dashboard/src/app/api/projects/[id]/updates/[updateId]/image/route.ts
@@ -3,14 +3,14 @@ import { getAuthedUserAndProject } from '@/lib/api-auth'
 import { publicImageUrl } from '@/lib/product-update-service'
 import { readRequestBodyWithLimit, RequestBodyTooLargeError } from '@/lib/request-body-limit'
 import { validateAndSanitizeFeedbackImage } from '@/lib/feedback-media-validation'
-import { editConflictResponse, formatVersionEtag, parseIfMatchVersion } from '@/lib/optimistic-concurrency'
+import { editConflictResponse, formatVersionEtag, parseMutationVersion } from '@/lib/optimistic-concurrency'
 
 const headers = { 'Cache-Control': 'no-store' }
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string; updateId: string }> }) {
   const { id, updateId } = await params; const auth = await getAuthedUserAndProject(id); if ('error' in auth) return auth.error
   const { data: update } = await auth.admin.from('product_updates').select('image_path,updated_at').eq('project_id', id).eq('id', updateId).maybeSingle()
   if (!update) return NextResponse.json({ error: 'Update not found.' }, { status: 404, headers })
-  const expectedVersion = parseIfMatchVersion(request.headers.get('if-match'))
+  const expectedVersion = parseMutationVersion(request.headers)
   if (!expectedVersion) return NextResponse.json({ code: 'PRECONDITION_REQUIRED', error: 'Reload this update before changing its image.' }, { status: 428, headers: { ...headers, ETag: formatVersionEtag(update.updated_at) } })
   if (expectedVersion !== update.updated_at) return NextResponse.json(editConflictResponse(update.updated_at), { status: 409, headers: { ...headers, ETag: formatVersionEtag(update.updated_at) } })
   let bytes: Uint8Array; try { bytes = await readRequestBodyWithLimit(request, 2 * 1024 * 1024) } catch (error) { return NextResponse.json({ error: error instanceof RequestBodyTooLargeError ? 'Image exceeds 2 MB.' : 'Unable to read image.' }, { status: 413, headers }) }
@@ -60,7 +60,7 @@ export async function DELETE(request: NextRequest, { params }: { params: Promise
   const { id, updateId } = await params; const auth = await getAuthedUserAndProject(id); if ('error' in auth) return auth.error
   const { data: update } = await auth.admin.from('product_updates').select('image_path,updated_at').eq('project_id', id).eq('id', updateId).maybeSingle()
   if (!update) return NextResponse.json({ error: 'Update not found.' }, { status: 404, headers })
-  const expectedVersion = parseIfMatchVersion(request.headers.get('if-match'))
+  const expectedVersion = parseMutationVersion(request.headers)
   if (!expectedVersion) return NextResponse.json({ code: 'PRECONDITION_REQUIRED', error: 'Reload this update before changing its image.' }, { status: 428, headers: { ...headers, ETag: formatVersionEtag(update.updated_at) } })
   if (expectedVersion !== update.updated_at) return NextResponse.json(editConflictResponse(update.updated_at), { status: 409, headers: { ...headers, ETag: formatVersionEtag(update.updated_at) } })
   const { data, error } = await auth.admin.from('product_updates').update({ image_path: null, updated_at: new Date().toISOString() }).eq('project_id', id).eq('id', updateId).eq('updated_at', expectedVersion).select('updated_at').maybeSingle()

--- a/packages/dashboard/src/app/api/projects/[id]/updates/[updateId]/publish/route.ts
+++ b/packages/dashboard/src/app/api/projects/[id]/updates/[updateId]/publish/route.ts
@@ -7,7 +7,7 @@ import { readJsonBody } from '@/lib/api-request'
 import {
   editConflictResponse,
   formatVersionEtag,
-  parseIfMatchVersion,
+  parseMutationVersion,
 } from '@/lib/optimistic-concurrency'
 
 const headers = { 'Cache-Control': 'no-store' }
@@ -18,7 +18,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   const body: unknown = bodyResult.data
   const { data: update } = await auth.admin.from('product_updates').select('*').eq('project_id', id).eq('id', updateId).maybeSingle()
   if (!update) return NextResponse.json({ error: 'Update not found.' }, { status: 404, headers })
-  const expectedVersion = parseIfMatchVersion(request.headers.get('if-match'))
+  const expectedVersion = parseMutationVersion(request.headers)
   if (!expectedVersion) return NextResponse.json(
     { code: 'PRECONDITION_REQUIRED', error: 'Reload this update before publishing it.' },
     { status: 428, headers: { ...headers, ETag: formatVersionEtag(update.updated_at) } },

--- a/packages/dashboard/src/app/api/projects/[id]/updates/[updateId]/restore/route.ts
+++ b/packages/dashboard/src/app/api/projects/[id]/updates/[updateId]/restore/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getAuthedUserAndProject } from '@/lib/api-auth'
-import { editConflictResponse, formatVersionEtag, parseIfMatchVersion } from '@/lib/optimistic-concurrency'
+import { editConflictResponse, formatVersionEtag, parseMutationVersion } from '@/lib/optimistic-concurrency'
 const headers = { 'Cache-Control': 'no-store' }
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string; updateId: string }> }) {
   const { id, updateId } = await params; const auth = await getAuthedUserAndProject(id); if ('error' in auth) return auth.error
   const { data: existing, error: existingError } = await auth.admin.from('product_updates').select('updated_at').eq('project_id', id).eq('id', updateId).maybeSingle()
   if (existingError || !existing) return NextResponse.json({ error: 'Update not found.' }, { status: 404, headers })
-  const expectedVersion = parseIfMatchVersion(request.headers.get('if-match'))
+  const expectedVersion = parseMutationVersion(request.headers)
   if (!expectedVersion) return NextResponse.json({ code: 'PRECONDITION_REQUIRED', error: 'Reload this update before restoring it.' }, { status: 428, headers: { ...headers, ETag: formatVersionEtag(existing.updated_at) } })
   if (expectedVersion !== existing.updated_at) return NextResponse.json(editConflictResponse(existing.updated_at), { status: 409, headers: { ...headers, ETag: formatVersionEtag(existing.updated_at) } })
   const { data, error } = await auth.admin.from('product_updates').update({ status: 'draft', published_at: null, expires_at: null, updated_at: new Date().toISOString() }).eq('project_id', id).eq('id', updateId).eq('updated_at', expectedVersion).select('*').maybeSingle()

--- a/packages/dashboard/src/app/api/projects/[id]/updates/[updateId]/route.ts
+++ b/packages/dashboard/src/app/api/projects/[id]/updates/[updateId]/route.ts
@@ -6,7 +6,7 @@ import { readJsonBody } from '@/lib/api-request'
 import {
   editConflictResponse,
   formatVersionEtag,
-  parseIfMatchVersion,
+  parseMutationVersion,
 } from '@/lib/optimistic-concurrency'
 
 const headers = { 'Cache-Control': 'no-store' }
@@ -31,7 +31,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
   if (!body || typeof body !== 'object' || ['status', 'projectId', 'project_id', 'publishedAt', 'published_at', 'expiresAt', 'expires_at'].some((key) => key in body)) return NextResponse.json({ error: 'Lifecycle fields require their explicit action.' }, { status: 400, headers })
   const { data: existing, error: existingError } = await auth.admin.from('product_updates').select('*').eq('project_id', id).eq('id', updateId).maybeSingle()
   if (existingError || !existing) return NextResponse.json({ error: 'Update not found.' }, { status: 404, headers })
-  const expectedVersion = parseIfMatchVersion(request.headers.get('if-match'))
+  const expectedVersion = parseMutationVersion(request.headers)
   if (!expectedVersion) {
     return NextResponse.json(
       {
@@ -93,7 +93,7 @@ export async function DELETE(request: NextRequest, { params }: { params: Promise
   const { id, updateId, auth } = await resolve(params); if ('error' in auth) return auth.error
   const { data } = await auth.admin.from('product_updates').select('image_path,updated_at').eq('project_id', id).eq('id', updateId).maybeSingle()
   if (!data) return NextResponse.json({ error: 'Update not found.' }, { status: 404, headers })
-  const expectedVersion = parseIfMatchVersion(request.headers.get('if-match'))
+  const expectedVersion = parseMutationVersion(request.headers)
   if (!expectedVersion) return NextResponse.json({ code: 'PRECONDITION_REQUIRED', error: 'Reload this update before deleting it.' }, { status: 428, headers: { ...headers, ETag: formatVersionEtag(data.updated_at) } })
   if (expectedVersion !== data.updated_at) return NextResponse.json(editConflictResponse(data.updated_at), { status: 409, headers: { ...headers, ETag: formatVersionEtag(data.updated_at) } })
   const { data: deleted, error } = await auth.admin.from('product_updates').delete().eq('project_id', id).eq('id', updateId).eq('updated_at', expectedVersion).select('image_path').maybeSingle()

--- a/packages/dashboard/src/app/api/projects/[id]/updates/settings/route.ts
+++ b/packages/dashboard/src/app/api/projects/[id]/updates/settings/route.ts
@@ -7,7 +7,7 @@ import { readJsonBody } from '@/lib/api-request'
 import {
   editConflictResponse,
   formatVersionEtag,
-  parseIfMatchVersion,
+  parseMutationVersion,
 } from '@/lib/optimistic-concurrency'
 
 const headers = { 'Cache-Control': 'no-store' }
@@ -40,7 +40,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     .eq('project_id', id)
     .maybeSingle()
   if (existingError) return NextResponse.json({ error: 'Unable to load settings.' }, { status: 500, headers })
-  const expectedVersion = parseIfMatchVersion(request.headers.get('if-match'))
+  const expectedVersion = parseMutationVersion(request.headers)
   if (existing && !expectedVersion) {
     return NextResponse.json(
       {

--- a/packages/dashboard/src/components/product-updates/ProductUpdatesTab.tsx
+++ b/packages/dashboard/src/components/product-updates/ProductUpdatesTab.tsx
@@ -19,7 +19,11 @@ import { Textarea } from "@/components/ui/textarea";
 import { dismissToast, toast } from "@/hooks/use-toast";
 import { UpdatesOnboarding } from "./UpdatesOnboarding";
 import { ProductUpdateImageEditor } from "./ProductUpdateImageEditor";
-import { formatVersionEtag } from "@/lib/optimistic-concurrency";
+import {
+  MUTATION_VERSION_HEADER,
+  mutationVersionHeaders,
+  parseIfMatchVersion,
+} from "@/lib/optimistic-concurrency";
 import { ProductUpdatesOverview } from "./ProductUpdatesOverview";
 import { ProductUpdatesSettings } from "./ProductUpdatesSettings";
 import {
@@ -105,6 +109,7 @@ export function ProductUpdatesTab({
   const imageInputRef = React.useRef<HTMLInputElement>(null);
   const hydratedUpdateRef = React.useRef<string | null>(null);
   const savedFormRef = React.useRef<FormValues | null>(null);
+  const selectedVersionRef = React.useRef<string | null>(null);
   const conflictToastIdRef = React.useRef<string | null>(null);
   const [modules, setModules] = React.useState<Modules | null>(null);
   const [embedStatus, setEmbedStatus] = React.useState<EmbedStatus | null>(
@@ -222,6 +227,7 @@ export function ProductUpdatesTab({
     hydratedUpdateRef.current = update.id;
     setSelectedId(update.id);
     savedFormRef.current = nextForm;
+    selectedVersionRef.current = update.updated_at;
     setForm(nextForm);
     setPublishAt(localDateTime(update.published_at));
     setEditorConflict(null);
@@ -245,17 +251,24 @@ export function ProductUpdatesTab({
             )
           : {};
       const fieldMessage = Object.values(errors).join(" ");
+      const isEditConflict = response.status === 409 || response.status === 412;
       throw new ApiRequestError(
         data?.error ||
           fieldMessage ||
-          (response.status >= 500
+          (isEditConflict
+            ? "A newer saved version is available. Your text is still in the editor. Reload the saved version, review your changes, then save again."
+            : response.status >= 500
             ? "A temporary service problem prevented this save. Your draft is still in the editor; wait a moment and try again."
             : "The server rejected this request. Your draft is still in the editor; reload the latest version and try again."),
         errors,
-        typeof data?.code === "string" ? data.code : undefined,
+        typeof data?.code === "string"
+          ? data.code
+          : isEditConflict
+            ? "EDIT_CONFLICT"
+            : undefined,
         typeof data?.currentVersion === "string"
           ? data.currentVersion
-          : undefined,
+          : parseIfMatchVersion(response.headers.get("etag")) || undefined,
       );
     }
     return data;
@@ -293,7 +306,7 @@ export function ProductUpdatesTab({
         throw error;
       }
       const headers = new Headers(options.headers);
-      headers.set("If-Match", formatVersionEtag(error.currentVersion));
+      headers.set(MUTATION_VERSION_HEADER, error.currentVersion);
       return {
         data: await request(url, { ...options, headers }),
         recoveredFromConflict: true,
@@ -322,8 +335,13 @@ export function ProductUpdatesTab({
   ) {
     if (!selected) return;
     const next = { ...selected, ...update };
+    if (typeof update.updated_at === "string") {
+      selectedVersionRef.current = update.updated_at;
+    }
     setUpdates((current) =>
-      current.map((item) => (item.id === selected.id ? next : item)),
+      current.map((item) =>
+        item.id === selected.id ? { ...item, ...update } : item,
+      ),
     );
     if (!recoveredFromConflict) return;
     if (hasUnsavedEditorChanges()) {
@@ -364,7 +382,9 @@ export function ProductUpdatesTab({
             method: "PATCH",
             headers: {
               "Content-Type": "application/json",
-              "If-Match": formatVersionEtag(selected.updated_at),
+              ...mutationVersionHeaders(
+                selectedVersionRef.current || selected.updated_at,
+              ),
             },
             body,
           })
@@ -376,6 +396,14 @@ export function ProductUpdatesTab({
       if (!selected && data.update?.id) {
         setSelectedId(data.update.id);
         router.replace(`/projects/${projectId}/release-notes/${data.update.id}`);
+      }
+      if (typeof data.update?.updated_at === "string") {
+        selectedVersionRef.current = data.update.updated_at;
+        setUpdates((current) =>
+          current.map((item) =>
+            item.id === data.update.id ? { ...item, ...data.update } : item,
+          ),
+        );
       }
       toast({ title: selected ? "Release note saved" : "Draft saved" });
       savedFormRef.current = {
@@ -433,13 +461,15 @@ export function ProductUpdatesTab({
     }
     setSaving(true);
     try {
-      await request(
+      const data = await request(
         `/api/projects/${projectId}/updates/${selected.id}/publish`,
         {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            "If-Match": formatVersionEtag(selected.updated_at),
+            ...mutationVersionHeaders(
+              selectedVersionRef.current || selected.updated_at,
+            ),
           },
           body: JSON.stringify({
             publishedAt: scheduled
@@ -451,6 +481,9 @@ export function ProductUpdatesTab({
           }),
         },
       );
+      if (typeof data.update?.updated_at === "string") {
+        selectedVersionRef.current = data.update.updated_at;
+      }
       toast({
         title: scheduled ? "Update scheduled" : "Update published",
         description: "It is usually visible in the widget within a minute.",
@@ -499,7 +532,9 @@ export function ProductUpdatesTab({
         method: "POST",
         headers: {
           "Content-Type": file.type,
-          "If-Match": formatVersionEtag(selected.updated_at),
+          ...mutationVersionHeaders(
+            selectedVersionRef.current || selected.updated_at,
+          ),
         },
         body: file,
         },
@@ -604,7 +639,9 @@ export function ProductUpdatesTab({
         `/api/projects/${projectId}/updates/${selected.id}/image`,
         {
           method: "DELETE",
-          headers: { "If-Match": formatVersionEtag(selected.updated_at) },
+          headers: mutationVersionHeaders(
+            selectedVersionRef.current || selected.updated_at,
+          ),
         },
       );
       const result = mutation.data as { update: Partial<Update> };
@@ -639,7 +676,9 @@ export function ProductUpdatesTab({
         `/api/projects/${projectId}/updates/${selected.id}`,
         {
           method: "DELETE",
-          headers: { "If-Match": formatVersionEtag(selected.updated_at) },
+          headers: mutationVersionHeaders(
+            selectedVersionRef.current || selected.updated_at,
+          ),
         },
       );
       toast({ title: "Release note deleted" });
@@ -667,7 +706,7 @@ export function ProductUpdatesTab({
           headers: {
             "Content-Type": "application/json",
             ...(settingsVersion
-              ? { "If-Match": formatVersionEtag(settingsVersion) }
+              ? mutationVersionHeaders(settingsVersion)
               : {}),
           },
           body: JSON.stringify(next),
@@ -786,7 +825,7 @@ export function ProductUpdatesTab({
                 {
                   method: action === "delete" ? "DELETE" : "POST",
                   headers: {
-                    "If-Match": formatVersionEtag(update.updated_at),
+                    ...mutationVersionHeaders(update.updated_at),
                   },
                 },
               );

--- a/packages/dashboard/src/lib/optimistic-concurrency.ts
+++ b/packages/dashboard/src/lib/optimistic-concurrency.ts
@@ -1,5 +1,7 @@
 const ETAG_VALUE = /^"([^"]+)"$/
 
+export const MUTATION_VERSION_HEADER = 'X-Feedbacks-Version'
+
 export function formatVersionEtag(version: string): string {
   return `"${version.replaceAll('"', '')}"`
 }
@@ -8,6 +10,16 @@ export function parseIfMatchVersion(value: string | null): string | null {
   if (!value) return null
   const match = ETAG_VALUE.exec(value.trim())
   return match?.[1] || null
+}
+
+export function mutationVersionHeaders(version: string): Record<string, string> {
+  return { [MUTATION_VERSION_HEADER]: version }
+}
+
+export function parseMutationVersion(headers: Pick<Headers, 'get'>): string | null {
+  const applicationVersion = headers.get(MUTATION_VERSION_HEADER)?.trim()
+  if (applicationVersion) return applicationVersion
+  return parseIfMatchVersion(headers.get('if-match'))
 }
 
 export function editConflictResponse(currentVersion: string) {

--- a/packages/dashboard/tests/e2e/concurrency.spec.ts
+++ b/packages/dashboard/tests/e2e/concurrency.spec.ts
@@ -17,14 +17,14 @@ test("stale project settings writes are rejected instead of silently overwriting
   expect(initialVersion).toBeTruthy();
 
   const accepted = await page.request.patch(`/api/projects/${project.id}`, {
-    headers: { "If-Match": initialVersion },
+    headers: { "X-Feedbacks-Version": initialVersion.replaceAll('"', '') },
     data: { name: `${project.name} accepted` },
   });
   expect(accepted.ok()).toBe(true);
   expect(accepted.headers().etag).not.toBe(initialVersion);
 
   const stale = await page.request.patch(`/api/projects/${project.id}`, {
-    headers: { "If-Match": initialVersion },
+    headers: { "X-Feedbacks-Version": initialVersion.replaceAll('"', '') },
     data: { name: `${project.name} stale` },
   });
   expect(stale.status()).toBe(409);
@@ -63,13 +63,13 @@ test("stale inbox triage writes preserve the first accepted change", async ({
   const initialVersion = `"${listed.updated_at}"`;
 
   const accepted = await page.request.patch(`/api/feedback/${id}`, {
-    headers: { "If-Match": initialVersion },
+    headers: { "X-Feedbacks-Version": initialVersion.replaceAll('"', '') },
     data: { status: "reviewed" },
   });
   expect(accepted.ok()).toBe(true);
 
   const stale = await page.request.patch(`/api/feedback/${id}`, {
-    headers: { "If-Match": initialVersion },
+    headers: { "X-Feedbacks-Version": initialVersion.replaceAll('"', '') },
     data: { priority: "critical" },
   });
   expect(stale.status()).toBe(409);

--- a/packages/dashboard/tests/e2e/customize.spec.ts
+++ b/packages/dashboard/tests/e2e/customize.spec.ts
@@ -86,7 +86,7 @@ test('retries feedback-form saves after an unrelated project version change', as
 
   const current = await page.request.get(`/api/projects/${project.id}`)
   const accepted = await page.request.patch(`/api/projects/${project.id}`, {
-    headers: { 'If-Match': current.headers().etag },
+    headers: { 'X-Feedbacks-Version': current.headers().etag.replaceAll('"', '') },
     data: { name: `${project.name} renamed` },
   })
   expect(accepted.ok()).toBe(true)

--- a/packages/dashboard/tests/e2e/product-updates.spec.ts
+++ b/packages/dashboard/tests/e2e/product-updates.spec.ts
@@ -37,7 +37,7 @@ async function createEditableReleaseNote(page: Page, projectId: string) {
     `/api/projects/${projectId}/updates/settings`,
     {
       headers: currentSettings.settingsVersion
-        ? { 'If-Match': `"${currentSettings.settingsVersion}"` }
+        ? { 'X-Feedbacks-Version': currentSettings.settingsVersion }
         : undefined,
       data: { enabled: true },
     },
@@ -178,6 +178,16 @@ test('release note conflicts keep recovery visible and retry confirmed deletion'
   await expect(page.getByTestId('release-note-preview-image')).not.toHaveAttribute('src', /^blob:/)
   await expect(page.getByRole('button', { name: 'Replace image' })).toBeVisible()
 
+  const saveAfterUpload = page.waitForResponse((response) =>
+    response.url().includes(`/api/projects/${project.id}/updates/${update.id}`)
+      && response.request().method() === 'PATCH'
+      && response.status() === 200,
+  )
+  await page.getByLabel('Summary').fill('Saved immediately after the image upload.')
+  await page.getByRole('button', { name: 'Save draft' }).click()
+  await saveAfterUpload
+  await expect(page.getByLabel('Saved version recovery')).toHaveCount(0)
+
   const remoteTitle = 'Saved somewhere else'
   const currentAfterUpload = await page.request.get(
     `/api/projects/${project.id}/updates/${update.id}`,
@@ -187,7 +197,7 @@ test('release note conflicts keep recovery visible and retry confirmed deletion'
     `/api/projects/${project.id}/updates/${update.id}`,
     {
       headers: {
-        'If-Match': `"${currentAfterUploadPayload.update.updated_at}"`,
+        'X-Feedbacks-Version': currentAfterUploadPayload.update.updated_at,
       },
       data: { title: remoteTitle },
     },
@@ -214,7 +224,7 @@ test('release note conflicts keep recovery visible and retry confirmed deletion'
   const secondRemoteChange = await page.request.patch(
     `/api/projects/${project.id}/updates/${update.id}`,
     {
-      headers: { 'If-Match': `"${currentPayload.update.updated_at}"` },
+      headers: { 'X-Feedbacks-Version': currentPayload.update.updated_at },
       data: { summary: 'A newer remote summary.' },
     },
   )

--- a/packages/dashboard/tests/unit/optimistic-concurrency.test.ts
+++ b/packages/dashboard/tests/unit/optimistic-concurrency.test.ts
@@ -3,7 +3,9 @@ import test from 'node:test'
 import {
   editConflictResponse,
   formatVersionEtag,
+  mutationVersionHeaders,
   parseIfMatchVersion,
+  parseMutationVersion,
 } from '../../src/lib/optimistic-concurrency.ts'
 
 test('project versions round-trip through a strong ETag', () => {
@@ -16,6 +18,16 @@ test('malformed or wildcard If-Match values are rejected', () => {
   assert.equal(parseIfMatchVersion('*'), null)
   assert.equal(parseIfMatchVersion('weak-version'), null)
   assert.equal(parseIfMatchVersion('W/"version"'), null)
+})
+
+test('application mutation versions use a namespaced header and keep legacy ETag compatibility', () => {
+  const version = '2026-08-02T02:30:00.000Z'
+  const applicationHeaders = new Headers(mutationVersionHeaders(version))
+  assert.equal(applicationHeaders.get('x-feedbacks-version'), version)
+  assert.equal(parseMutationVersion(applicationHeaders), version)
+
+  const legacyHeaders = new Headers({ 'If-Match': formatVersionEtag(version) })
+  assert.equal(parseMutationVersion(legacyHeaders), version)
 })
 
 test('edit conflicts preserve a safe recovery instruction and current version', () => {

--- a/packages/dashboard/tests/unit/security-boundaries.test.ts
+++ b/packages/dashboard/tests/unit/security-boundaries.test.ts
@@ -49,8 +49,22 @@ test('owner-editable project, feedback, and Product Update routes require versio
   ]
   for (const route of routes) {
     const source = read(route)
-    assert.match(source, /parseIfMatchVersion/, route)
+    assert.match(source, /parseMutationVersion/, route)
     assert.match(source, /(PRECONDITION_REQUIRED|status:\s*428)/, route)
     assert.match(source, /(editConflictResponse|status:\s*409)/, route)
+  }
+})
+
+test('browser mutations use the application version header instead of transport If-Match', () => {
+  const clients = [
+    '../../src/components/product-updates/ProductUpdatesTab.tsx',
+    '../../src/app/(dashboard)/feedback/[id]/feedback-actions.tsx',
+    '../../src/app/(dashboard)/projects/[id]/customize-tab.tsx',
+    '../../src/app/(dashboard)/projects/[id]/project-tabs.tsx',
+  ]
+  for (const client of clients) {
+    const source = read(client)
+    assert.match(source, /mutationVersionHeaders|MUTATION_VERSION_HEADER/, client)
+    assert.doesNotMatch(source, /['"]If-Match['"]/, client)
   }
 })


### PR DESCRIPTION
## What changed

- moved authenticated browser mutation versions from standard `If-Match` to the namespaced `X-Feedbacks-Version` contract
- kept server-side legacy ETag parsing for compatibility
- added a synchronous release-note version ref so upload/remove/save/publish actions can be safely chained without waiting for React state
- normalized 409/412 conflicts into the existing recovery UI while preserving editor text
- added the exact upload → immediate draft save regression and contract boundary tests
- documented the production reproduction, whole-flow audit, findings, and remediation status

## Root cause

The browser used the standard conditional-request `If-Match` header as an internal app version token. Production could turn a stale request into HTTP 412 before the app's JSON conflict recovery ran. Separately, release-note media actions advanced the saved version through React state, so a following action could still read the pre-upload render version.

## Impact

Successful editor actions now immediately advance the next mutation baseline across release notes, feedback triage, widget customization, project settings, and update display settings. Real cross-tab conflicts still preserve user input and surface recovery.

## Validation

- 178 unit tests pass
- full `pnpm ci:verify` passes
- production build generated all 66 pages
- widget gzip and all 33 dashboard route budgets pass
- dependency audit reports no known vulnerabilities
- live Supabase schema check passes